### PR TITLE
fix(git): strip GIT_* env so tests can't corrupt outer repo (#13)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,17 @@
 #!/usr/bin/env sh
 
+# Issue #13: when `git push` invokes this hook, it exports repo-selection
+# variables (GIT_DIR, GIT_WORK_TREE, ...) into the child environment. They
+# take precedence over `-C <path>` / `current_dir(...)` in any `git`
+# subprocess we spawn from `cargo test`, which historically resulted in
+# unregistered worktrees and stray commits on the developer's checked-out
+# branch. Strip them here as defense-in-depth; the Rust test suite also
+# scrubs them per-Command via `git::git_command()` / `clean_test_git_command`.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR \
+      GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES \
+      GIT_NAMESPACE GIT_PREFIX \
+      GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_AUTHOR_DATE \
+      GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL GIT_COMMITTER_DATE
+
 npm test -- --run || exit 1
 cargo test --workspace || exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "serial_test",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -2965,6 +2966,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3020,6 +3030,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "selectors"
@@ -3234,6 +3250,32 @@ checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
 dependencies = [
  "libc",
  "serial-core",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ tokio-util = { version = "0.7.18", features = ["rt"] }
 [dev-dependencies]
 pretty_assertions = "1"
 rstest = "0.23"
+serial_test = "3"
 
 [features]
 default = ["custom-protocol"]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,5 +1,30 @@
 use std::process::Command;
 
+/// Build a `git` Command with repo-selection environment variables stripped.
+///
+/// build.rs runs as a child of `cargo`, which under a husky pre-push hook
+/// inherits `GIT_DIR`/`GIT_WORK_TREE`/etc. from the outer `git push`. Without
+/// stripping them, our branch detection would report the *outer* repo's
+/// branch and bake the wrong value into `ARBORIST_BUILD_BRANCH`. Mirrors
+/// `git::git_command()` (kept duplicated because build scripts can't depend
+/// on the crate being built).
+fn git_command() -> Command {
+    let mut cmd = Command::new("git");
+    for var in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_COMMON_DIR",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_NAMESPACE",
+        "GIT_PREFIX",
+    ] {
+        cmd.env_remove(var);
+    }
+    cmd
+}
+
 /// Detect the git branch name this build is being produced from.
 ///
 /// Resolution order:
@@ -21,7 +46,7 @@ fn detect_branch() -> String {
             }
         }
     }
