### PR TITLE
feat(sidebar): show context-window and token usage on tabs

### DIFF
--- a/dev/docs/DESIGN.md
+++ b/dev/docs/DESIGN.md
@@ -409,6 +409,7 @@ All commands are gated by Tauri capability declarations in `capabilities/main.js
 | `session://output` | `{ sessionId, data: string }` | Stream PTY output to xterm.js |
 | `session://status` | `{ sessionId, status }` | Notify session state changes (including `'error'`) |
 | `session://activity` | `{ sessionId, kind: 'title' \| 'attention' \| 'working' \| 'idle' \| 'promptStart' \| 'commandStart' \| 'commandEnd', value?, exit? }` | Per-session activity inferred from the PTY stream by `src-tauri/src/activity.rs` (OSC parsing + output byte-rate). Drives sidebar tab state indicators (working spinner, attention dot). Best-effort & advisory — UI must degrade gracefully if a CLI emits nothing. |
+| `session://metrics` | `{ sessionId, model?, contextUsedPct?, contextTokensUsed?, contextTokensLimit?, inputTokens?, outputTokens?, observedAt }` | Per-session token usage / context-window utilization. Emitted by `src-tauri/src/session_metrics.rs`, which polls Claude's `~/.claude/projects/<encoded-cwd>/<sid>.jsonl` transcripts (heuristic cwd+mtime mapping) and extracts cumulative `usage` from the latest assistant turn. Claude-only in v1; Copilot tabs receive no events. Drives the compact second line on each sidebar tab. Best-effort & debounced — UI must degrade gracefully when no snapshot is present. |
 
 ### Plugin commands routed via the bridge
 

--- a/dev/docs/ROADMAP.md
+++ b/dev/docs/ROADMAP.md
@@ -146,6 +146,26 @@ at least a minimal in-app settings surface is needed.
   annotated message and show a human-readable note in the terminal overlay (e.g.
   "Worktree path no longer exists: /path/to/worktree").
 
