### PR TITLE
Stop Vite HMR reloading on every new worktree

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { fileURLToPath, URL } from 'node:url';
+import { relative, isAbsolute } from 'node:path';
 
 function devPort(): number {
   const raw = process.env.ARBORIST_DEV_PORT;
@@ -10,6 +11,23 @@ function devPort(): number {
   if (!raw || !/^\d+$/.test(raw)) return 1420;
   const n = Number(raw);
   return n >= 1 && n <= 65535 ? n : 1420;
+}
+
+const projectRoot = fileURLToPath(new URL('.', import.meta.url));
+
+// Ignore `.worktrees/` directories that live *inside* the Vite project root
+// without matching `.worktrees` segments in the project root's own absolute
+// path. A naive `'**/.worktrees/**'` glob is unsafe here: when the dev server
+// is itself launched from a linked worktree (e.g. `<repo>/.worktrees/foo/`),
+// every absolute file path contains `.worktrees` as an ancestor segment, so
+// chokidar would ignore the entire source tree and silently break HMR.
+function ignoreNestedWorktrees(file: string): boolean {
+  const rel = relative(projectRoot, file);
+  if (!rel || rel.startsWith('..') || isAbsolute(rel)) return false;
+  // Split on either separator: `path.relative` uses the platform separator
+  // (`\` on Windows, `/` on POSIX), but chokidar can hand us paths with
+  // forward slashes on Windows too — handle both.
+  return rel.split(/[\\/]/).includes('.worktrees');
 }
 
 // https://vitejs.dev/config/
@@ -24,6 +42,14 @@ export default defineConfig({
   server: {
     port: devPort(),
     strictPort: true,
+    watch: {
+      // Arborist creates linked git worktrees under `<workspaceRoot>/.worktrees/<name>/`.
+      // When the workspace root is the Vite project root, each new worktree
+      // dumps thousands of files into chokidar's tree and triggers a full HMR
+      // reload. See `ignoreNestedWorktrees` for why this is path-anchored
+      // rather than a `**/.worktrees/**` glob.
+      ignored: [ignoreNestedWorktrees],
+    },
   },
   envPrefix: ['VITE_', 'TAURI_'],
   build: {


### PR DESCRIPTION
Arborist creates linked git worktrees under `<workspaceRoot>/.worktrees/<name>/`. When the workspace root is (or is inside) the Vite project root, each `git worktree add` dumps thousands of files into chokidar's watch tree and triggers a full HMR reload, blanking any in-progress dev session.

## Fix

Add `server.watch.ignored` with an **anchored function** that ignores `.worktrees/` directories under the project root only.

## Why not `'**/.worktrees/**'`

A naive glob would have been a regression: the dev server itself usually runs from a linked worktree (e.g. `<repo>/.worktrees/feature/`), so every absolute source path contains `.worktrees` as an ancestor segment. chokidar would match those globs and silently disable HMR for the entire app. The function form computes the path relative to `projectRoot` first, so only nested `.worktrees` segments are ignored.

## Verification

- `vite build` clean.
- `npm run lint` clean.
- Manual unit check of `ignoreNestedWorktrees` against representative paths (project source, nested worktree, sibling worktree outside root, the project root itself, `node_modules`) — all expected outcomes.