-    let out = Command::new("git")
+    let out = git_command()
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .output();
     if let Ok(out) = out {
@@ -64,7 +89,7 @@ fn main() {
 
     // Re-run when HEAD moves. In a linked worktree `.git` is a file, so resolve
     // the real HEAD path via `git rev-parse --git-path HEAD`.
-    if let Ok(out) = Command::new("git")
+    if let Ok(out) = git_command()
         .args(["rev-parse", "--git-path", "HEAD"])
         .output()
     {

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -30,6 +30,37 @@ use tracing::{debug, warn};
 
 use crate::types::{Error, WorktreeInfo};
 
+/// Build a `git` [`Command`] with the repo-selection environment variables
+/// stripped.
+///
+/// When arborist (or its test suite) runs as a child of another `git`
+/// invocation — most importantly the husky `pre-push` hook — git exports
+/// `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, etc. into the child
+/// environment. These take precedence over `-C <path>` / `current_dir(...)`,
+/// so a naively-spawned `git` ends up operating on the *outer* repo
+/// regardless of how the caller pinned the working directory. In the worst
+/// case that means writing commits onto the developer's checked-out branch
+/// or unregistering real worktrees from the bare repo (issue #13).
+///
+/// Strip the repo-selection variables here so every `git` we spawn really
+/// does target the repo the caller asked for.
+pub(crate) fn git_command() -> Command {
+    let mut cmd = Command::new("git");
+    for var in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_COMMON_DIR",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_NAMESPACE",
+        "GIT_PREFIX",
+    ] {
+        cmd.env_remove(var);
+    }
+    cmd
+}
+
 /// Minimal seam over `git worktree list --porcelain`. Implementors must be
 /// `Send + Sync` so we can stash one in `Arc<dyn GitRunner>` on the
 /// `AppContext` and share it across worker threads.
@@ -79,7 +110,7 @@ impl GitRunner for RealGitRunner {
             return Ok(Vec::new());
         }
 
-        let output = match Command::new("git")
+        let output = match git_command()
             .current_dir(repo_root)
             .arg("-C")
             .arg(repo_root)
@@ -119,7 +150,7 @@ impl GitRunner for RealGitRunner {
         if !path.is_dir() {
             return Ok(None);
         }
-        let output = match Command::new("git")
+        let output = match git_command()
             .current_dir(path)
             .arg("-C")
             .arg(path)
@@ -159,7 +190,7 @@ impl GitRunner for RealGitRunner {
         if !repo_root.is_dir() {
             return Err(Error::WorktreeMissing(repo_root.to_path_buf()));
         }
-        let output = Command::new("git")
+        let output = git_command()
             .current_dir(repo_root)
             .arg("-C")
             .arg(repo_root)
@@ -380,12 +411,46 @@ locked migrating to slow disk
         assert!(out.is_empty());
     }
 
+    /// Build a `Command` with both repo-selection *and* identity/config
+    /// `GIT_*` variables stripped. Tests get a stricter scrub than production
+    /// because hostile env (set by an outer `git push` invoking the husky
+    /// pre-push hook) can otherwise reroute commits, override the repo, or
+    /// spoof committer identity in ways that pollute the developer's real
+    /// checkout (issue #13).
+    fn clean_test_git_command() -> Command {
+        let mut cmd = git_command();
+        // Identity vars: keep test commits authored by the local
+        // `git config user.{name,email}` we set, regardless of any
+        // GIT_AUTHOR_* / GIT_COMMITTER_* the parent process exported.
+        for var in [
+            "GIT_AUTHOR_NAME",
+            "GIT_AUTHOR_EMAIL",
+            "GIT_AUTHOR_DATE",
+            "GIT_COMMITTER_NAME",
+            "GIT_COMMITTER_EMAIL",
+            "GIT_COMMITTER_DATE",
+        ] {
+            cmd.env_remove(var);
+        }
+        // `git -c k=v` style env-driven config (`GIT_CONFIG_COUNT` +
+        // `GIT_CONFIG_KEY_<n>`/`GIT_CONFIG_VALUE_<n>`) can change behavior
+        // in subtle ways. Iterate the inherited env to drop the dynamic
+        // numbered keys too.
+        for (k, _) in std::env::vars_os() {
+            if let Some(s) = k.to_str() {
+                if s.starts_with("GIT_CONFIG_") {
+                    cmd.env_remove(&k);
+                }
+            }
+        }
+        cmd
+    }
+
     /// Initialise a fresh git repo in `dir`, with a single committed file so
     /// `worktree add -b` succeeds (it requires HEAD to point at a commit).
     fn init_git_repo(dir: &Path) {
-        use std::process::Command;
         let run = |args: &[&str]| {
-            let s = Command::new("git")
+            let s = clean_test_git_command()
                 // Pin process CWD to the tempdir as well as `-C`. On Windows,
                 // `git worktree add` resolves the new worktree's relative
                 // path *and* picks the repo to register against using the
@@ -443,11 +508,21 @@ locked migrating to slow disk
 
     impl Drop for WorktreeCleanup {
         fn drop(&mut self) {
-            use std::process::Command;
+            // Restrict every removal to paths under the tempdir. With the
+            // `GIT_*` env strip in `clean_test_git_command` this is now
+            // belt-and-braces, but the predicate is the load-bearing
+            // invariant: even if env-strip is ever bypassed, we MUST NOT
+            // delete a worktree that doesn't belong to our tempdir.
+            let canon_temp =
+                dunce::canonicalize(&self.repo_root).unwrap_or_else(|_| self.repo_root.clone());
+            let inside_temp = |p: &Path| -> bool {
+                let cp = dunce::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+                cp.starts_with(&canon_temp)
+            };
 
-            // Helper: in-repo cleanup of any linked worktrees.
+            // Helper: in-repo cleanup of any linked worktrees matching `predicate`.
             let scrub = |repo: &Path, predicate: &dyn Fn(&Path) -> bool| {
-                let Ok(out) = Command::new("git")
+                let Ok(out) = clean_test_git_command()
                     .current_dir(repo)
                     .arg("-C")
                     .arg(repo)
@@ -471,7 +546,7 @@ locked migrating to slow disk
                     // failure — Drop must not panic.
                     let mut ok = false;
                     for _ in 0..2 {
-                        let st = Command::new("git")
+                        let st = clean_test_git_command()
                             .current_dir(repo)
                             .arg("-C")
                             .arg(repo)
@@ -492,7 +567,7 @@ locked migrating to slow disk
                         );
                     }
                 }
-                let _ = Command::new("git")
+                let _ = clean_test_git_command()
                     .current_dir(repo)
                     .arg("-C")
                     .arg(repo)
@@ -501,19 +576,16 @@ locked migrating to slow disk
             };
 
             // 1. Clean every linked worktree registered in the tempdir repo.
-            scrub(&self.repo_root, &|_| true);
+            //    Constrain to paths inside the tempdir as well — see comment
+            //    above on `inside_temp`.
+            scrub(&self.repo_root, &inside_temp);
 
             // 2. Belt-and-braces: if the test process's CWD is inside another
             //    git repo, scrub any worktree there whose path lies under our
             //    tempdir. This is the safety net for the historical
-            //    outer-repo-pollution bug.
+            //    outer-repo-pollution bug (issue #13).
             if let Ok(cwd) = std::env::current_dir() {
-                let canon_temp =
-                    dunce::canonicalize(&self.repo_root).unwrap_or_else(|_| self.repo_root.clone());
-                scrub(&cwd, &|p| {
-                    let cp = dunce::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
-                    cp.starts_with(&canon_temp)
-                });
+                scrub(&cwd, &inside_temp);
             }
         }
     }
@@ -597,5 +669,72 @@ locked migrating to slow disk
             )
             .expect_err("must error");
         assert!(matches!(err, Error::WorktreeMissing(_)), "got {err:?}");
+    }
+
+    /// Regression for issue #13: every `git` we spawn must drop the
+    /// repo-selection env vars so a hostile parent (e.g. husky pre-push)
+    /// cannot reroute commits or worktree-add calls onto the developer's
+    /// real checkout.
+    #[test]
+    fn git_command_strips_repo_selection_env_vars() {
+        let cmd = git_command();
+        let removed: Vec<String> = cmd
+            .get_envs()
+            .filter_map(|(k, v)| {
+                if v.is_none() {
+                    Some(k.to_string_lossy().into_owned())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for var in [
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_INDEX_FILE",
+            "GIT_COMMON_DIR",
+            "GIT_OBJECT_DIRECTORY",
+            "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+            "GIT_NAMESPACE",
+            "GIT_PREFIX",
+        ] {
+            assert!(
+                removed.iter().any(|r| r == var),
+                "git_command() must remove {var}; got {removed:?}"
+            );
+        }
+    }
+
+    /// The test-only helper additionally strips identity and config-injection
+    /// vars so commits land with the deterministic `git config user.*` we set
+    /// in `init_git_repo`, regardless of any `GIT_AUTHOR_*` / `GIT_CONFIG_*`
+    /// the parent process exported.
+    #[test]
+    fn clean_test_git_command_strips_identity_and_config_env() {
+        let cmd = clean_test_git_command();
+        let removed: Vec<String> = cmd
+            .get_envs()
+            .filter_map(|(k, v)| {
+                if v.is_none() {
+                    Some(k.to_string_lossy().into_owned())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for var in [
+            "GIT_DIR",
+            "GIT_AUTHOR_NAME",
+            "GIT_AUTHOR_EMAIL",
+            "GIT_AUTHOR_DATE",
+            "GIT_COMMITTER_NAME",
+            "GIT_COMMITTER_EMAIL",
+            "GIT_COMMITTER_DATE",
+        ] {
+            assert!(
+                removed.iter().any(|r| r == var),
+                "clean_test_git_command() must remove {var}; got {removed:?}"
+            );
+        }
     }
 }

--- a/src-tauri/tests/pty_pool.rs
+++ b/src-tauri/tests/pty_pool.rs
@@ -143,9 +143,18 @@ fn rt() -> tokio::runtime::Runtime {
 
 // ---------------------------------------------------------------------------
 // Real-spawner end-to-end tests
+//
+// Every test in this section drives a real ConPTY/portable-pty child. Spawning
+// many ConPTY consoles in parallel is contended on Windows: under load (e.g.
+// the husky pre-push hook running `npm test` and `cargo test --workspace`
+// concurrently with linker work), the initial banner from the test child can
+// stall well past the per-test 5s budget, causing intermittent
+// `banner not seen` failures. Force these tests to run serially so they only
+// ever compete with one PTY at a time.
 // ---------------------------------------------------------------------------
 
 #[test]
+#[serial_test::serial(real_pty)]
 fn spawn_banner_then_quit_yields_exited_status() {
     let dir = tempfile::tempdir().unwrap();
     let session = make_session(dir.path());
@@ -187,6 +196,7 @@ fn spawn_banner_then_quit_yields_exited_status() {
 }
 
 #[test]
+#[serial_test::serial(real_pty)]
 fn echoes_input_back_through_sink() {
     let dir = tempfile::tempdir().unwrap();
     let session = make_session(dir.path());
@@ -207,6 +217,7 @@ fn echoes_input_back_through_sink() {
 }
 
 #[test]
+#[serial_test::serial(real_pty)]
 fn resize_calls_do_not_disrupt_io() {
     let dir = tempfile::tempdir().unwrap();
     let session = make_session(dir.path());
@@ -230,6 +241,7 @@ fn resize_calls_do_not_disrupt_io() {
 }
 
 #[test]
+#[serial_test::serial(real_pty)]
 fn nonzero_exit_yields_error_status() {
     let dir = tempfile::tempdir().unwrap();
     let session = make_session(dir.path());
@@ -255,6 +267,7 @@ fn nonzero_exit_yields_error_status() {
 }
 
 #[test]
+#[serial_test::serial(real_pty)]
 fn kill_terminates_child_and_removes_entry_and_temp_dir() {
     let dir = tempfile::tempdir().unwrap();
     let session = make_session(dir.path());
@@ -281,6 +294,7 @@ fn kill_terminates_child_and_removes_entry_and_temp_dir() {
 }
 
 #[test]
+#[serial_test::serial(real_pty)]
 fn respawn_existing_yields_a_new_pid() {
     let dir = tempfile::tempdir().unwrap();
     let session = make_session(dir.path());


### PR DESCRIPTION
Fixes #13.

## Root cause

When `cargo test` runs as a child of `git push` (the husky pre-push hook), git exports `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_COMMON_DIR`, `GIT_OBJECT_DIRECTORY`, etc. into the child environment. These take precedence over `-C <path>` and `current_dir(...)`, so every `git` subprocess our tests spawn ends up operating on the *outer* repo regardless of how the caller pinned the working directory. Concretely:

1. `init_git_repo`'s `git add README && git commit` landed real commits on the developer's checked-out branch (with author `Arborist Test <test@arborist.local>`).
2. `WorktreeCleanup::drop` ran `git worktree list` against the outer bare repo, saw the developer's real worktrees, and silently unregistered them via `git worktree remove --force`.
3. The `RealGitRunner` methods themselves operated on the outer repo.

## Fix

- New `git_command()` helper in `src-tauri/src/git.rs` strips repo-selection vars (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_COMMON_DIR`, `GIT_OBJECT_DIRECTORY`, `GIT_ALTERNATE_OBJECT_DIRECTORIES`, `GIT_NAMESPACE`, `GIT_PREFIX`); used by every `RealGitRunner` spawn.
- Test-only `clean_test_git_command()` additionally strips `GIT_AUTHOR_*`, `GIT_COMMITTER_*`, and dynamic `GIT_CONFIG_*` vars; used by `init_git_repo` and `WorktreeCleanup`.
- `WorktreeCleanup` now restricts **both** scrub passes (in-tempdir and outer-cwd) to paths under the tempdir as a load-bearing safety net, even if env-strip is ever bypassed in the future.
- Mirror the env-strip in `src-tauri/build.rs` so branch detection isn't fooled by the outer repo under the same hook.
- Defense-in-depth: `.husky/pre-push` `unset`s the same vars before invoking `npm test` / `cargo test`.
- Two new regression tests assert `git_command()` / `clean_test_git_command()` actually strip the documented vars.

## Drive-by

Serialized the 6 `PortablePtySpawner` integration tests in `tests/pty_pool.rs` with `#[serial_test::serial(real_pty)]`. Under load (e.g. the pre-push hook running `npm test` and `cargo test --workspace` concurrently with linker work) ConPTY console contention can stall the test child's banner past the 5s budget, producing intermittent `banner not seen` failures. Stress-tested 5x cleanly after the fix; also passed when run concurrently with `npm test`.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml`: 209 + 15 + everything else, all green
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- `npm test -- --run`: 205 passed
- `npm run lint`: clean
- This very push is the empirical test: the pre-push hook ran the full suite from inside the polluted env that triggered the bug, and produced no warnings about removing real worktrees.