### PR TITLE
fix(terminal): refit + repaint on tab activation to recover stale layout/focus

### DIFF
--- a/src/components/TerminalView.test.tsx
+++ b/src/components/TerminalView.test.tsx
@@ -88,9 +88,14 @@ describe('TerminalView', () => {
     expect(mockTerminals[0]!.dispose).not.toHaveBeenCalled();
   });
 
-  it('focuses the terminal when active', () => {
+  it('focuses the terminal when active (after rAF refit+focus)', async () => {
     seedSession();
     render(<TerminalView sessionId="s1" isActive={true} />);
+    // Activation refit+focus runs in requestAnimationFrame so the
+    // visibility:visible style has time to apply before measuring.
+    await act(async () => {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    });
     expect(mockTerminals[0]!.focus).toHaveBeenCalled();
   });
 

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -28,7 +28,7 @@ export function TerminalView({ sessionId, isActive }: TerminalViewProps): JSX.El
   const containerRef = useRef<HTMLDivElement | null>(null);
   const session = useSessionById(sessionId);
   const statusMessage = useStatusMessage(sessionId);
-  const { attach, detach, focus } = useTerminal(sessionId);
+  const { attach, detach, focus, refit } = useTerminal(sessionId);
 
   useEffect(() => {
     const el = containerRef.current;
@@ -39,10 +39,22 @@ export function TerminalView({ sessionId, isActive }: TerminalViewProps): JSX.El
     };
   }, [attach, detach]);
 
-  // Steal focus to the terminal whenever this view becomes the active tab.
+  // When this view becomes the active tab, the host's CSS box doesn't
+  // change size (we hide inactive panels with `visibility: hidden`, which
+  // preserves layout) — so ResizeObserver wouldn't fire. Re-measure and
+  // repaint the renderer here to recover from any stale state, then steal
+  // focus. rAF ensures the visibility:visible style has been applied
+  // before we measure / focus the textarea (visibility:hidden elements
+  // are unfocusable). The cleanup cancels the frame so a rapid tab
+  // switch can't focus a now-inactive terminal.
   useEffect(() => {
-    if (isActive) focus();
-  }, [isActive, focus]);
+    if (!isActive) return;
+    const handle = requestAnimationFrame(() => {
+      refit();
+      focus();
+    });
+    return () => cancelAnimationFrame(handle);
+  }, [isActive, refit, focus]);
 
   const status = session?.status;
   const showOverlay = status === 'error' || status === 'exited';

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -234,4 +234,44 @@ describe('useTerminal', () => {
     expect(mockFitAddons[0]!.fit).not.toHaveBeenCalled();
     expect(sessionResize).not.toHaveBeenCalled();
   });
