### PR TITLE
fix(ui): add gutter around terminal so it doesn't butt against sidebar

### DIFF
--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -58,7 +58,7 @@ export function TerminalView({ sessionId, isActive }: TerminalViewProps): JSX.El
     <div
       role="tabpanel"
       aria-label={session ? `Terminal for ${session.label}` : 'Terminal'}
-      className="relative h-full w-full"
+      className="relative h-full w-full bg-black p-2"
     >
       <div ref={containerRef} className="h-full w-full bg-black" />
       {showOverlay && (


### PR DESCRIPTION
The xterm host previously rendered flush against the left edge of the main panel because the sidebar sits immediately beside it. Add `p-2` to the `TerminalView` tabpanel root (the normal-flow ancestor of the xterm host) so the terminal sits inside an even gutter on all four sides.

Padding on `MainArea`'s `<main>` would not have worked: its children are `position: absolute` with `inset-0`, which fill the parent's padding box rather than its content box, so the gutter would have been negated.

## Verification
- `npm run lint` clean
- Affected vitest suites pass (`MainArea`, `TerminalView`)
- xterm `fitAddon` measures the now-padded host's content area, so PTY resize fires with the correct cols/rows on next observer tick