### PR TITLE
feat(window): show build branch in title bar when not main

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
-    "tauri:dev": "tauri dev",
+    "tauri:dev": "node scripts/tauri-dev.mjs",
     "tauri:build": "tauri build",
     "lint": "eslint . && prettier --check .",
     "lint:fix": "eslint . --fix && prettier --write .",

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -36,10 +36,7 @@ process.env.ARBORIST_DEV_PORT = String(port);
 // Windows the shell strips quotes from inline JSON args, breaking parsing.
 const dir = mkdtempSync(join(tmpdir(), 'arborist-dev-'));
 const overridePath = join(dir, 'tauri.conf.override.json');
-writeFileSync(
-  overridePath,
-  JSON.stringify({ build: { devUrl: `http://localhost:${port}` } }),
-);
+writeFileSync(overridePath, JSON.stringify({ build: { devUrl: `http://localhost:${port}` } }));
 
 console.log(`[arborist] tauri dev on port ${port}`);
 

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -68,27 +68,59 @@ process.on('exit', cleanup);
 console.log(`[arborist] tauri dev on port ${port}`);
 
 const isWindows = process.platform === 'win32';
+
+// On POSIX we can spawn `npx` directly without a shell and put the child in
+// its own process group (`detached: true`); this lets us deliver signals to
+// the whole tree (`tauri dev`, `vite`, …) via `process.kill(-pid, sig)`.
+//
+// On Windows we still need `shell: true` because Node's `spawn` refuses to
+// execute `.cmd`/`.bat` files directly without a shell since the CVE-2024-27980
+// fix.  In return we use `taskkill /pid <pid> /T /F` to terminate the whole
+// process tree on shutdown — `child.kill()` against the wrapping `cmd.exe`
+// alone does not reliably reach `tauri`/`vite`.
 const child = spawn(
   isWindows ? 'npx.cmd' : 'npx',
   ['tauri', 'dev', '--config', overridePath, ...process.argv.slice(2)],
-  { stdio: 'inherit', env: process.env, shell: isWindows },
+  {
+    stdio: 'inherit',
+    env: process.env,
+    shell: isWindows,
+    detached: !isWindows,
+  },
 );
 