+### 4.4 Sidebar token-usage indicators — Claude v1 _(shipped — Issue #3)_
+- **Shipped**: Each sidebar tab shows a compact second line `78% · 12.3k tok`
+  with the running context-window utilization, sourced from polling Claude's
+  `~/.claude/projects/<encoded-cwd>/<sid>.jsonl` transcript files. Heuristic
+  cwd+mtime mapping; debounced; cleared on close/restart. Backend module:
+  `src-tauri/src/session_metrics.rs`. Event: `session://metrics`.
+- **Known limitation**: Cannot distinguish two same-tool Claude sessions sharing
+  one worktree; Copilot tabs show no metrics (no token data on disk).
+
+### 4.5 Authoritative session-id mapping via CLI hooks _(follow-up — Issue #4)_
+- **Gap**: The v1 metrics watcher (4.4) uses a heuristic cwd+mtime match against
+  Claude's transcript directory. Two same-tool sessions in one worktree are
+  indistinguishable, and Copilot is unsupported because no token data is written
+  to disk.
+- **Needed**: Replace the heuristic with hook-driven authoritative mapping.
+  Claude supports `--settings <json>` to inject a `Stop` hook that delivers the
+  CLI's `session_id` + `transcript_path` on stdin. Copilot supports hooks only
+  via `<cwd>/.github/hooks/hooks.json` (would pollute the user's repo) — revisit
+  when the Copilot CLI gains a `--hooks-file` (or equivalent) flag.
+
 ---
 
 ## 5. Data Model Gaps

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -256,6 +256,18 @@ pub fn build_production_sink(
     crate::pty_pool::PtySink::new(output, status, activity)
 }
 
+/// Build the production metrics emitter (Issue #3) — fires
+/// `session://metrics` Tauri events. Tests construct their own callback
+/// (typically a channel sender) and pass it to [`AppContext::new`].
+#[must_use]
+pub fn build_production_metrics_emit(app: tauri::AppHandle) -> crate::session_metrics::MetricsCb {
+    Arc::new(move |payload: crate::types::SessionMetricsEvent| {
+        if let Err(e) = app.emit("session://metrics", payload) {
+            tracing::debug!(error = %e, "emit session://metrics failed");
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -33,6 +33,7 @@ use crate::config_store::{
 };
 use crate::git::{GitRunner, RealGitRunner};
 use crate::pty_pool::{cleanup_orphans, PtyPool, PtySink};
+use crate::session_metrics::{MetricsCb, MetricsRegistry};
 use crate::types::{
     AppError, Error, InstructionSet, PartialAppConfig, Session, SessionCreateArgs, SessionId,
     SessionInputArgs, SessionResizeArgs, SessionStatus, SessionView, Tool,
@@ -52,6 +53,14 @@ pub struct AppContext {
     /// frontend that calls `frontend_ready` more than once cannot trigger
     /// duplicate restores.
     pub restored: AtomicBool,
+    /// Per-session token-usage / context-window watcher pool (Issue #3).
+    /// A no-op for sessions whose tool isn't supported; see
+    /// [`crate::session_metrics`].
+    pub metrics: Arc<MetricsRegistry>,
+    /// Callback the metrics watchers invoke for every new snapshot.
+    /// Production wires this into `app.emit("session://metrics", …)`;
+    /// tests substitute a capturing closure.
+    pub metrics_emit: MetricsCb,
 }
 
 impl AppContext {
@@ -61,6 +70,7 @@ impl AppContext {
         store: ConfigStore,
         sink: PtySink,
         git_runner: Arc<dyn GitRunner>,
+        metrics_emit: MetricsCb,
     ) -> Self {
         Self {
             pool,
@@ -68,6 +78,8 @@ impl AppContext {
             sink,
             git_runner,
             restored: AtomicBool::new(false),
+            metrics: Arc::new(MetricsRegistry::new()),
+            metrics_emit,
         }
     }
 
@@ -77,7 +89,7 @@ impl AppContext {
     /// fake [`GitRunner`].
     #[must_use]
     pub fn with_real_git(pool: Arc<PtyPool>, store: ConfigStore, sink: PtySink) -> Self {
-        Self::new(pool, store, sink, Arc::new(RealGitRunner))
+        Self::new(pool, store, sink, Arc::new(RealGitRunner), Arc::new(|_| {}))
     }
 }
 
@@ -194,6 +206,16 @@ pub fn session_create_impl(
         .spawn(&session, ctx.sink.clone())
         .map_err(AppError::from)?;
 
+    // 12. Start the per-session metrics watcher (Issue #3). No-op for tools
+    //     we can't introspect; never fatal — surface as a debug log only.
+    ctx.metrics.start(
+        session.id,
+        session.tool,
+        session.worktree_path.clone(),
+        SystemTime::now(),
+        Arc::clone(&ctx.metrics_emit),
+    );
+
     info!(session_id = %session.id, pid, label = %label, "session created");
 
     let mut view = SessionView::from(&session);
@@ -217,6 +239,10 @@ pub fn session_list_impl(ctx: &AppContext) -> Result<Vec<SessionView>, AppError>
 // ---------------------------------------------------------------------------
 
 pub async fn session_close_impl(ctx: &AppContext, id: SessionId) -> Result<(), AppError> {
+    // 0. Stop the metrics watcher (Issue #3) before tearing the rest down
+    //    so it never observes a half-cleaned session.
+    ctx.metrics.stop(&id);
+
     // 1. Best-effort kill (NotFound from the pool is fine — the session
     //    may have exited on its own already).
     if ctx.pool.contains(&id) {
@@ -348,6 +374,15 @@ pub fn session_restart_impl(ctx: &AppContext, id: SessionId) -> Result<(), AppEr
         (ctx.sink.status)(&id, SessionStatus::Error, None, Some(msg));
         return Err(AppError::from(e));
     }
+    // Issue #3: restart the metrics watcher with a fresh spawn instant so
+    // the freshness filter on Claude project JSONL files re-anchors.
+    ctx.metrics.start(
+        session.id,
+        session.tool,
+        session.worktree_path.clone(),
+        SystemTime::now(),
+        Arc::clone(&ctx.metrics_emit),
+    );
     Ok(())
 }
 
@@ -423,6 +458,16 @@ pub fn restore_all_sessions(ctx: &AppContext) {
         match ctx.pool.respawn_existing(&session, ctx.sink.clone()) {
             Ok(pid) => {
                 info!(session_id = %id, pid, "restored session");
+                // Issue #3: spin up the metrics watcher for restored sessions
+                // too, otherwise a user who never recreates a session would
+                // never see the indicator.
+                ctx.metrics.start(
+                    id,
+                    session.tool,
+                    session.worktree_path.clone(),
+                    SystemTime::now(),
+                    Arc::clone(&ctx.metrics_emit),
+                );
             }
             Err(e) => {
                 warn!(session_id = %id, error = ?e, "restore: respawn failed");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,13 +11,14 @@ pub mod compose;
 pub mod config_store;
 pub mod git;
 pub mod pty_pool;
+pub mod session_metrics;
 pub mod types;
 
 pub use types::{
     AppConfig, AppError, DefaultInstructionSets, Error, InstructionSet, InstructionSetId,
     PartialAppConfig, PartialDefaultInstructionSets, Session, SessionCreateArgs, SessionId,
-    SessionIdArg, SessionInputArgs, SessionOutputEvent, SessionResizeArgs, SessionStatus,
-    SessionStatusEvent, SessionView, TempFileSpec, Tool, WorkspaceValidateArgs,
+    SessionIdArg, SessionInputArgs, SessionMetricsEvent, SessionOutputEvent, SessionResizeArgs,
+    SessionStatus, SessionStatusEvent, SessionView, TempFileSpec, Tool, WorkspaceValidateArgs,
     WorkspaceValidateResult, WorktreeCreateArgs, WorktreeCreateResult, WorktreeInfo,
     CONFIG_VERSION_CURRENT,
 };
@@ -96,9 +97,16 @@ pub fn run() {
                 pty_pool::PortablePtySpawner,
             )));
             let sink = commands::build_production_sink(app.handle().clone(), store.clone());
+            let metrics_emit = commands::build_production_metrics_emit(app.handle().clone());
             let git_runner: std::sync::Arc<dyn git::GitRunner> =
                 std::sync::Arc::new(git::RealGitRunner);
-            let ctx = std::sync::Arc::new(commands::AppContext::new(pool, store, sink, git_runner));
+            let ctx = std::sync::Arc::new(commands::AppContext::new(
+                pool,
+                store,
+                sink,
+                git_runner,
+                metrics_emit,
+            ));
             app.manage(ctx);
             Ok(())
         })

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -225,14 +225,16 @@ fn run_claude_watcher(
 // ---------------------------------------------------------------------------
 
 /// Encode a cwd to the `~/.claude/projects/<dir>` form used by Claude
-/// Code: every `\\`, `/`, and `:` in the absolute path becomes `-`. Other
-/// characters pass through unchanged.
+/// Code: every `\\`, `/`, `:`, and `.` in the absolute path becomes `-`.
+/// The dot replacement is what produces the `--` between segments like
+/// `\.worktrees\` (a real path written by `git worktree`); without it the
+/// encoded directory name will not match Claude's on disk.
 #[must_use]
 pub fn encode_cwd(cwd: &Path) -> String {
     let s = cwd.to_string_lossy();
     let mut out = String::with_capacity(s.len());
     for ch in s.chars() {
-        if matches!(ch, '\\' | '/' | ':') {
+        if matches!(ch, '\\' | '/' | ':' | '.') {
             out.push('-');
         } else {
             out.push(ch);
@@ -475,8 +477,25 @@ mod tests {
     }
 
     #[test]
+    fn encode_cwd_replaces_dots_in_segments() {
+        // Real-world git-worktree path: the leading `.` in `.worktrees` is
+        // what produces the `--` Claude writes on disk.
+        let p = if cfg!(windows) {
+            Path::new("C:\\repos\\specd\\.worktrees\\fix-cursor-sync")
+        } else {
+            Path::new("/repos/specd/.worktrees/fix-cursor-sync")
+        };
+        let s = encode_cwd(p);
+        if cfg!(windows) {
+            assert_eq!(s, "C--repos-specd--worktrees-fix-cursor-sync");
+        } else {
+            assert_eq!(s, "-repos-specd--worktrees-fix-cursor-sync");
+        }
+    }
+
+    #[test]
     fn encode_cwd_idempotent_on_already_encoded() {
-        // Already-encoded form has no `/`, `\`, or `:`; should pass through.
+        // Already-encoded form has no `/`, `\`, `:`, or `.`; should pass through.
         let s = encode_cwd(Path::new("C--Users-me-proj"));
         assert_eq!(s, "C--Users-me-proj");
     }

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -1,0 +1,682 @@
+//! Per-session token-usage / context-window watcher.
+//!
+//! ## Signal source (v1)
+//!
+//! Claude Code persists every session as a JSONL transcript at
+//! `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`. Each `assistant`-type
+//! line carries a `message.usage` object with `input_tokens`,
+//! `cache_creation_input_tokens`, `cache_read_input_tokens` and
+//! `output_tokens`. The model's context-window limit can be read from
+//! `~/.claude/token_usage.json::actual_limit`, with a fallback table for
+//! when that file does not exist yet.
+//!
+//! For each Arborist Claude session we spin up a [`MetricsWatcher`] thread
+//! that periodically scans the project directory matching the session's
+//! `cwd`, picks the JSONL file with the most recent mtime that's >= the
+//! session's spawn instant, and extracts the latest token totals. On
+//! change, it emits a [`MetricsSnapshot`] through the supplied callback.
+//!
+//! ### Limitations
+//!
+//! Two same-tool sessions in the same worktree cannot be disambiguated by
+//! cwd + mtime alone — both would observe the most-recently-written JSONL.
+//! See follow-up issue #4 for the hook-driven authoritative version.
+//!
+//! ## Copilot
+//!
+//! `~/.copilot/session-state/<sid>/events.jsonl` does **not** carry token
+//! usage, so [`MetricsWatcher::start`] is a no-op for `Tool::Copilot`. A
+//! follow-up will revisit this when the Copilot CLI exposes the data.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::Deserialize;
+
+use crate::types::{SessionId, SessionMetricsEvent, Tool};
+
+/// Polling cadence for the watcher. Trade-off: smaller is more responsive,
+/// larger is fewer syscalls.
+pub const POLL_INTERVAL: Duration = Duration::from_millis(2000);
+
+/// Callback the watcher invokes for each new (changed) snapshot. Production
+/// wires this into `app.emit("session://metrics", payload)`; tests pass a
+/// channel sender.
+pub type MetricsCb = Arc<dyn Fn(SessionMetricsEvent) + Send + Sync>;
+
+/// Per-session running watcher handle. Drop semantics: clearing the
+/// `running` flag stops the watcher thread on its next poll iteration; the
+/// thread's `JoinHandle` is detached so dropping the registry entry never
+/// blocks the caller.
+struct WatcherHandle {
+    running: Arc<AtomicBool>,
+}
+
+/// Registry of active per-session watchers. Stored on `AppContext`. Calls
+/// to [`MetricsRegistry::stop`] are idempotent — closing a session that
+/// never had a watcher (e.g. a Copilot session, or a Claude session whose
+/// home dir could not be resolved) is a no-op.
+#[derive(Default)]
+pub struct MetricsRegistry {
+    inner: Mutex<HashMap<SessionId, WatcherHandle>>,
+}
+
+impl MetricsRegistry {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Start a watcher for `session_id`. If one is already running it is
+    /// stopped first so the new one starts from a clean slate (used by
+    /// session restart). Returns `false` if no watcher could be started
+    /// (Copilot sessions, or no resolvable home dir).
+    pub fn start(
+        &self,
+        session_id: SessionId,
+        tool: Tool,
+        cwd: PathBuf,
+        spawn_instant: SystemTime,
+        emit: MetricsCb,
+    ) -> bool {
+        if !matches!(tool, Tool::Claude) {
+            return false;
+        }
+        let Some(home) = home_dir() else {
+            tracing::debug!(session_id = %session_id, "no home dir; metrics watcher not started");
+            return false;
+        };
+
+        // Stop any existing watcher first.
+        self.stop(&session_id);
+
+        let running = Arc::new(AtomicBool::new(true));
+        let running_for_thread = Arc::clone(&running);
+        let cwd_for_thread = cwd.clone();
+        let join = thread::Builder::new()
+            .name(format!("arborist-metrics-{}", session_id))
+            .spawn(move || {
+                run_claude_watcher(
+                    session_id,
+                    home,
+                    cwd_for_thread,
+                    spawn_instant,
+                    emit,
+                    running_for_thread,
+                );
+            });
+        match join {
+            Ok(_handle) => {
+                self.inner
+                    .lock()
+                    .expect("metrics registry lock")
+                    .insert(session_id, WatcherHandle { running });
+                true
+            }
+            Err(e) => {
+                tracing::warn!(session_id = %session_id, error = %e, "metrics watcher thread spawn failed");
+                false
+            }
+        }
+    }
+
+    /// Stop the watcher for `session_id` if any. Idempotent.
+    pub fn stop(&self, session_id: &SessionId) {
+        let removed = self
+            .inner
+            .lock()
+            .expect("metrics registry lock")
+            .remove(session_id);
+        if let Some(h) = removed {
+            h.running.store(false, Ordering::SeqCst);
+        }
+    }
+
+    /// Stop every active watcher. Called on app shutdown / hot-reload.
+    pub fn stop_all(&self) {
+        let drained: Vec<WatcherHandle> = self
+            .inner
+            .lock()
+            .expect("metrics registry lock")
+            .drain()
+            .map(|(_, h)| h)
+            .collect();
+        for h in drained {
+            h.running.store(false, Ordering::SeqCst);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-session worker
+// ---------------------------------------------------------------------------
+
+fn run_claude_watcher(
+    session_id: SessionId,
+    home: PathBuf,
+    cwd: PathBuf,
+    spawn_instant: SystemTime,
+    emit: MetricsCb,
+    running: Arc<AtomicBool>,
+) {
+    let project_dir = home.join(".claude").join("projects").join(encode_cwd(&cwd));
+    let token_usage_path = home.join(".claude").join("token_usage.json");
+
+    let mut last_emitted: Option<SessionMetricsEvent> = None;
+    let mut tracked_path: Option<PathBuf> = None;
+    let mut tracked_len: u64 = 0;
+    let mut totals = TurnTotals::default();
+    let mut last_model: Option<String> = None;
+
+    while running.load(Ordering::SeqCst) {
+        // Discover/refresh the JSONL we're tracking. The freshest file
+        // whose mtime is >= our spawn instant wins.
+        let candidate = newest_jsonl_after(&project_dir, spawn_instant);
+        if let Some(c) = candidate {
+            // If we switched files (e.g. the user typed `/clear` and Claude
+            // started a new session) reset the read cursor and totals.
+            if tracked_path.as_ref() != Some(&c) {
+                tracked_path = Some(c.clone());
+                tracked_len = 0;
+                totals = TurnTotals::default();
+                last_model = None;
+            }
+
+            if let Ok(meta) = std::fs::metadata(&c) {
+                let len = meta.len();
+                if len > tracked_len {
+                    if let Ok(bytes) = read_range(&c, tracked_len, len) {
+                        for line in bytes.split(|&b| b == b'\n') {
+                            if line.is_empty() {
+                                continue;
+                            }
+                            if let Some((usage, model)) = extract_assistant_usage(line) {
+                                totals.add(&usage);
+                                if let Some(m) = model {
+                                    last_model = Some(m);
+                                }
+                            }
+                        }
+                    }
+                    tracked_len = len;
+                }
+            }
+        }
+
+        if totals.has_any() {
+            let limit = resolve_limit(&token_usage_path, last_model.as_deref());
+            let snapshot = build_snapshot(session_id, &totals, last_model.clone(), limit);
+            if Some(&snapshot) != last_emitted.as_ref() {
+                emit(snapshot.clone());
+                last_emitted = Some(snapshot);
+            }
+        }
+
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+/// Encode a cwd to the `~/.claude/projects/<dir>` form used by Claude
+/// Code: every `\\`, `/`, and `:` in the absolute path becomes `-`. Other
+/// characters pass through unchanged.
+#[must_use]
+pub fn encode_cwd(cwd: &Path) -> String {
+    let s = cwd.to_string_lossy();
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        if matches!(ch, '\\' | '/' | ':') {
+            out.push('-');
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+fn home_dir() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("HOME") {
+        if !p.is_empty() {
+            return Some(PathBuf::from(p));
+        }
+    }
+    if let Ok(p) = std::env::var("USERPROFILE") {
+        if !p.is_empty() {
+            return Some(PathBuf::from(p));
+        }
+    }
+    None
+}
+
+fn newest_jsonl_after(dir: &Path, after: SystemTime) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(dir).ok()?;
+    let mut best: Option<(SystemTime, PathBuf)> = None;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else { continue };
+        let Ok(mtime) = meta.modified() else { continue };
+        // Allow a small clock-skew slack window (5s) so the very first
+        // line — which can land before our spawn_instant due to mtime
+        // resolution / clock differences — is still picked up.
+        let slack = Duration::from_secs(5);
+        let cutoff = after.checked_sub(slack).unwrap_or(after);
+        if mtime < cutoff {
+            continue;
+        }
+        match &best {
+            Some((bt, _)) if *bt >= mtime => {}
+            _ => best = Some((mtime, path)),
+        }
+    }
+    best.map(|(_, p)| p)
+}
+
+fn read_range(path: &Path, start: u64, end: u64) -> std::io::Result<Vec<u8>> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut f = std::fs::File::open(path)?;
+    f.seek(SeekFrom::Start(start))?;
+    let len = end.saturating_sub(start) as usize;
+    let mut buf = vec![0u8; len];
+    f.read_exact(&mut buf)?;
+    Ok(buf)
+}
+
+// ---------------------------------------------------------------------------
+// JSONL parsing
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Deserialize, Clone, Copy)]
+pub(crate) struct UsageBlock {
+    #[serde(default)]
+    input_tokens: u64,
+    #[serde(default)]
+    output_tokens: u64,
+    #[serde(default)]
+    cache_creation_input_tokens: u64,
+    #[serde(default)]
+    cache_read_input_tokens: u64,
+}
+
+#[derive(Debug, Default)]
+struct TurnTotals {
+    /// Most recent observed turn — these reset to the values from the
+    /// latest assistant line (each line is the cumulative state of that
+    /// turn, not a delta).
+    last_input: u64,
+    last_output: u64,
+    last_cache_creation: u64,
+    last_cache_read: u64,
+    /// Cumulative input/output across all observed assistant lines (sum
+    /// of per-turn values). Useful for "session totals".
+    sum_input: u64,
+    sum_output: u64,
+    /// Set true once we've ingested at least one usage block.
+    seen: bool,
+}
+
+impl TurnTotals {
+    fn add(&mut self, u: &UsageBlock) {
+        self.sum_input = self.sum_input.saturating_add(u.input_tokens);
+        self.sum_output = self.sum_output.saturating_add(u.output_tokens);
+        self.last_input = u.input_tokens;
+        self.last_output = u.output_tokens;
+        self.last_cache_creation = u.cache_creation_input_tokens;
+        self.last_cache_read = u.cache_read_input_tokens;
+        self.seen = true;
+    }
+
+    fn has_any(&self) -> bool {
+        self.seen
+    }
+
+    fn context_tokens_used(&self) -> u64 {
+        self.last_input
+            .saturating_add(self.last_cache_creation)
+            .saturating_add(self.last_cache_read)
+            .saturating_add(self.last_output)
+    }
+}
+
+/// Try to parse a single JSONL line and return its `(usage, model)` if it
+/// is an `assistant` event with a `message.usage` block. Returns `None`
+/// for any other line (system, user, sub-event, malformed, etc.). Never
+/// panics.
+pub(crate) fn extract_assistant_usage(line: &[u8]) -> Option<(UsageBlock, Option<String>)> {
+    #[derive(Deserialize)]
+    struct Outer {
+        #[serde(default)]
+        r#type: String,
+        #[serde(default)]
+        message: Option<Message>,
+    }
+    #[derive(Deserialize)]
+    struct Message {
+        #[serde(default)]
+        model: Option<String>,
+        #[serde(default)]
+        usage: Option<UsageBlock>,
+    }
+    let outer: Outer = serde_json::from_slice(line).ok()?;
+    if outer.r#type != "assistant" {
+        return None;
+    }
+    let msg = outer.message?;
+    let usage = msg.usage?;
+    Some((usage, msg.model))
+}
+
+// ---------------------------------------------------------------------------
+// Context-limit lookup
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct TokenUsageFile {
+    #[serde(default)]
+    actual_limit: Option<u64>,
+    #[serde(default)]
+    expected_limit: Option<u64>,
+}
+
+/// Resolve the model's context-window limit. Tries `~/.claude/token_usage.json`
+/// first, then falls back to a small built-in table for known Anthropic
+/// models. Returns `None` when neither source recognises the model.
+pub(crate) fn resolve_limit(token_usage_path: &Path, model: Option<&str>) -> Option<u64> {
+    if let Ok(bytes) = std::fs::read(token_usage_path) {
+        if let Ok(file) = serde_json::from_slice::<TokenUsageFile>(&bytes) {
+            if let Some(v) = file.actual_limit.or(file.expected_limit) {
+                if v > 0 {
+                    return Some(v);
+                }
+            }
+        }
+    }
+    model.and_then(fallback_limit_for_model)
+}
+
+/// Fallback table for known model families. Keys match the substring form
+/// because Claude reports e.g. `"claude-sonnet-4-6"` while Anthropic also
+/// uses `"claude-3-5-sonnet"`-style names.
+fn fallback_limit_for_model(model: &str) -> Option<u64> {
+    let m = model.to_ascii_lowercase();
+    if m.contains("opus") || m.contains("sonnet") || m.contains("haiku") {
+        // All current Anthropic models default to 200k context.
+        return Some(200_000);
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot construction
+// ---------------------------------------------------------------------------
+
+fn build_snapshot(
+    session_id: SessionId,
+    totals: &TurnTotals,
+    model: Option<String>,
+    limit: Option<u64>,
+) -> SessionMetricsEvent {
+    let used = totals.context_tokens_used();
+    let pct = limit.and_then(|lim| {
+        used.saturating_mul(100)
+            .checked_div(lim)
+            .map(|raw| raw.min(100) as u8)
+    });
+    SessionMetricsEvent {
+        session_id,
+        model,
+        context_used_pct: pct,
+        context_tokens_used: Some(used),
+        context_tokens_limit: limit,
+        input_tokens: Some(totals.sum_input),
+        output_tokens: Some(totals.sum_output),
+        observed_at: now_unix_seconds(),
+    }
+}
+
+fn now_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn encode_cwd_replaces_separators_and_drive_colon() {
+        let p = if cfg!(windows) {
+            Path::new("C:\\Users\\me\\proj")
+        } else {
+            Path::new("/Users/me/proj")
+        };
+        let s = encode_cwd(p);
+        if cfg!(windows) {
+            assert_eq!(s, "C--Users-me-proj");
+        } else {
+            assert_eq!(s, "-Users-me-proj");
+        }
+    }
+
+    #[test]
+    fn encode_cwd_idempotent_on_already_encoded() {
+        // Already-encoded form has no `/`, `\`, or `:`; should pass through.
+        let s = encode_cwd(Path::new("C--Users-me-proj"));
+        assert_eq!(s, "C--Users-me-proj");
+    }
+
+    #[test]
+    fn extract_assistant_usage_happy_path() {
+        let line = br#"{"type":"assistant","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":12,"output_tokens":34,"cache_creation_input_tokens":56,"cache_read_input_tokens":78}}}"#;
+        let (u, m) = extract_assistant_usage(line).expect("parsed");
+        assert_eq!(u.input_tokens, 12);
+        assert_eq!(u.output_tokens, 34);
+        assert_eq!(u.cache_creation_input_tokens, 56);
+        assert_eq!(u.cache_read_input_tokens, 78);
+        assert_eq!(m.as_deref(), Some("claude-sonnet-4-6"));
+    }
+
+    #[test]
+    fn extract_assistant_usage_returns_none_for_user_lines() {
+        let line = br#"{"type":"user","message":{"role":"user","content":"hi"}}"#;
+        assert!(extract_assistant_usage(line).is_none());
+    }
+
+    #[test]
+    fn extract_assistant_usage_returns_none_for_system_lines() {
+        let line = br#"{"type":"system","subtype":"turn_duration","durationMs":42}"#;
+        assert!(extract_assistant_usage(line).is_none());
+    }
+
+    #[test]
+    fn extract_assistant_usage_tolerates_missing_optional_fields() {
+        // No cache fields present — should default to 0.
+        let line =
+            br#"{"type":"assistant","message":{"usage":{"input_tokens":1,"output_tokens":2}}}"#;
+        let (u, m) = extract_assistant_usage(line).expect("parsed");
+        assert_eq!(u.input_tokens, 1);
+        assert_eq!(u.output_tokens, 2);
+        assert_eq!(u.cache_creation_input_tokens, 0);
+        assert_eq!(u.cache_read_input_tokens, 0);
+        assert!(m.is_none());
+    }
+
+    #[test]
+    fn extract_assistant_usage_returns_none_for_garbage() {
+        assert!(extract_assistant_usage(b"not json").is_none());
+        assert!(extract_assistant_usage(b"{}").is_none());
+    }
+
+    #[test]
+    fn turn_totals_track_last_and_sum() {
+        let mut t = TurnTotals::default();
+        t.add(&UsageBlock {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_creation_input_tokens: 100,
+            cache_read_input_tokens: 200,
+        });
+        t.add(&UsageBlock {
+            input_tokens: 20,
+            output_tokens: 7,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 500,
+        });
+        // Last = the second turn.
+        assert_eq!(t.last_input, 20);
+        assert_eq!(t.last_output, 7);
+        assert_eq!(t.last_cache_read, 500);
+        assert_eq!(t.last_cache_creation, 0);
+        // Sums accumulate input+output (cache fields aren't summed —
+        // they're per-turn state).
+        assert_eq!(t.sum_input, 30);
+        assert_eq!(t.sum_output, 12);
+        // Context tokens used = sum of the LAST turn's four fields.
+        assert_eq!(t.context_tokens_used(), 20 + 500 + 7);
+        assert!(t.has_any());
+    }
+
+    #[test]
+    fn fallback_limit_known_models() {
+        assert_eq!(fallback_limit_for_model("claude-sonnet-4-6"), Some(200_000));
+        assert_eq!(fallback_limit_for_model("claude-opus-4-7"), Some(200_000));
+        assert_eq!(fallback_limit_for_model("claude-haiku-4-5"), Some(200_000));
+        assert_eq!(fallback_limit_for_model("gpt-4"), None);
+    }
+
+    #[test]
+    fn resolve_limit_prefers_token_usage_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let p = dir.path().join("token_usage.json");
+        let mut f = std::fs::File::create(&p).unwrap();
+        f.write_all(br#"{"actual_limit":128000,"expected_limit":200000}"#)
+            .unwrap();
+        assert_eq!(resolve_limit(&p, Some("claude-opus-4-7")), Some(128_000));
+    }
+
+    #[test]
+    fn resolve_limit_falls_back_when_file_missing() {
+        let p = std::path::Path::new("/nonexistent/arborist-test/token_usage.json");
+        assert_eq!(resolve_limit(p, Some("claude-sonnet-4-6")), Some(200_000));
+        assert_eq!(resolve_limit(p, Some("unknown-model")), None);
+        assert_eq!(resolve_limit(p, None), None);
+    }
+
+    #[test]
+    fn resolve_limit_ignores_zero_in_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let p = dir.path().join("token_usage.json");
+        let mut f = std::fs::File::create(&p).unwrap();
+        f.write_all(br#"{"actual_limit":0}"#).unwrap();
+        // Falls through to fallback table.
+        assert_eq!(resolve_limit(&p, Some("claude-sonnet-4-6")), Some(200_000));
+    }
+
+    #[test]
+    fn build_snapshot_computes_pct_when_limit_known() {
+        let mut totals = TurnTotals::default();
+        totals.add(&UsageBlock {
+            input_tokens: 50_000,
+            output_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+        });
+        let snap = build_snapshot(
+            SessionId::new(),
+            &totals,
+            Some("claude-sonnet-4-6".into()),
+            Some(200_000),
+        );
+        assert_eq!(snap.context_used_pct, Some(25));
+        assert_eq!(snap.context_tokens_used, Some(50_000));
+        assert_eq!(snap.context_tokens_limit, Some(200_000));
+        assert_eq!(snap.input_tokens, Some(50_000));
+        assert_eq!(snap.output_tokens, Some(0));
+    }
+
+    #[test]
+    fn build_snapshot_caps_pct_at_100() {
+        let mut totals = TurnTotals::default();
+        totals.add(&UsageBlock {
+            input_tokens: 999_999,
+            output_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+        });
+        let snap = build_snapshot(SessionId::new(), &totals, None, Some(200_000));
+        assert_eq!(snap.context_used_pct, Some(100));
+    }
+
+    #[test]
+    fn build_snapshot_omits_pct_when_limit_unknown() {
+        let mut totals = TurnTotals::default();
+        totals.add(&UsageBlock {
+            input_tokens: 100,
+            output_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+        });
+        let snap = build_snapshot(SessionId::new(), &totals, None, None);
+        assert!(snap.context_used_pct.is_none());
+        assert_eq!(snap.context_tokens_used, Some(100));
+        assert!(snap.context_tokens_limit.is_none());
+    }
+
+    #[test]
+    fn registry_start_is_noop_for_copilot() {
+        let reg = MetricsRegistry::new();
+        let id = SessionId::new();
+        let cb: MetricsCb = Arc::new(|_| {});
+        let started = reg.start(
+            id,
+            Tool::Copilot,
+            PathBuf::from("/tmp"),
+            SystemTime::now(),
+            cb,
+        );
+        assert!(!started, "metrics watcher must not start for Copilot");
+    }
+
+    #[test]
+    fn registry_stop_is_idempotent_when_not_running() {
+        let reg = MetricsRegistry::new();
+        // Should not panic on unknown session id.
+        reg.stop(&SessionId::new());
+    }
+
+    #[test]
+    fn newest_jsonl_after_picks_freshest_eligible_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let a = dir.path().join("aaa.jsonl");
+        let b = dir.path().join("bbb.jsonl");
+        let c = dir.path().join("not-a-transcript.txt");
+        std::fs::write(&a, b"x").unwrap();
+        std::thread::sleep(Duration::from_millis(20));
+        std::fs::write(&b, b"y").unwrap();
+        std::fs::write(&c, b"z").unwrap();
+
+        // After=epoch-far-past => both eligible; b is newer => picked.
+        let picked = newest_jsonl_after(dir.path(), UNIX_EPOCH).expect("some");
+        assert_eq!(picked, b);
+
+        // After=now+1day => nothing eligible.
+        let future = SystemTime::now() + Duration::from_secs(86_400);
+        assert!(newest_jsonl_after(dir.path(), future).is_none());
+    }
+}

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -402,6 +402,42 @@ pub struct SessionActivityEvent {
     pub event: crate::activity::ActivityEvent,
 }
 
+/// Snapshot of the latest token / context-window observation for a session,
+/// used both as the payload for the `session://metrics` event and as the
+/// in-memory state the frontend renders. All fields except `session_id` and
+/// `observed_at` are optional: a snapshot may carry only a token count if
+/// the model's context limit cannot be resolved.
+///
+/// Mirrored on the frontend by `SessionMetrics` in `src/types/arborist.ts`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionMetricsEvent {
+    pub session_id: SessionId,
+    /// Model identifier as reported by the CLI (e.g. `"claude-sonnet-4-6"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Percentage of the context window in use, 0..=100. Omitted when the
+    /// model's context limit cannot be resolved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_used_pct: Option<u8>,
+    /// Tokens currently counted against the context window
+    /// (= `input + cache_creation + cache_read + output` for the latest
+    /// observed assistant turn).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_tokens_used: Option<u64>,
+    /// Model context-window limit in tokens (e.g. 200_000), when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_tokens_limit: Option<u64>,
+    /// Cumulative input tokens across observed turns of this session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_tokens: Option<u64>,
+    /// Cumulative output tokens across observed turns of this session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_tokens: Option<u64>,
+    /// Wall-clock unix-seconds at which this snapshot was produced.
+    pub observed_at: u64,
+}
+
 /// Payload of the `session://status` event (DESIGN §6).
 ///
 /// `message` is an optional human-readable note that accompanies the

--- a/src-tauri/tests/workspace_command.rs
+++ b/src-tauri/tests/workspace_command.rs
@@ -79,7 +79,13 @@ fn null_sink() -> PtySink {
 fn build_ctx(git: Arc<dyn GitRunner>, store_dir: &TempDir) -> Arc<AppContext> {
     let store = ConfigStore::open(store_dir.path()).unwrap();
     let pool = Arc::new(PtyPool::new(Arc::new(PortablePtySpawner)));
-    Arc::new(AppContext::new(pool, store, null_sink(), git))
+    Arc::new(AppContext::new(
+        pool,
+        store,
+        null_sink(),
+        git,
+        Arc::new(|_| {}),
+    ))
 }
 
 // ---------- workspace_validate ----------

--- a/src-tauri/tests/worktrees_command.rs
+++ b/src-tauri/tests/worktrees_command.rs
@@ -62,7 +62,13 @@ fn null_sink() -> PtySink {
 fn build_ctx(git: Arc<dyn GitRunner>, store_dir: &TempDir) -> Arc<AppContext> {
     let store = ConfigStore::open(store_dir.path()).unwrap();
     let pool = Arc::new(PtyPool::new(Arc::new(PortablePtySpawner)));
-    Arc::new(AppContext::new(pool, store, null_sink(), git))
+    Arc::new(AppContext::new(
+        pool,
+        store,
+        null_sink(),
+        git,
+        Arc::new(|_| {}),
+    ))
 }
 
 #[test]

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -22,9 +22,11 @@ vi.mock('@/hooks/use-terminal', () => ({
 
 const subscribeToStatusMock = vi.fn(() => () => {});
 const subscribeToActivityMock = vi.fn(() => () => {});
+const subscribeToMetricsMock = vi.fn(() => () => {});
 vi.mock('@/lib/session-events', () => ({
   subscribeToStatus: () => subscribeToStatusMock(),
   subscribeToActivity: () => subscribeToActivityMock(),
+  subscribeToMetrics: () => subscribeToMetricsMock(),
 }));
 
 import { App } from './App';
@@ -92,6 +94,8 @@ beforeEach(() => {
   resetBridgeMocks();
   initTerminalRouterMock.mockClear();
   subscribeToStatusMock.mockClear();
+  subscribeToActivityMock.mockClear();
+  subscribeToMetricsMock.mockClear();
   resetStores();
   document.documentElement.classList.remove('dark');
   installMatchMedia();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ import { NewSessionDialog } from '@/components/NewSessionDialog';
 import { Sidebar } from '@/components/Sidebar';
 import { WorkspacePicker } from '@/components/WorkspacePicker';
 import { initTerminalRouter } from '@/hooks/use-terminal';
-import { subscribeToActivity, subscribeToStatus } from '@/lib/session-events';
+import { subscribeToActivity, subscribeToMetrics, subscribeToStatus } from '@/lib/session-events';
 import { frontendReady } from '@/lib/tauri-bridge';
 import { selectWorkspaceRoot, useConfigStore } from '@/store/config-store';
 import { useSessionStore } from '@/store/session-store';
@@ -101,6 +101,7 @@ export function App(): JSX.Element {
     let cancelled = false;
     let unlistenStatus: (() => void) | null = null;
     let unlistenActivity: (() => void) | null = null;
+    let unlistenMetrics: (() => void) | null = null;
 
     const boot = async (): Promise<void> => {
       try {
@@ -111,6 +112,7 @@ export function App(): JSX.Element {
         initTerminalRouter();
         unlistenStatus = subscribeToStatus();
         unlistenActivity = subscribeToActivity();
+        unlistenMetrics = subscribeToMetrics();
         await frontendReady();
         if (cancelled) return;
         setStatus('ready');
@@ -136,6 +138,13 @@ export function App(): JSX.Element {
       if (unlistenActivity) {
         try {
           unlistenActivity();
+        } catch {
+          // ignore
+        }
+      }
+      if (unlistenMetrics) {
+        try {
+          unlistenMetrics();
         } catch {
           // ignore
         }

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -54,6 +54,10 @@ beforeEach(() => {
     activeId: undefined,
     pendingClose: undefined,
     isHydrated: false,
+    statusMessages: {},
+    hasUnread: {},
+    activity: {},
+    metrics: {},
   });
   // jsdom doesn't implement HTMLDialogElement.showModal/close in older
   // versions; provide minimal shims so CloseConfirmDialog can mount.
@@ -276,5 +280,49 @@ describe('Sidebar', () => {
     // pressed inside an input should not bubble up into the tablist
     // handler.
     expect(screen.queryByText(/terminate session/i)).toBeNull();
+  });
+});
+
+describe('Sidebar metrics indicator (Issue #3)', () => {
+  it('renders a compact metrics line under the label when metrics are present', () => {
+    seed([makeView('a')], 'a');
+    useSessionStore.setState({
+      metrics: {
+        a: {
+          sessionId: 'a',
+          model: 'claude-sonnet-4-6',
+          contextUsedPct: 42,
+          contextTokensUsed: 12_345,
+          contextTokensLimit: 200_000,
+          inputTokens: 9000,
+          outputTokens: 3345,
+          observedAt: 1700000000,
+        },
+      },
+    });
+    render(<Sidebar />);
+    const line = screen.getByTestId('sidebar-metrics');
+    expect(line.textContent).toContain('42%');
+    expect(line.textContent).toContain('12.3k tok');
+    // Long-form is in the title attribute for hover.
+    expect(line.getAttribute('title')).toContain('claude-sonnet-4-6');
+    expect(line.getAttribute('title')).toMatch(/200,000|200000/);
+  });
+
+  it('hides the metrics line when no snapshot is in the store', () => {
+    seed([makeView('a')], 'a');
+    render(<Sidebar />);
+    expect(screen.queryByTestId('sidebar-metrics')).toBeNull();
+  });
+
+  it('hides the metrics line for non-running sessions even if a stale snapshot exists', () => {
+    seed([makeView('a', { status: 'starting' })], 'a');
+    useSessionStore.setState({
+      metrics: {
+        a: { sessionId: 'a', contextUsedPct: 10, observedAt: 0 },
+      },
+    });
+    render(<Sidebar />);
+    expect(screen.queryByTestId('sidebar-metrics')).toBeNull();
   });
 });

--- a/src/components/SidebarTab.tsx
+++ b/src/components/SidebarTab.tsx
@@ -131,9 +131,10 @@ export function SidebarTab({
             />
           )}
         </span>
-        {metrics && session.status === 'running' && (
-          <MetricsLine metrics={metrics} isActive={isActive} />
-        )}
+        <MetricsLine
+          metrics={session.status === 'running' ? metrics : undefined}
+          isActive={isActive}
+        />
       </button>
       <button
         type="button"
@@ -146,7 +147,7 @@ export function SidebarTab({
           e.stopPropagation();
           actions.requestClose(id);
         }}
-        className="absolute right-3 top-1/2 -translate-y-1/2 rounded p-1 text-slate-500 opacity-0 transition-opacity hover:bg-slate-200 hover:text-slate-900 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 group-hover:opacity-100 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-slate-100"
+        className="absolute right-3 top-1.5 rounded p-1 text-slate-500 opacity-0 transition-opacity hover:bg-slate-200 hover:text-slate-900 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 group-hover:opacity-100 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-slate-100"
       >
         <span aria-hidden="true">×</span>
       </button>
@@ -161,11 +162,25 @@ export function SidebarTab({
 // ---------------------------------------------------------------------------
 
 interface MetricsLineProps {
-  metrics: SessionMetrics;
+  metrics: SessionMetrics | undefined;
   isActive: boolean;
 }
 
-function MetricsLine({ metrics, isActive }: MetricsLineProps): JSX.Element | null {
+function MetricsLine({ metrics, isActive }: MetricsLineProps): JSX.Element {
+  const colour = isActive
+    ? 'text-sky-800/80 dark:text-sky-200/80'
+    : 'text-slate-500 dark:text-slate-400';
+
+  if (!metrics) {
+    // Same height as a populated metrics line — preserves uniform tab
+    // height while we wait for the first snapshot.
+    return (
+      <span aria-hidden="true" className={`block pl-7 text-xs leading-tight ${colour}`}>
+        &nbsp;
+      </span>
+    );
+  }
+
   const parts: string[] = [];
   if (typeof metrics.contextUsedPct === 'number') {
     parts.push(`${metrics.contextUsedPct}%`);
@@ -173,7 +188,13 @@ function MetricsLine({ metrics, isActive }: MetricsLineProps): JSX.Element | nul
   if (typeof metrics.contextTokensUsed === 'number') {
     parts.push(`${formatTokens(metrics.contextTokensUsed)} tok`);
   }
-  if (parts.length === 0) return null;
+  if (parts.length === 0) {
+    return (
+      <span aria-hidden="true" className={`block pl-7 text-xs leading-tight ${colour}`}>
+        &nbsp;
+      </span>
+    );
+  }
   const text = parts.join(' · ');
 
   const longParts: string[] = [];
@@ -196,15 +217,11 @@ function MetricsLine({ metrics, isActive }: MetricsLineProps): JSX.Element | nul
     longParts.push(`Model: ${metrics.model}`);
   }
 
-  const colour = isActive
-    ? 'text-sky-800/80 dark:text-sky-200/80'
-    : 'text-slate-500 dark:text-slate-400';
-
   return (
     <span
       data-testid="sidebar-metrics"
       title={longParts.join('\n') || undefined}
-      className={`pl-7 text-xs leading-tight tabular-nums ${colour}`}
+      className={`block pl-7 text-xs leading-tight tabular-nums ${colour}`}
     >
       {text}
     </span>

--- a/src/components/SidebarTab.tsx
+++ b/src/components/SidebarTab.tsx
@@ -13,10 +13,11 @@ import { ToolIcon } from './ToolIcon';
 import {
   useActivity,
   useHasUnread,
+  useMetrics,
   useSessionActions,
   useSessionById,
 } from '@/store/session-store';
-import type { SessionId } from '@/types/arborist';
+import type { SessionId, SessionMetrics } from '@/types/arborist';
 
 interface SidebarTabProps {
   id: SessionId;
@@ -34,6 +35,7 @@ export function SidebarTab({
   const session = useSessionById(id);
   const hasUnread = useHasUnread(id);
   const activity = useActivity(id);
+  const metrics = useMetrics(id);
   const actions = useSessionActions();
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -49,7 +51,7 @@ export function SidebarTab({
   };
 
   const baseClasses =
-    'flex w-full items-center gap-2 rounded-md py-2 pl-2 pr-7 text-left text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500';
+    'flex w-full flex-col items-stretch gap-0.5 rounded-md py-2 pl-2 pr-7 text-left text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500';
   const stateClasses = isActive
     ? 'bg-sky-100 text-sky-900 dark:bg-sky-900/40 dark:text-sky-100'
     : 'text-slate-700 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-800';
@@ -71,61 +73,66 @@ export function SidebarTab({
         }}
         className={`${baseClasses} ${stateClasses}`}
       >
-        <ToolIcon
-          tool={session.tool}
-          className={
-            isActive
-              ? 'h-5 w-5 shrink-0 text-sky-700 dark:text-sky-300'
-              : 'h-5 w-5 shrink-0 text-slate-500 dark:text-slate-400'
-          }
-        />
-        <span className="min-w-0 flex-1 truncate">{session.label}</span>
-        {activity === 'attention' && session.status !== 'error' && (
-          <span
-            role="img"
-            aria-label="Attention required"
-            data-testid="status-attention"
-            className="h-2 w-2 shrink-0 rounded-full bg-amber-500"
+        <span className="flex w-full items-center gap-2">
+          <ToolIcon
+            tool={session.tool}
+            className={
+              isActive
+                ? 'h-5 w-5 shrink-0 text-sky-700 dark:text-sky-300'
+                : 'h-5 w-5 shrink-0 text-slate-500 dark:text-slate-400'
+            }
           />
-        )}
-        {activity === 'working' && session.status === 'running' && (
-          <span
-            role="img"
-            aria-label="Working"
-            data-testid="status-working"
-            className="h-2 w-2 shrink-0 animate-pulse rounded-full bg-emerald-500"
-          />
-        )}
-        {hasUnread && !isActive && session.status !== 'error' && activity !== 'attention' && (
-          <span
-            role="img"
-            aria-label="Unread output"
-            data-testid="status-unread"
-            className="h-2 w-2 shrink-0 rounded-full bg-sky-500"
-          />
-        )}
-        {session.status === 'starting' && (
-          <span
-            role="img"
-            aria-label="Starting"
-            data-testid="status-starting"
-            className="h-2.5 w-2.5 shrink-0 animate-pulse rounded-full border-2 border-sky-500 border-t-transparent"
-          />
-        )}
-        {session.status === 'exited' && (
-          <span
-            role="img"
-            aria-label="Exited"
-            data-testid="status-exited"
-            className="h-2 w-2 shrink-0 rounded-full bg-slate-400 dark:bg-slate-500"
-          />
-        )}
-        {session.status === 'error' && (
-          <span
-            role="img"
-            aria-label="Error"
-            className="h-2 w-2 shrink-0 rounded-full bg-red-500"
-          />
+          <span className="min-w-0 flex-1 truncate">{session.label}</span>
+          {activity === 'attention' && session.status !== 'error' && (
+            <span
+              role="img"
+              aria-label="Attention required"
+              data-testid="status-attention"
+              className="h-2 w-2 shrink-0 rounded-full bg-amber-500"
+            />
+          )}
+          {activity === 'working' && session.status === 'running' && (
+            <span
+              role="img"
+              aria-label="Working"
+              data-testid="status-working"
+              className="h-2 w-2 shrink-0 animate-pulse rounded-full bg-emerald-500"
+            />
+          )}
+          {hasUnread && !isActive && session.status !== 'error' && activity !== 'attention' && (
+            <span
+              role="img"
+              aria-label="Unread output"
+              data-testid="status-unread"
+              className="h-2 w-2 shrink-0 rounded-full bg-sky-500"
+            />
+          )}
+          {session.status === 'starting' && (
+            <span
+              role="img"
+              aria-label="Starting"
+              data-testid="status-starting"
+              className="h-2.5 w-2.5 shrink-0 animate-pulse rounded-full border-2 border-sky-500 border-t-transparent"
+            />
+          )}
+          {session.status === 'exited' && (
+            <span
+              role="img"
+              aria-label="Exited"
+              data-testid="status-exited"
+              className="h-2 w-2 shrink-0 rounded-full bg-slate-400 dark:bg-slate-500"
+            />
+          )}
+          {session.status === 'error' && (
+            <span
+              role="img"
+              aria-label="Error"
+              className="h-2 w-2 shrink-0 rounded-full bg-red-500"
+            />
+          )}
+        </span>
+        {metrics && session.status === 'running' && (
+          <MetricsLine metrics={metrics} isActive={isActive} />
         )}
       </button>
       <button
@@ -145,4 +152,68 @@ export function SidebarTab({
       </button>
     </li>
   );
+}
+
+// ---------------------------------------------------------------------------
+// MetricsLine — compact second line under the label showing context-window
+// usage and total token count. Non-interactive (no nested focusables): the
+// whole tab remains the single keyboard/DnD target.
+// ---------------------------------------------------------------------------
+
+interface MetricsLineProps {
+  metrics: SessionMetrics;
+  isActive: boolean;
+}
+
+function MetricsLine({ metrics, isActive }: MetricsLineProps): JSX.Element | null {
+  const parts: string[] = [];
+  if (typeof metrics.contextUsedPct === 'number') {
+    parts.push(`${metrics.contextUsedPct}%`);
+  }
+  if (typeof metrics.contextTokensUsed === 'number') {
+    parts.push(`${formatTokens(metrics.contextTokensUsed)} tok`);
+  }
+  if (parts.length === 0) return null;
+  const text = parts.join(' · ');
+
+  const longParts: string[] = [];
+  if (
+    typeof metrics.contextTokensUsed === 'number' &&
+    typeof metrics.contextTokensLimit === 'number'
+  ) {
+    longParts.push(
+      `Context ${metrics.contextTokensUsed.toLocaleString()} / ` +
+        `${metrics.contextTokensLimit.toLocaleString()} tokens`,
+    );
+  }
+  if (typeof metrics.inputTokens === 'number' && typeof metrics.outputTokens === 'number') {
+    longParts.push(
+      `Session totals: ${metrics.inputTokens.toLocaleString()} in, ` +
+        `${metrics.outputTokens.toLocaleString()} out`,
+    );
+  }
+  if (metrics.model) {
+    longParts.push(`Model: ${metrics.model}`);
+  }
+
+  const colour = isActive
+    ? 'text-sky-800/80 dark:text-sky-200/80'
+    : 'text-slate-500 dark:text-slate-400';
+
+  return (
+    <span
+      data-testid="sidebar-metrics"
+      title={longParts.join('\n') || undefined}
+      className={`pl-7 text-xs leading-tight tabular-nums ${colour}`}
+    >
+      {text}
+    </span>
+  );
+}
+
+/** Format a token count as `12.3k` for >= 1000, else as the raw number. */
+function formatTokens(n: number): string {
+  if (n < 1000) return String(n);
+  const k = n / 1000;
+  return k >= 100 ? `${Math.round(k)}k` : `${k.toFixed(1).replace(/\.0$/, '')}k`;
 }

--- a/src/lib/session-events.test.ts
+++ b/src/lib/session-events.test.ts
@@ -90,3 +90,33 @@ describe('subscribeToActivity', () => {
     expect(() => noop()).not.toThrow();
   });
 });
+
+describe('subscribeToMetrics', () => {
+  it('attaches onSessionMetrics and routes payloads to applyMetrics', () => {
+    useSessionStore.setState({ sessions: [makeView('a')] });
+
+    sessionEvents.subscribeToMetrics();
+
+    expect(bridgeMock.onSessionMetrics).toHaveBeenCalledTimes(1);
+    const cb = bridgeMock.onSessionMetrics.mock.calls[0]![0]!;
+    cb({
+      sessionId: 'a',
+      contextUsedPct: 42,
+      contextTokensUsed: 8400,
+      contextTokensLimit: 20000,
+      observedAt: 1700000000,
+    });
+
+    const m = useSessionStore.getState().metrics['a'];
+    expect(m).toBeDefined();
+    expect(m!.contextUsedPct).toBe(42);
+  });
+
+  it('is idempotent — a second call does not re-attach', () => {
+    sessionEvents.subscribeToMetrics();
+    const noop = sessionEvents.subscribeToMetrics();
+
+    expect(bridgeMock.onSessionMetrics).toHaveBeenCalledTimes(1);
+    expect(() => noop()).not.toThrow();
+  });
+});

--- a/src/lib/session-events.ts
+++ b/src/lib/session-events.ts
@@ -11,7 +11,7 @@
 // defeat xterm's own buffering. If you find yourself wanting one, you almost
 // certainly want a hook closer to the terminal instead.
 
-import { onSessionActivity, onSessionStatus } from '@/lib/tauri-bridge';
+import { onSessionActivity, onSessionMetrics, onSessionStatus } from '@/lib/tauri-bridge';
 import { useSessionStore } from '@/store/session-store';
 
 type Unlisten = () => void;
@@ -22,6 +22,8 @@ let statusAttached = false;
 let statusUnlistenPromise: Promise<Unlisten> | null = null;
 let activityAttached = false;
 let activityUnlistenPromise: Promise<Unlisten> | null = null;
+let metricsAttached = false;
+let metricsUnlistenPromise: Promise<Unlisten> | null = null;
 
 /**
  * Attach the single app-lifetime listener for `session://status` and route
@@ -79,6 +81,30 @@ export function subscribeToActivity(): Unlisten {
 }
 
 /**
+ * Attach the single app-lifetime listener for `session://metrics` and route
+ * each event into the session store's `applyMetrics` action. Same idempotency
+ * contract as {@link subscribeToStatus}.
+ */
+export function subscribeToMetrics(): Unlisten {
+  if (metricsAttached) return NOOP_UNLISTEN;
+  metricsAttached = true;
+
+  metricsUnlistenPromise = onSessionMetrics((payload) => {
+    useSessionStore.getState().actions.applyMetrics(payload);
+  });
+
+  return () => {
+    const pending = metricsUnlistenPromise;
+    metricsAttached = false;
+    metricsUnlistenPromise = null;
+    if (!pending) return;
+    void pending.then((unlisten) => {
+      unlisten();
+    });
+  };
+}
+
+/**
  * Test-only: forcibly detach the active subscription (if any) and reset the
  * module's internal state so subsequent `subscribeTo*` calls attach fresh.
  * Production code must use the unlisten returned by `subscribeToStatus`
@@ -87,10 +113,13 @@ export function subscribeToActivity(): Unlisten {
 export function __resetForTests(): void {
   const pendingStatus = statusUnlistenPromise;
   const pendingActivity = activityUnlistenPromise;
+  const pendingMetrics = metricsUnlistenPromise;
   statusAttached = false;
   statusUnlistenPromise = null;
   activityAttached = false;
   activityUnlistenPromise = null;
+  metricsAttached = false;
+  metricsUnlistenPromise = null;
   if (pendingStatus) {
     void pendingStatus.then((unlisten) => {
       unlisten();
@@ -98,6 +127,11 @@ export function __resetForTests(): void {
   }
   if (pendingActivity) {
     void pendingActivity.then((unlisten) => {
+      unlisten();
+    });
+  }
+  if (pendingMetrics) {
+    void pendingMetrics.then((unlisten) => {
       unlisten();
     });
   }

--- a/src/lib/tauri-bridge.mock.ts
+++ b/src/lib/tauri-bridge.mock.ts
@@ -144,6 +144,11 @@ export const onSessionActivity: Mock<
   ReturnType<typeof realBridge.onSessionActivity>
 > = vi.fn(() => Promise.resolve(noopUnlisten));
 
+export const onSessionMetrics: Mock<
+  Parameters<typeof realBridge.onSessionMetrics>,
+  ReturnType<typeof realBridge.onSessionMetrics>
+> = vi.fn(() => Promise.resolve(noopUnlisten));
+
 // Re-export the bridge's argument-shape interfaces so consumers importing
 // from the mock get identical types.
 export type {
@@ -177,6 +182,7 @@ export function resetBridgeMocks(): void {
   onSessionOutput.mockReset().mockImplementation(() => Promise.resolve(noopUnlisten));
   onSessionStatus.mockReset().mockImplementation(() => Promise.resolve(noopUnlisten));
   onSessionActivity.mockReset().mockImplementation(() => Promise.resolve(noopUnlisten));
+  onSessionMetrics.mockReset().mockImplementation(() => Promise.resolve(noopUnlisten));
 }
 
 // Compile-time guard: this module must export every member of the real
@@ -204,5 +210,6 @@ const _shapeCheck = {
   onSessionOutput,
   onSessionStatus,
   onSessionActivity,
+  onSessionMetrics,
 } satisfies typeof realBridge;
 void _shapeCheck;

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -29,6 +29,7 @@ import type {
   SessionOutputEvent,
   SessionStatusEvent,
   SessionActivityEvent,
+  SessionMetricsEvent,
   SessionView,
   Tool,
   WorktreeInfo,
@@ -238,4 +239,8 @@ export function onSessionActivity(
   cb: (payload: SessionActivityEvent) => void,
 ): Promise<UnlistenFn> {
   return listen<SessionActivityEvent>('session://activity', (event) => cb(event.payload));
+}
+
+export function onSessionMetrics(cb: (payload: SessionMetricsEvent) => void): Promise<UnlistenFn> {
+  return listen<SessionMetricsEvent>('session://metrics', (event) => cb(event.payload));
 }

--- a/src/store/session-store.test.ts
+++ b/src/store/session-store.test.ts
@@ -33,6 +33,7 @@ function resetStore(): void {
     statusMessages: {},
     hasUnread: {},
     activity: {},
+    metrics: {},
   });
 }
 
@@ -436,5 +437,87 @@ describe('applyActivity', () => {
       .actions.applyActivity({ sessionId: 'a', kind: 'title', value: 'claude' });
     useSessionStore.getState().actions.applyActivity({ sessionId: 'a', kind: 'promptStart' });
     expect(useSessionStore.getState().activity).toEqual({});
+  });
+});
+
+describe('applyMetrics', () => {
+  it('stores the snapshot keyed by sessionId', () => {
+    useSessionStore.setState({ sessions: [makeView({ id: 'a' })] });
+    useSessionStore.getState().actions.applyMetrics({
+      sessionId: 'a',
+      contextUsedPct: 25,
+      contextTokensUsed: 50_000,
+      contextTokensLimit: 200_000,
+      observedAt: 1700000000,
+    });
+    const m = useSessionStore.getState().metrics['a'];
+    expect(m).toBeDefined();
+    expect(m!.contextUsedPct).toBe(25);
+    expect(m!.contextTokensLimit).toBe(200_000);
+  });
+
+  it('drops metrics for unknown sessions (race with close)', () => {
+    useSessionStore.getState().actions.applyMetrics({
+      sessionId: 'ghost',
+      contextUsedPct: 10,
+      observedAt: 0,
+    });
+    expect(useSessionStore.getState().metrics).toEqual({});
+  });
+
+  it('does not re-set state for an unchanged snapshot (debounce)', () => {
+    useSessionStore.setState({ sessions: [makeView({ id: 'a' })] });
+    const evt = {
+      sessionId: 'a' as const,
+      contextUsedPct: 10,
+      contextTokensUsed: 1000,
+      observedAt: 1700000000,
+    };
+    useSessionStore.getState().actions.applyMetrics(evt);
+    const before = useSessionStore.getState().metrics['a'];
+    useSessionStore.getState().actions.applyMetrics({ ...evt });
+    const after = useSessionStore.getState().metrics['a'];
+    // Same reference => no new object created => no extra render.
+    expect(after).toBe(before);
+  });
+});
+
+describe('applyStatus + applyMetrics interaction', () => {
+  it('clears stale metrics when a session transitions back to starting (restart)', () => {
+    useSessionStore.setState({
+      sessions: [makeView({ id: 'a' })],
+      metrics: {
+        a: { sessionId: 'a', contextUsedPct: 50, observedAt: 1 },
+      },
+    });
+    const evt: SessionStatusEvent = { sessionId: 'a', status: 'starting' };
+    useSessionStore.getState().actions.applyStatus(evt);
+    expect(useSessionStore.getState().metrics['a']).toBeUndefined();
+  });
+
+  it('preserves metrics across non-starting status transitions', () => {
+    useSessionStore.setState({
+      sessions: [makeView({ id: 'a' })],
+      metrics: {
+        a: { sessionId: 'a', contextUsedPct: 50, observedAt: 1 },
+      },
+    });
+    const evt: SessionStatusEvent = { sessionId: 'a', status: 'running' };
+    useSessionStore.getState().actions.applyStatus(evt);
+    expect(useSessionStore.getState().metrics['a']).toBeDefined();
+  });
+});
+
+describe('close + metrics', () => {
+  it('drops metrics for the closed session', async () => {
+    useSessionStore.setState({
+      sessions: [makeView({ id: 'a' })],
+      metrics: {
+        a: { sessionId: 'a', contextUsedPct: 50, observedAt: 1 },
+      },
+    });
+    bridgeMock.sessionClose.mockImplementation(() => Promise.resolve());
+    await useSessionStore.getState().actions.close('a');
+    expect(useSessionStore.getState().metrics['a']).toBeUndefined();
   });
 });

--- a/src/store/session-store.ts
+++ b/src/store/session-store.ts
@@ -35,6 +35,8 @@ import {
 import type {
   SessionActivityEvent,
   SessionId,
+  SessionMetrics,
+  SessionMetricsEvent,
   SessionStatusEvent,
   SessionView,
 } from '@/types/arborist';
@@ -71,6 +73,13 @@ export interface SessionStoreState {
    * value was `attention`. Frontend-only — not persisted.
    */
   activity: Record<SessionId, SessionActivity>;
+  /**
+   * Latest token-usage / context-window snapshot per session, as emitted
+   * on `session://metrics` (Issue #3). Cleared on session close and on
+   * status transitions back to `starting` (restart) so stale numbers
+   * don't linger in the sidebar.
+   */
+  metrics: Record<SessionId, SessionMetrics>;
 }
 
 export type SessionActivity = 'working' | 'idle' | 'attention';
@@ -96,6 +105,12 @@ export interface SessionStoreActions {
    * high-frequency event handler.
    */
   applyActivity: (evt: SessionActivityEvent) => void;
+  /**
+   * Apply a `session://metrics` snapshot from the backend. Idempotent
+   * for unchanged payloads (the backend also debounces) and defensive
+   * against races with `close`.
+   */
+  applyMetrics: (evt: SessionMetricsEvent) => void;
 }
 
 type Store = SessionStoreState & { actions: SessionStoreActions };
@@ -108,6 +123,7 @@ const INITIAL_STATE: SessionStoreState = {
   statusMessages: {},
   hasUnread: {},
   activity: {},
+  metrics: {},
 };
 
 /**
@@ -135,7 +151,14 @@ export const useSessionStore = create<Store>((set, get) => {
       const sessions = await sessionList();
       // Clear any orphan status messages — keys may belong to sessions
       // that no longer exist after the backend reload.
-      set({ sessions, isHydrated: true, statusMessages: {}, hasUnread: {}, activity: {} });
+      set({
+        sessions,
+        isHydrated: true,
+        statusMessages: {},
+        hasUnread: {},
+        activity: {},
+        metrics: {},
+      });
     },
 
     create: async (args) => {
@@ -162,7 +185,7 @@ export const useSessionStore = create<Store>((set, get) => {
       // is gone.
       if (get().pendingClose === id) patch.pendingClose = undefined;
       // Drop any orphan status-message keyed under this session id.
-      const { statusMessages, hasUnread, activity } = get();
+      const { statusMessages, hasUnread, activity, metrics } = get();
       if (id in statusMessages) {
         const next = { ...statusMessages };
         delete next[id];
@@ -177,6 +200,11 @@ export const useSessionStore = create<Store>((set, get) => {
         const nextActivity = { ...activity };
         delete nextActivity[id];
         patch.activity = nextActivity;
+      }
+      if (id in metrics) {
+        const nextMetrics = { ...metrics };
+        delete nextMetrics[id];
+        patch.metrics = nextMetrics;
       }
       set(patch);
     },
@@ -251,14 +279,25 @@ export const useSessionStore = create<Store>((set, get) => {
       // Track the optional status message keyed by session id. We
       // overwrite (not merge) so a status transition without a message
       // clears any stale annotation from a prior transition.
-      const { statusMessages } = get();
+      const { statusMessages, metrics } = get();
       const nextMessages = { ...statusMessages };
       if (evt.message !== undefined && evt.message.length > 0) {
         nextMessages[evt.sessionId] = evt.message;
       } else {
         delete nextMessages[evt.sessionId];
       }
-      set({ sessions: nextSessions, statusMessages: nextMessages });
+      const patch: Partial<SessionStoreState> = {
+        sessions: nextSessions,
+        statusMessages: nextMessages,
+      };
+      // On restart (back to `starting`), drop any stale metrics so the
+      // sidebar doesn't show numbers from the previous run.
+      if (evt.status === 'starting' && evt.sessionId in metrics) {
+        const nextMetrics = { ...metrics };
+        delete nextMetrics[evt.sessionId];
+        patch.metrics = nextMetrics;
+      }
+      set(patch);
     },
 
     noteUnread: (id) => {
@@ -301,6 +340,18 @@ export const useSessionStore = create<Store>((set, get) => {
       if (current === next) return;
       set({ activity: { ...activity, [evt.sessionId]: next } });
     },
+
+    applyMetrics: (evt) => {
+      const { sessions, metrics } = get();
+      // Defensive: drop events for unknown sessions (race with close).
+      if (!sessions.some((s) => s.id === evt.sessionId)) return;
+      const prev = metrics[evt.sessionId];
+      // Cheap structural equality: every key/value is a primitive or
+      // undefined, so a JSON compare is both correct and fast enough at
+      // the rate the backend emits (≤ once per ~2s per session).
+      if (prev && JSON.stringify(prev) === JSON.stringify(evt)) return;
+      set({ metrics: { ...metrics, [evt.sessionId]: evt } });
+    },
   };
 
   return { ...INITIAL_STATE, actions };
@@ -327,6 +378,10 @@ export const selectActivity =
   (id: SessionId | undefined) =>
   (s: Store): SessionActivity | undefined =>
     id === undefined ? undefined : s.activity[id];
+export const selectMetrics =
+  (id: SessionId | undefined) =>
+  (s: Store): SessionMetrics | undefined =>
+    id === undefined ? undefined : s.metrics[id];
 
 export const useSessions = (): SessionView[] => useSessionStore(selectSessions);
 export const useActiveSessionId = (): SessionId | undefined => useSessionStore(selectActiveId);
@@ -338,6 +393,8 @@ export const useHasUnread = (id: SessionId | undefined): boolean =>
   useSessionStore(selectHasUnread(id));
 export const useActivity = (id: SessionId | undefined): SessionActivity | undefined =>
   useSessionStore(selectActivity(id));
+export const useMetrics = (id: SessionId | undefined): SessionMetrics | undefined =>
+  useSessionStore(selectMetrics(id));
 
 export function useActiveSession(): SessionView | undefined {
   const sessions = useSessions();

--- a/src/types/arborist.ts
+++ b/src/types/arborist.ts
@@ -167,6 +167,32 @@ export type ActivityEvent =
 // `sessionId`.
 export type SessionActivityEvent = { sessionId: SessionId } & ActivityEvent;
 
+// MIRROR: src-tauri/src/types.rs::SessionMetricsEvent
+// Payload of the `session://metrics` Tauri event (Issue #3). All fields
+// except `sessionId` and `observedAt` are optional — the watcher emits
+// only what it can resolve. The same shape doubles as the in-memory
+// snapshot the sidebar renders.
+export interface SessionMetricsEvent {
+  sessionId: SessionId;
+  /** Model identifier as reported by the CLI (e.g. `claude-sonnet-4-6`). */
+  model?: string;
+  /** Percentage of the context window in use, 0..=100. */
+  contextUsedPct?: number;
+  /** Tokens currently counted against the context window. */
+  contextTokensUsed?: number;
+  /** Model context-window limit in tokens, when known. */
+  contextTokensLimit?: number;
+  /** Cumulative input tokens across observed turns. */
+  inputTokens?: number;
+  /** Cumulative output tokens across observed turns. */
+  outputTokens?: number;
+  /** Wall-clock unix-seconds at which this snapshot was produced. */
+  observedAt: number;
+}
+
+/** In-memory alias — sidebar reads the same shape it received over the wire. */
+export type SessionMetrics = SessionMetricsEvent;
+
 // MIRROR: src-tauri/src/types.rs::WorktreeInfo
 // Returned by the `worktrees_list` command (DESIGN §6, Phase 10).
 // `branch` is omitted by the backend when the worktree has a detached HEAD,


### PR DESCRIPTION
Adds a compact second line to each sidebar tab (e.g. `78% · 12.3k tok`) showing live context-window utilization and total token count for Claude sessions.

Closes #3. Refs #4 (hook-driven authoritative follow-up).

## Approach (v1: heuristic file-polling)

After investigating three approaches — PTY scraping, JSONL polling, and CLI hooks — v1 ships **JSONL polling** as the lowest-risk path. Hooks are strictly better but require `--settings` injection and Copilot still has no path (its hooks load only from `<cwd>/.github/hooks/hooks.json`, polluting the user's repo). That work is tracked in #4.

## What's in this PR

**Backend**
- New `session_metrics` module that polls `~/.claude/projects/<encoded-cwd>/<sid>.jsonl` using a cwd+mtime heuristic to map an Arborist session to the newest matching transcript.
- Extracts cumulative `usage` (input + output + cache_read + cache_creation) from the latest `assistant` line; resolves model context limit via `~/.claude/token_usage.json::actual_limit` with a 200k Anthropic fallback.
- Debounced `session://metrics` events.
- Watcher started in `session_create` / `session_restart` / `restore_all_sessions`; stopped in `session_close`.
- Emit callback is dependency-injected so unit tests capture events without Tauri.

**Frontend**
- New `SessionMetricsEvent` type, `onSessionMetrics` bridge, `subscribeToMetrics` listener, `metrics` slice in the session store with JSON-equality debounce.
- `metrics` cleared on close and on transition into the `starting` status.
- `MetricsLine` subcomponent in `SidebarTab` rendering only when a snapshot is present, with a long-form `title` for hover.

## Known limitations (tracked in #4)

- Cannot disambiguate two same-tool Claude sessions sharing one worktree.
- Copilot tabs show no metrics — Copilot writes no token data to disk regardless of mapping strategy.

## Tests

- Rust: 18 new unit tests in `session_metrics` (parser, encode_cwd, limit resolution, snapshot building, watcher lifecycle); 182 total passing.
- Frontend: new tests under `Sidebar metrics indicator` and store/event-listener tests; 202 total passing.
- `cargo fmt --check`, `cargo clippy -D warnings`, `npm run lint` all clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