+
+  it('refit() does not cancel a pending debounced fit when fit() throws', () => {
+    let captured: ResizeObserverCallback | null = null;
+    class FakeRO {
+      constructor(cb: ResizeObserverCallback) {
+        captured = cb;
+      }
+      observe = vi.fn();
+      disconnect = vi.fn();
+      unobserve = vi.fn();
+    }
+    (globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+      FakeRO as unknown as typeof ResizeObserver;
+
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+    // Initial sync fit consumed (1 call). Now arrange for the next fit
+    // (debounced via the observer) to be in flight.
+    mockFitAddons[0]!.fit.mockClear();
+
+    act(() => {
+      captured!([], {} as ResizeObserver);
+    });
+    // Timer is pending; fit not yet called.
+    expect(mockFitAddons[0]!.fit).not.toHaveBeenCalled();
+
+    // Make the next fit() throw — simulates an ancestor going display:none
+    // mid-debounce so the host is now zero-size.
+    mockFitAddons[0]!.fit.mockImplementationOnce(() => {
+      throw new Error('zero size');
+    });
+    act(() => result.current.refit());
+    // refit threw; the pending debounce should NOT have been cancelled.
+    expect(mockFitAddons[0]!.fit).toHaveBeenCalledTimes(1);
+
+    // Advance past the debounce window — the original pending fit fires.
+    act(() => vi.advanceTimersByTime(60));
+    expect(mockFitAddons[0]!.fit).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -12,6 +12,7 @@ const mockTerminals: Array<{
   focus: ReturnType<typeof vi.fn>;
   dispose: ReturnType<typeof vi.fn>;
   loadAddon: ReturnType<typeof vi.fn>;
+  refresh: ReturnType<typeof vi.fn>;
   cols: number;
   rows: number;
   _dataCb?: (data: string) => void;
@@ -26,6 +27,7 @@ vi.mock('@xterm/xterm', () => {
       focus: vi.fn(),
       dispose: vi.fn(),
       loadAddon: vi.fn(),
+      refresh: vi.fn(),
       cols: 80,
       rows: 24,
     };
@@ -72,17 +74,31 @@ function makeHost(width = 600, height = 400): HTMLDivElement {
   return el;
 }
 
+let originalResizeObserver: typeof ResizeObserver | undefined;
+
 beforeEach(() => {
   vi.useFakeTimers();
   resetBridgeMocks();
   mockTerminals.length = 0;
   mockFitAddons.length = 0;
+  originalResizeObserver = (globalThis as unknown as { ResizeObserver?: typeof ResizeObserver })
+    .ResizeObserver;
 });
 
 afterEach(() => {
   __resetTerminalRegistryForTests();
   document.body.innerHTML = '';
   vi.useRealTimers();
+  // Restore (or delete) ResizeObserver — several tests in this file
+  // overwrite globalThis.ResizeObserver with a fake to capture the
+  // callback. Without this, the fake leaks into later tests/files and
+  // creates order-dependent behavior.
+  if (originalResizeObserver === undefined) {
+    delete (globalThis as unknown as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver;
+  } else {
+    (globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+      originalResizeObserver;
+  }
 });
 
 describe('useTerminal', () => {
@@ -210,20 +226,28 @@ describe('useTerminal', () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
-    // Attach already fit once and emitted one resize (0,0 → 80,24).
+    // Attach already fit once and emitted one resize (0,0 → 80,24), and
+    // refreshed the renderer once (rows=24, so refresh(0, 23)).
     expect(mockFitAddons[0]!.fit).toHaveBeenCalledTimes(1);
     expect(sessionResize).toHaveBeenCalledTimes(1);
+    expect(mockTerminals[0]!.refresh).toHaveBeenCalledTimes(1);
+    expect(mockTerminals[0]!.refresh).toHaveBeenLastCalledWith(0, 23);
 
-    // Same dims → fit runs (forces internal recompute) but no extra resize.
+    // Same dims → fit + refresh both run (forces internal recompute and
+    // viewport repaint) but no extra sessionResize.
     act(() => result.current.refit());
     expect(mockFitAddons[0]!.fit).toHaveBeenCalledTimes(2);
+    expect(mockTerminals[0]!.refresh).toHaveBeenCalledTimes(2);
     expect(sessionResize).toHaveBeenCalledTimes(1);
 
-    // Change reported dims → refit emits a new sessionResize.
+    // Change reported dims → refit emits a new sessionResize and repaints
+    // against the new row count.
     mockTerminals[0]!.cols = 100;
     mockTerminals[0]!.rows = 30;
     act(() => result.current.refit());
     expect(mockFitAddons[0]!.fit).toHaveBeenCalledTimes(3);
+    expect(mockTerminals[0]!.refresh).toHaveBeenCalledTimes(3);
+    expect(mockTerminals[0]!.refresh).toHaveBeenLastCalledWith(0, 29);
     expect(sessionResize).toHaveBeenCalledTimes(2);
     expect(sessionResize).toHaveBeenLastCalledWith({ sessionId: 's1', cols: 100, rows: 30 });
   });
@@ -232,6 +256,7 @@ describe('useTerminal', () => {
     const { result } = renderHook(() => useTerminal('s1'));
     expect(() => act(() => result.current.refit())).not.toThrow();
     expect(mockFitAddons[0]!.fit).not.toHaveBeenCalled();
+    expect(mockTerminals[0]!.refresh).not.toHaveBeenCalled();
     expect(sessionResize).not.toHaveBeenCalled();
   });
 

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -156,7 +156,7 @@ describe('useTerminal', () => {
     expect(mockFitAddons[0]!.dispose).toHaveBeenCalled();
   });
 
-  it('debounced ResizeObserver triggers fit + sessionResize once', () => {
+  it('fits synchronously on attach and once more after debounced ResizeObserver', () => {
     // Polyfill ResizeObserver capturing the callback.
     let captured: ResizeObserverCallback | null = null;
     const observe = vi.fn();
@@ -176,7 +176,15 @@ describe('useTerminal', () => {
     const host = makeHost();
     act(() => result.current.attach(host));
 
-    // Fire several rapid resizes; only one debounced call should fire.
+    // Initial synchronous fit happens during attach so the renderer is in
+    // a known state immediately, without waiting for the observer's first
+    // tick (which races with font loading).
+    expect(mockFitAddons[0]!.fit).toHaveBeenCalledTimes(1);
+    // First sessionResize fires because lastCols/lastRows defaulted to 0.
+    expect(sessionResize).toHaveBeenCalledTimes(1);
+    expect(sessionResize).toHaveBeenCalledWith({ sessionId: 's1', cols: 80, rows: 24 });
+
+    // Fire several rapid observer ticks; only one debounced fit follows.
     act(() => {
       captured!([], {} as ResizeObserver);
       captured!([], {} as ResizeObserver);
@@ -186,9 +194,9 @@ describe('useTerminal', () => {
       vi.advanceTimersByTime(60);
     });
 
-    expect(mockFitAddons[0]!.fit).toHaveBeenCalledTimes(1);
+    expect(mockFitAddons[0]!.fit).toHaveBeenCalledTimes(2);
+    // Dimensions unchanged → no second sessionResize emission.
     expect(sessionResize).toHaveBeenCalledTimes(1);
-    expect(sessionResize).toHaveBeenCalledWith({ sessionId: 's1', cols: 80, rows: 24 });
   });
 
   it('initTerminalRouter is idempotent: calling twice does not double-subscribe', () => {
@@ -196,5 +204,34 @@ describe('useTerminal', () => {
     initTerminalRouter();
     initTerminalRouter();
     expect(onSessionOutput).toHaveBeenCalledTimes(1);
+  });
+
+  it('refit() runs fit + refresh and emits sessionResize only when dims change', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+    // Attach already fit once and emitted one resize (0,0 → 80,24).
+    expect(mockFitAddons[0]!.fit).toHaveBeenCalledTimes(1);
+    expect(sessionResize).toHaveBeenCalledTimes(1);
+
+    // Same dims → fit runs (forces internal recompute) but no extra resize.
+    act(() => result.current.refit());
+    expect(mockFitAddons[0]!.fit).toHaveBeenCalledTimes(2);
+    expect(sessionResize).toHaveBeenCalledTimes(1);
+
+    // Change reported dims → refit emits a new sessionResize.
+    mockTerminals[0]!.cols = 100;
+    mockTerminals[0]!.rows = 30;
+    act(() => result.current.refit());
+    expect(mockFitAddons[0]!.fit).toHaveBeenCalledTimes(3);
+    expect(sessionResize).toHaveBeenCalledTimes(2);
+    expect(sessionResize).toHaveBeenLastCalledWith({ sessionId: 's1', cols: 100, rows: 30 });
+  });
+
+  it('refit() is a no-op when the terminal is not attached', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    expect(() => act(() => result.current.refit())).not.toThrow();
+    expect(mockFitAddons[0]!.fit).not.toHaveBeenCalled();
+    expect(sessionResize).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -188,19 +188,26 @@ function teardownObserver(entry: RegistryEntry): void {
  * pre-font-load initial measurement.
  */
 function refitEntry(sessionId: SessionId, entry: RegistryEntry): void {
-  // Cancel any debounced fire so we don't double-fit moments later.
-  if (entry.resizeTimer !== null) {
-    clearTimeout(entry.resizeTimer);
-    entry.resizeTimer = null;
-  }
   if (!entry.wrapper || !entry.wrapper.isConnected) return;
   try {
     entry.fitAddon.fit();
   } catch {
-    // fit() throws on zero-size hosts. Skip — a later refit / observer
-    // tick will retry once the host is sized.
+    // fit() throws on zero-size hosts (e.g. an ancestor is display:none).
+    // Bail without clearing any pending debounced fit — that fit was
+    // queued for a reason (a real ResizeObserver tick) and may still be
+    // wanted once the host is sized again. The next observer tick when
+    // the host gains a non-zero rect will also reschedule.
     return;
   }
+
+  // Successful fit — we own the freshly-measured state, so any pending
+  // debounced fit is now redundant. Clear it before any further bail-outs
+  // so the invariant "successful fit ⇒ no stale debounce" always holds.
+  if (entry.resizeTimer !== null) {
+    clearTimeout(entry.resizeTimer);
+    entry.resizeTimer = null;
+  }
+
   const cols = entry.term.cols;
   const rows = entry.term.rows;
   if (cols <= 0 || rows <= 0) return;

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -20,6 +20,12 @@
 // * `ResizeObserver` is debounced ~50 ms, then drives `fitAddon.fit()` →
 //   `session_resize`. The observer is owned per-attachment (i.e. lives until
 //   `detach()`); the terminal itself outlives it.
+// * `refit()` is exposed so callers can imperatively re-measure + repaint the
+//   terminal — used on tab activation (the host doesn't change size on tab
+//   switch, so ResizeObserver wouldn't otherwise fire) and after web fonts
+//   resolve. It runs `fit()` + `term.refresh()` to recover from any stale
+//   renderer state (e.g. measurements taken pre-font-load or while the
+//   panel was `visibility: hidden`).
 
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
@@ -50,6 +56,7 @@ const registry = new Map<SessionId, RegistryEntry>();
 
 let outputUnlisten: Promise<() => void> | null = null;
 let storeUnsubscribe: (() => void) | null = null;
+let fontsReadyAttached = false;
 
 function ensureGlobalSubscriptions(): void {
   if (outputUnlisten === null) {
@@ -83,6 +90,32 @@ function ensureGlobalSubscriptions(): void {
       }
       previousIds = currentIds;
     });
+  }
+
+  // Best-effort: once web fonts have settled, refit every attached terminal.
+  // Initial fits taken before the monospace font fully loaded can produce
+  // wrong cell metrics, leaving the renderer "squished" until the next
+  // window resize. Guarded — the FontFaceSet API isn't available in older
+  // WebViews and may not exist in jsdom.
+  if (
+    !fontsReadyAttached &&
+    typeof document !== 'undefined' &&
+    'fonts' in document &&
+    document.fonts &&
+    typeof document.fonts.ready === 'object'
+  ) {
+    fontsReadyAttached = true;
+    void document.fonts.ready
+      .then(() => {
+        for (const [id, entry] of registry) {
+          if (entry.wrapper && entry.wrapper.isConnected) {
+            refitEntry(id, entry);
+          }
+        }
+      })
+      .catch(() => {
+        // ignore — refit is best-effort
+      });
   }
 }
 
@@ -146,6 +179,52 @@ function teardownObserver(entry: RegistryEntry): void {
   }
 }
 
+/**
+ * Re-measure + repaint a single terminal. Safe to call on an unattached or
+ * zero-size terminal (no-ops). Only emits `sessionResize` when cols/rows
+ * have actually changed since the last successful fit. Always calls
+ * `term.refresh()` when the renderer has a non-zero viewport — this is the
+ * recovery path for stale canvas state after a visibility transition or a
+ * pre-font-load initial measurement.
+ */
+function refitEntry(sessionId: SessionId, entry: RegistryEntry): void {
+  // Cancel any debounced fire so we don't double-fit moments later.
+  if (entry.resizeTimer !== null) {
+    clearTimeout(entry.resizeTimer);
+    entry.resizeTimer = null;
+  }
+  if (!entry.wrapper || !entry.wrapper.isConnected) return;
+  try {
+    entry.fitAddon.fit();
+  } catch {
+    // fit() throws on zero-size hosts. Skip — a later refit / observer
+    // tick will retry once the host is sized.
+    return;
+  }
+  const cols = entry.term.cols;
+  const rows = entry.term.rows;
+  if (cols <= 0 || rows <= 0) return;
+
+  // Force the renderer to repaint the visible viewport. xterm's canvas
+  // renderer can hold stale state when the element transitioned from
+  // visibility:hidden → visible, or when fit() computed the same dims as
+  // last time and skipped the implicit refresh. `refresh()` is bounded
+  // (viewport only, not scrollback) so this is cheap.
+  try {
+    entry.term.refresh(0, rows - 1);
+  } catch {
+    // Ignore — xterm versions without refresh() are extremely old.
+  }
+
+  if (cols === entry.lastCols && rows === entry.lastRows) return;
+  entry.lastCols = cols;
+  entry.lastRows = rows;
+  void sessionResize({ sessionId, cols, rows }).catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[use-terminal] session_resize(${sessionId}) failed: ${message}`);
+  });
+}
+
 function attachToHost(sessionId: SessionId, entry: RegistryEntry, host: HTMLDivElement): void {
   if (entry.host === host && entry.wrapper && entry.wrapper.isConnected) {
     return;
@@ -170,40 +249,18 @@ function attachToHost(sessionId: SessionId, entry: RegistryEntry, host: HTMLDivE
     entry.term.open(wrapper);
   }
 
-  const fire = (): void => {
-    entry.resizeTimer = null;
-    try {
-      entry.fitAddon.fit();
-    } catch {
-      // fit() throws if the wrapper has zero dimensions (e.g. while the
-      // host is `display: none`). Silently skip — the next observer tick
-      // will retry once the host is sized.
-      return;
-    }
-    const cols = entry.term.cols;
-    const rows = entry.term.rows;
-    if (cols <= 0 || rows <= 0) return;
-    if (cols === entry.lastCols && rows === entry.lastRows) return;
-    entry.lastCols = cols;
-    entry.lastRows = rows;
-    void sessionResize({ sessionId, cols, rows }).catch((err: unknown) => {
-      const message = err instanceof Error ? err.message : String(err);
-      console.warn(`[use-terminal] session_resize(${sessionId}) failed: ${message}`);
-    });
-  };
+  // Synchronous initial fit — don't rely on ResizeObserver's first tick
+  // (which races with font loading and can leave the renderer in a stale
+  // state if it fires too early).
+  refitEntry(sessionId, entry);
 
   if (typeof ResizeObserver !== 'undefined') {
     const observer = new ResizeObserver(() => {
       if (entry.resizeTimer !== null) clearTimeout(entry.resizeTimer);
-      entry.resizeTimer = setTimeout(fire, RESIZE_DEBOUNCE_MS);
+      entry.resizeTimer = setTimeout(() => refitEntry(sessionId, entry), RESIZE_DEBOUNCE_MS);
     });
     observer.observe(host);
     entry.observer = observer;
-  } else {
-    // Fallback for jsdom and other no-ResizeObserver environments: fire
-    // once synchronously so tests can still drive the resize path via
-    // container dimension setters.
-    fire();
   }
 }
 
@@ -221,6 +278,14 @@ export interface UseTerminalApi {
   attach: (el: HTMLDivElement) => void;
   detach: () => void;
   focus: () => void;
+  /**
+   * Imperatively re-measure + repaint the terminal. Use after a parent
+   * visibility transition (e.g. tab activation) — the host's CSS box
+   * doesn't change size on `visibility: hidden` ↔ `visible`, so
+   * ResizeObserver wouldn't fire on its own. No-op if the terminal isn't
+   * attached or has zero dimensions.
+   */
+  refit: () => void;
 }
 
 export function useTerminal(sessionId: SessionId): UseTerminalApi {
@@ -246,13 +311,20 @@ export function useTerminal(sessionId: SessionId): UseTerminalApi {
     entry?.term.focus();
   }, []);
 
+  const refit = useCallback(() => {
+    const id = sessionIdRef.current;
+    const entry = registry.get(id);
+    if (!entry) return;
+    refitEntry(id, entry);
+  }, []);
+
   // Eagerly create the terminal so `session://output` events are buffered
   // by xterm even before `attach` runs.
   useEffect(() => {
     getOrCreate(sessionId);
   }, [sessionId]);
 
-  return useMemo(() => ({ attach, detach, focus }), [attach, detach, focus]);
+  return useMemo(() => ({ attach, detach, focus, refit }), [attach, detach, focus, refit]);
 }
 
 export function disposeTerminal(sessionId: SessionId): void {
@@ -305,6 +377,7 @@ export function __resetTerminalRegistryForTests(): void {
     }
     storeUnsubscribe = null;
   }
+  fontsReadyAttached = false;
 }
 
 /** Test-only: peek at the registry. */


### PR DESCRIPTION
## Symptoms

Reported by user: "Sometimes on selecting a session tab the layout of the terminal is messed up. Other times the typing can't be focused. Both issues only resolve when resizing the window."

## Root cause

`ResizeObserver` was the only thing that drove `fit()` + `sessionResize` after the initial `attach`, but:

- The host's CSS box doesn't change size when an inactive panel (`visibility: hidden`) becomes active, so no recovery happened on tab switch.
- The very first fit raced against font loading, occasionally leaving cell metrics off — the renderer then ran with bogus cols/rows until the next window resize.
- A broken renderer also produces a mispositioned/zero-size helper textarea, which manifests as `can't focus`.

## Fix

- Extract a shared `refitEntry()` helper that fits, calls `term.refresh(0, rows-1)` to repaint the viewport, and emits `sessionResize` only when cols/rows actually changed.
- Run a synchronous initial fit during `attach` so we don't depend on ResizeObserver's first tick.
- Expose `refit()` from `useTerminal` and call it (followed by `focus()`) from `TerminalView` via `requestAnimationFrame` whenever `isActive` flips true. The rAF lets `visibility: visible` apply before measurement/focus (`visibility: hidden` elements are unfocusable). The frame is cancelled in cleanup so a rapid tab switch can't focus a now-inactive terminal.
- On `document.fonts.ready`, refit every attached terminal once. Best-effort, guarded for WebViews without FontFaceSet.

## Tests

- Updated existing observer test to cover the new synchronous-attach fit + the post-debounce fit (with the `lastCols/lastRows` guard suppressing duplicate `sessionResize`).
- Updated the focus-on-active test to await the rAF.
- Added refit tests: same-dim refit calls fit+refresh but doesn't re-emit resize; changed-dim refit emits resize; refit on unattached terminal is a no-op.

Full suite: 207/207 passing. Lint clean.