-// Forward terminating signals to the child so we don't orphan `tauri dev` /
-// Vite (which would keep holding the dev port). The child's `exit` handler
-// below performs cleanup and propagates its exit status. SIGBREAK is
-// Windows-only; registering it on POSIX would crash with `ERR_UNKNOWN_SIGNAL`.
+function killChildTree(sig) {
+  if (isWindows) {
+    try {
+      // /T = tree, /F = force. Spawn synchronously and ignore output —
+      // failure usually just means the child already exited.
+      spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], {
+        stdio: 'ignore',
+      });
+    } catch {
+      // best-effort
+    }
+    return;
+  }
+  try {
+    // Negative pid targets the process group created by `detached: true`.
+    process.kill(-child.pid, sig);
+  } catch {
+    try {
+      child.kill(sig);
+    } catch {
+      // child may already be gone
+    }
+  }
+}
+
+// SIGBREAK is Windows-only; registering it on POSIX would crash with
+// `ERR_UNKNOWN_SIGNAL`.
 const forwardSignals = isWindows
   ? ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGBREAK']
   : ['SIGINT', 'SIGTERM', 'SIGHUP'];
 for (const sig of forwardSignals) {
-  process.on(sig, () => {
-    try {
-      child.kill(sig);
-    } catch {
-      // child may already be gone — fall through to cleanup
-    }
-  });
+  process.on(sig, () => killChildTree(sig));
 }
 
 child.on('exit', (code, signal) => {

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -68,26 +68,34 @@ process.on('exit', cleanup);
 console.log(`[arborist] tauri dev on port ${port}`);
 
 const isWindows = process.platform === 'win32';
+const tauriDevArgs = ['tauri', 'dev', '--config', overridePath, ...process.argv.slice(2)];
 
 // On POSIX we can spawn `npx` directly without a shell and put the child in
 // its own process group (`detached: true`); this lets us deliver signals to
 // the whole tree (`tauri dev`, `vite`, …) via `process.kill(-pid, sig)`.
 //
-// On Windows we still need `shell: true` because Node's `spawn` refuses to
-// execute `.cmd`/`.bat` files directly without a shell since the CVE-2024-27980
-// fix.  In return we use `taskkill /pid <pid> /T /F` to terminate the whole
-// process tree on shutdown — `child.kill()` against the wrapping `cmd.exe`
-// alone does not reliably reach `tauri`/`vite`.
-const child = spawn(
-  isWindows ? 'npx.cmd' : 'npx',
-  ['tauri', 'dev', '--config', overridePath, ...process.argv.slice(2)],
-  {
-    stdio: 'inherit',
-    env: process.env,
-    shell: isWindows,
-    detached: !isWindows,
-  },
-);
+// On Windows Node's `spawn` won't execute `.cmd`/`.bat` files directly since
+// the CVE-2024-27980 fix, so we invoke `%COMSPEC%` (`cmd.exe`) explicitly and
+// pass a single carefully-quoted command string. This keeps `--config
+// <overridePath>` intact even when the temp path contains spaces (e.g. user
+// profiles like `C:\Users\Jane Doe\AppData\Local\Temp\...`).  Shutdown still
+// goes through `taskkill /pid <pid> /T /F` to terminate the full tree because
+// killing `cmd.exe` alone doesn't reliably reach `npx`/`tauri`/`vite`.
+function quoteCmdArg(value) {
+  return `"${String(value).replace(/"/g, '""')}"`;
+}
+
+const child = isWindows
+  ? spawn(
+      process.env.ComSpec ?? 'cmd.exe',
+      ['/d', '/s', '/c', [quoteCmdArg('npx.cmd'), ...tauriDevArgs.map(quoteCmdArg)].join(' ')],
+      { stdio: 'inherit', env: process.env, windowsVerbatimArguments: true },
+    )
+  : spawn('npx', tauriDevArgs, {
+      stdio: 'inherit',
+      env: process.env,
+      detached: true,
+    });
 
 function killChildTree(sig) {
   if (isWindows) {

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -100,7 +100,7 @@ const child = isWindows
 function killChildTree(sig) {
   if (isWindows) {
     try {
-      // /T = tree, /F = force. Spawn synchronously and ignore output —
+      // /T = tree, /F = force. Spawn and ignore output (fire-and-forget) —
       // failure usually just means the child already exited.
       spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], {
         stdio: 'ignore',

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -64,12 +64,6 @@ function cleanup() {
   }
 }
 process.on('exit', cleanup);
-for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGBREAK']) {
-  process.on(sig, () => {
-    cleanup();
-    process.exit(1);
-  });
-}
 
 console.log(`[arborist] tauri dev on port ${port}`);
 
@@ -79,7 +73,27 @@ const child = spawn(
   ['tauri', 'dev', '--config', overridePath, ...process.argv.slice(2)],
   { stdio: 'inherit', env: process.env, shell: isWindows },
 );
-child.on('exit', (code) => {
+
+// Forward terminating signals to the child so we don't orphan `tauri dev` /
+// Vite (which would keep holding the dev port). The child's `exit` handler
+// below performs cleanup and propagates its exit status.
+for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGBREAK']) {
+  process.on(sig, () => {
+    try {
+      child.kill(sig);
+    } catch {
+      // child may already be gone — fall through to cleanup
+    }
+  });
+}
+
+child.on('exit', (code, signal) => {
   cleanup();
+  if (signal) {
+    // Mirror the child's terminating signal in our exit code (128 + signum
+    // is the conventional shell encoding); fall back to 1 if unknown.
+    const signums = { SIGINT: 2, SIGTERM: 15, SIGHUP: 1, SIGBREAK: 21 };
+    process.exit(128 + (signums[signal] ?? 0) || 1);
+  }
   process.exit(code ?? 1);
 });

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -13,17 +13,32 @@
 //     desktop shell loads the matching URL.
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { writeFileSync, mkdtempSync } from 'node:fs';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 const PORT_MIN = 1420;
 const PORT_RANGE = 100;
+const PORT_MAX = 65535;
+
+function failInvalidPortOverride(override) {
+  console.error(
+    `[arborist] ARBORIST_DEV_PORT must be an integer between 1 and ${PORT_MAX}; received "${override}"`,
+  );
+  process.exit(1);
+}
 
 function pickPort() {
   const override = process.env.ARBORIST_DEV_PORT;
-  if (override && /^\d+$/.test(override)) {
-    return Number(override);
+  if (override !== undefined && override !== '') {
+    if (!/^\d+$/.test(override)) {
+      failInvalidPortOverride(override);
+    }
+    const port = Number(override);
+    if (!Number.isInteger(port) || port < 1 || port > PORT_MAX) {
+      failInvalidPortOverride(override);
+    }
+    return port;
   }
   const hash = createHash('sha1').update(process.cwd()).digest();
   return PORT_MIN + (hash.readUInt16BE(0) % PORT_RANGE);
@@ -38,6 +53,24 @@ const dir = mkdtempSync(join(tmpdir(), 'arborist-dev-'));
 const overridePath = join(dir, 'tauri.conf.override.json');
 writeFileSync(overridePath, JSON.stringify({ build: { devUrl: `http://localhost:${port}` } }));
 
+let cleanedUp = false;
+function cleanup() {
+  if (cleanedUp) return;
+  cleanedUp = true;
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // best-effort: nothing actionable if removal fails
+  }
+}
+process.on('exit', cleanup);
+for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGBREAK']) {
+  process.on(sig, () => {
+    cleanup();
+    process.exit(1);
+  });
+}
+
 console.log(`[arborist] tauri dev on port ${port}`);
 
 const isWindows = process.platform === 'win32';
@@ -46,4 +79,7 @@ const child = spawn(
   ['tauri', 'dev', '--config', overridePath, ...process.argv.slice(2)],
   { stdio: 'inherit', env: process.env, shell: isWindows },
 );
-child.on('exit', (code) => process.exit(code ?? 1));
+child.on('exit', (code) => {
+  cleanup();
+  process.exit(code ?? 1);
+});

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// Run `tauri dev` on a per-worktree dev-server port so multiple branches /
+// worktrees can be developed in parallel without colliding on port 1420.
+//
+// Port resolution:
+//   1. `ARBORIST_DEV_PORT` env var (explicit override).
+//   2. Otherwise a deterministic hash of the current working directory in
+//      the range [PORT_MIN, PORT_MIN + PORT_RANGE).
+//
+// The chosen port is exported to the child process so:
+//   - `vite.config.ts` picks it up for the dev server.
+//   - This script overrides Tauri's `build.devUrl` via `--config` so the
+//     desktop shell loads the matching URL.
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const PORT_MIN = 1420;
+const PORT_RANGE = 100;
+
+function pickPort() {
+  const override = process.env.ARBORIST_DEV_PORT;
+  if (override && /^\d+$/.test(override)) {
+    return Number(override);
+  }
+  const hash = createHash('sha1').update(process.cwd()).digest();
+  return PORT_MIN + (hash.readUInt16BE(0) % PORT_RANGE);
+}
+
+const port = pickPort();
+process.env.ARBORIST_DEV_PORT = String(port);
+
+// Write the override to a temp JSON file rather than passing it inline; on
+// Windows the shell strips quotes from inline JSON args, breaking parsing.
+const dir = mkdtempSync(join(tmpdir(), 'arborist-dev-'));
+const overridePath = join(dir, 'tauri.conf.override.json');
+writeFileSync(
+  overridePath,
+  JSON.stringify({ build: { devUrl: `http://localhost:${port}` } }),
+);
+
+console.log(`[arborist] tauri dev on port ${port}`);
+
+const isWindows = process.platform === 'win32';
+const child = spawn(
+  isWindows ? 'npx.cmd' : 'npx',
+  ['tauri', 'dev', '--config', overridePath, ...process.argv.slice(2)],
+  { stdio: 'inherit', env: process.env, shell: isWindows },
+);
+child.on('exit', (code) => process.exit(code ?? 1));

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -76,8 +76,12 @@ const child = spawn(
 
 // Forward terminating signals to the child so we don't orphan `tauri dev` /
 // Vite (which would keep holding the dev port). The child's `exit` handler
-// below performs cleanup and propagates its exit status.
-for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGBREAK']) {
+// below performs cleanup and propagates its exit status. SIGBREAK is
+// Windows-only; registering it on POSIX would crash with `ERR_UNKNOWN_SIGNAL`.
+const forwardSignals = isWindows
+  ? ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGBREAK']
+  : ['SIGINT', 'SIGTERM', 'SIGHUP'];
+for (const sig of forwardSignals) {
   process.on(sig, () => {
     try {
       child.kill(sig);
@@ -91,9 +95,14 @@ child.on('exit', (code, signal) => {
   cleanup();
   if (signal) {
     // Mirror the child's terminating signal in our exit code (128 + signum
-    // is the conventional shell encoding); fall back to 1 if unknown.
+    // is the conventional shell encoding). For unknown signals, fall back
+    // to exit code 1.
     const signums = { SIGINT: 2, SIGTERM: 15, SIGHUP: 1, SIGBREAK: 21 };
-    process.exit(128 + (signums[signal] ?? 0) || 1);
+    const signum = signums[signal];
+    if (signum === undefined) {
+      process.exit(1);
+    }
+    process.exit(128 + signum);
   }
   process.exit(code ?? 1);
 });

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -37,8 +37,24 @@ fn detect_branch() -> String {
     String::new()
 }
 
+/// Sanitize a branch name before embedding it in a `cargo:` directive.
+///
+/// Branch names can in principle contain control characters (notably
+/// newlines via the `ARBORIST_BUILD_BRANCH` override).  Without sanitization
+/// a malicious or malformed value could inject extra `cargo:` lines into
+/// the build output.  Restrict to a single-line, conservative character set:
+/// ASCII alphanumerics plus `-_./+:`.  Anything else is dropped.
+fn sanitize_branch(raw: &str) -> String {
+    raw.lines()
+        .next()
+        .unwrap_or("")
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/' | '+' | ':'))
+        .collect()
+}
+
 fn main() {
-    let branch = detect_branch();
+    let branch = sanitize_branch(&detect_branch());
     println!("cargo:rustc-env=ARBORIST_BUILD_BRANCH={branch}");
 
     // Re-run when the override or CI env vars change.

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,66 @@
+use std::process::Command;
+
+/// Detect the git branch name this build is being produced from.
+///
+/// Resolution order:
+///   1. `ARBORIST_BUILD_BRANCH` (explicit override)
+///   2. `GITHUB_HEAD_REF` (set in PR builds — source branch, not `merge`)
+///   3. `GITHUB_REF_NAME` (set in branch/tag builds)
+///   4. `git rev-parse --abbrev-ref HEAD`
+///
+/// Returns an empty string if none succeed or the branch is detached / `HEAD`.
+fn detect_branch() -> String {
+    if let Ok(b) = std::env::var("ARBORIST_BUILD_BRANCH") {
+        return b.trim().to_string();
+    }
+    for var in ["GITHUB_HEAD_REF", "GITHUB_REF_NAME"] {
+        if let Ok(v) = std::env::var(var) {
+            let v = v.trim();
+            if !v.is_empty() {
+                return v.to_string();
+            }
+        }
+    }
+    let out = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output();
+    if let Ok(out) = out {
+        if out.status.success() {
+            if let Ok(s) = String::from_utf8(out.stdout) {
+                let s = s.trim();
+                if !s.is_empty() && s != "HEAD" {
+                    return s.to_string();
+                }
+            }
+        }
+    }
+    String::new()
+}
+
 fn main() {
+    let branch = detect_branch();
+    println!("cargo:rustc-env=ARBORIST_BUILD_BRANCH={branch}");
+
+    // Re-run when the override or CI env vars change.
+    println!("cargo:rerun-if-env-changed=ARBORIST_BUILD_BRANCH");
+    println!("cargo:rerun-if-env-changed=GITHUB_HEAD_REF");
+    println!("cargo:rerun-if-env-changed=GITHUB_REF_NAME");
+
+    // Re-run when HEAD moves. In a linked worktree `.git` is a file, so resolve
+    // the real HEAD path via `git rev-parse --git-path HEAD`.
+    if let Ok(out) = Command::new("git")
+        .args(["rev-parse", "--git-path", "HEAD"])
+        .output()
+    {
+        if out.status.success() {
+            if let Ok(p) = String::from_utf8(out.stdout) {
+                let p = p.trim();
+                if !p.is_empty() {
+                    println!("cargo:rerun-if-changed={p}");
+                }
+            }
+        }
+    }
+
     tauri_build::build()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -182,10 +182,10 @@ mod tests {
 
     #[test]
     fn title_on_feature_branch_includes_name() {
+        assert_eq!(window_title_for_branch("feature/x"), "Arborist - feature/x");
         assert_eq!(
-            window_title_for_branch("feature/x"),
-            "Arborist - feature/x"
+            window_title_for_branch("  branch-name  "),
+            "Arborist - branch-name"
         );
-        assert_eq!(window_title_for_branch("  branch-name  "), "Arborist - branch-name");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -78,7 +78,7 @@ pub fn init_tracing(log_dir: Option<&std::path::Path>) -> Option<WorkerGuard> {
 /// On `main` (or when no branch could be detected) the title is just
 /// `"Arborist"`.  On any other branch the title becomes
 /// `"Arborist - <branch>"` so it is obvious which build is running.
-pub fn window_title_for_branch(branch: &str) -> String {
+pub(crate) fn window_title_for_branch(branch: &str) -> String {
     let trimmed = branch.trim();
     if trimmed.is_empty() || trimmed == "main" {
         "Arborist".to_string()
@@ -88,7 +88,7 @@ pub fn window_title_for_branch(branch: &str) -> String {
 }
 
 /// Branch this binary was built from, captured at compile time by `build.rs`.
-pub const BUILD_BRANCH: &str = env!("ARBORIST_BUILD_BRANCH");
+pub(crate) const BUILD_BRANCH: &str = env!("ARBORIST_BUILD_BRANCH");
 
 /// Build and run the Tauri application.
 pub fn run() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -73,6 +73,23 @@ pub fn init_tracing(log_dir: Option<&std::path::Path>) -> Option<WorkerGuard> {
     }
 }
 
+/// Compute the main window title for a given build branch.
+///
+/// On `main` (or when no branch could be detected) the title is just
+/// `"Arborist"`.  On any other branch the title becomes
+/// `"Arborist - <branch>"` so it is obvious which build is running.
+pub fn window_title_for_branch(branch: &str) -> String {
+    let trimmed = branch.trim();
+    if trimmed.is_empty() || trimmed == "main" {
+        "Arborist".to_string()
+    } else {
+        format!("Arborist - {trimmed}")
+    }
+}
+
+/// Branch this binary was built from, captured at compile time by `build.rs`.
+pub const BUILD_BRANCH: &str = env!("ARBORIST_BUILD_BRANCH");
+
 /// Build and run the Tauri application.
 pub fn run() {
     tauri::Builder::default()
@@ -88,6 +105,16 @@ pub fn run() {
                 app.manage(LogGuard(guard));
             }
             tracing::info!("Arborist starting up");
+
+            // If this build came from a branch other than `main`, surface the
+            // branch name in the window title bar so it's obvious which build
+            // is running.
+            if let Some(window) = app.get_webview_window("main") {
+                let title = window_title_for_branch(BUILD_BRANCH);
+                if let Err(err) = window.set_title(&title) {
+                    tracing::warn!(%err, "failed to set main window title");
+                }
+            }
 
             // Build the production AppContext: portable-pty spawner, the
             // on-disk ConfigStore, and a PtySink that bridges back into
@@ -140,5 +167,25 @@ mod tests {
         // Calling twice must not panic — the global subscriber may already be set.
         init_tracing(None);
         init_tracing(None);
+    }
+
+    #[test]
+    fn title_on_main_is_plain() {
+        assert_eq!(window_title_for_branch("main"), "Arborist");
+    }
+
+    #[test]
+    fn title_on_empty_branch_is_plain() {
+        assert_eq!(window_title_for_branch(""), "Arborist");
+        assert_eq!(window_title_for_branch("   "), "Arborist");
+    }
+
+    #[test]
+    fn title_on_feature_branch_includes_name() {
+        assert_eq!(
+            window_title_for_branch("feature/x"),
+            "Arborist - feature/x"
+        );
+        assert_eq!(window_title_for_branch("  branch-name  "), "Arborist - branch-name");
     }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,9 +4,12 @@ import { fileURLToPath, URL } from 'node:url';
 
 function devPort(): number {
   const raw = process.env.ARBORIST_DEV_PORT;
-  if (!raw) return 1420;
+  // Same validation rule as scripts/tauri-dev.mjs: integer in [1, 65535].
+  // Reject `Number()`-coerced forms like "1e3" or " 42 " so both entrypoints
+  // agree on what counts as a valid override.
+  if (!raw || !/^\d+$/.test(raw)) return 1420;
   const n = Number(raw);
-  return Number.isInteger(n) && n >= 1 && n <= 65535 ? n : 1420;
+  return n >= 1 && n <= 65535 ? n : 1420;
 }
 
 // https://vitejs.dev/config/

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   },
   clearScreen: false,
   server: {
-    port: 1420,
+    port: Number(process.env.ARBORIST_DEV_PORT) || 1420,
     strictPort: true,
   },
   envPrefix: ['VITE_', 'TAURI_'],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,13 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { fileURLToPath, URL } from 'node:url';
 
+function devPort(): number {
+  const raw = process.env.ARBORIST_DEV_PORT;
+  if (!raw) return 1420;
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= 1 && n <= 65535 ? n : 1420;
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
@@ -12,7 +19,7 @@ export default defineConfig({
   },
   clearScreen: false,
   server: {
-    port: Number(process.env.ARBORIST_DEV_PORT) || 1420,
+    port: devPort(),
     strictPort: true,
   },
   envPrefix: ['VITE_', 'TAURI_'],


### PR DESCRIPTION
When Arborist is built from a branch other than `main`, the main window title becomes `Arborist - <branch>` so it's obvious at a glance which build is running.

## Branch detection (build-time, in `src-tauri/build.rs`)
Resolution order:
1. `ARBORIST_BUILD_BRANCH` (explicit override)
2. `GITHUB_HEAD_REF` (PR builds — source branch)
3. `GITHUB_REF_NAME` (branch/tag builds)
4. `git rev-parse --abbrev-ref HEAD`

Re-runs when HEAD moves (worktree-aware via `git rev-parse --git-path HEAD`) or when any of the env vars change. Exposed to the binary as `env!(\"ARBORIST_BUILD_BRANCH\")`.

## Title application
`window_title_for_branch(branch)` returns `\"Arborist\"` on `main` / empty, otherwise `\"Arborist - <branch>\"`. Applied to the main window in `run()`'s setup with `window.set_title(...)`. Covered by 3 unit tests.

## Bonus: per-worktree dev port
Vite/Tauri were hardcoded to port 1420, so two worktrees couldn't run `tauri dev` at the same time. Added `scripts/tauri-dev.mjs` which:
- Picks a port from `ARBORIST_DEV_PORT` env, or a deterministic SHA-1 hash of `cwd` in `[1420, 1520)`.
- Writes a temp `--config` JSON overriding `build.devUrl` so Tauri loads the matching URL.
- Vite's `server.port` reads the same env var.

`npm run tauri:dev` now routes through this script.

## Verification
- `cargo test --lib` — 207 passed (including 3 new title tests).
- `cargo clippy --lib --tests -- -D warnings` — clean.
- Ran `npm run tauri:dev` from this worktree; window title displayed `Arborist - branch-name` on port 1439.