### PR TITLE
feat(session-close): opt-in delete worktree on terminate

### DIFF
--- a/dev/docs/DESIGN.md
+++ b/dev/docs/DESIGN.md
@@ -405,7 +405,7 @@ All commands are gated by Tauri capability declarations in `capabilities/main.js
 |---------|---------|--------|-------------|
 | `session_create` | `{ tool, worktreePath, instructionSetId? }` | `SessionView` | Compose and spawn a new session. `instructionSetId` is optional; when omitted, Claude is launched without `--system-prompt` and the CLI relies on `cwd`-based discovery for repo instructions. |
 | `session_list` | — | `SessionView[]` | Return all current sessions (without composedCommand/tempFiles) |
-| `session_close` | `{ sessionId, deleteWorktree? }` | — | Terminate a session (after UI confirmation). When `deleteWorktree` is `true`, the backend additionally runs `git worktree remove --force <worktreePath>` after killing the PTY. Refuses to remove the configured `workspaceRoot` (main worktree). |
+| `session_close` | `{ sessionId, deleteWorktree? }` | `SessionCloseResult` | Terminate a session (after UI confirmation). When `deleteWorktree` is `true`, the backend additionally runs `git worktree remove --force <worktreePath>` after killing the PTY. Refuses to remove the configured `workspaceRoot` (main worktree), any path outside the workspace root, or a path still referenced by another live session. The session record + PTY are always torn down on success; if the worktree-remove step fails, the message is reported via `worktreeDeleteError` rather than as a hard error. |
 | `session_focus` | `{ sessionId }` | — | Mark session as active |
 | `session_resize` | `{ sessionId, cols, rows }` | — | Resize PTY |
 | `session_input` | `{ sessionId, data }` | — | Send keystrokes to PTY |

--- a/dev/docs/DESIGN.md
+++ b/dev/docs/DESIGN.md
@@ -405,7 +405,7 @@ All commands are gated by Tauri capability declarations in `capabilities/main.js
 |---------|---------|--------|-------------|
 | `session_create` | `{ tool, worktreePath, instructionSetId? }` | `SessionView` | Compose and spawn a new session. `instructionSetId` is optional; when omitted, Claude is launched without `--system-prompt` and the CLI relies on `cwd`-based discovery for repo instructions. |
 | `session_list` | — | `SessionView[]` | Return all current sessions (without composedCommand/tempFiles) |
-| `session_close` | `{ sessionId }` | — | Terminate a session (after UI confirmation) |
+| `session_close` | `{ sessionId, deleteWorktree? }` | — | Terminate a session (after UI confirmation). When `deleteWorktree` is `true`, the backend additionally runs `git worktree remove --force <worktreePath>` after killing the PTY. Refuses to remove the configured `workspaceRoot` (main worktree). |
 | `session_focus` | `{ sessionId }` | — | Mark session as active |
 | `session_resize` | `{ sessionId, cols, rows }` | — | Resize PTY |
 | `session_input` | `{ sessionId, data }` | — | Send keystrokes to PTY |

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -26,10 +26,10 @@ use tauri::{Emitter, Manager};
 
 use crate::config_store::{list_instructions_for, ConfigStore};
 use crate::types::{
-    AppConfig, AppError, InstructionSet, PartialAppConfig, SessionCloseArgs, SessionCreateArgs,
-    SessionId, SessionIdArg, SessionInputArgs, SessionOutputEvent, SessionResizeArgs,
-    SessionStatus, SessionStatusEvent, SessionView, WorkspaceValidateArgs, WorkspaceValidateResult,
-    WorktreeCreateArgs, WorktreeCreateResult,
+    AppConfig, AppError, InstructionSet, PartialAppConfig, SessionCloseArgs, SessionCloseResult,
+    SessionCreateArgs, SessionId, SessionIdArg, SessionInputArgs, SessionOutputEvent,
+    SessionResizeArgs, SessionStatus, SessionStatusEvent, SessionView, WorkspaceValidateArgs,
+    WorkspaceValidateResult, WorktreeCreateArgs, WorktreeCreateResult,
 };
 
 pub use session::AppContext;
@@ -102,7 +102,10 @@ pub async fn session_list(app: tauri::AppHandle) -> Result<Vec<SessionView>, App
 }
 
 #[tauri::command]
-pub async fn session_close(app: tauri::AppHandle, args: SessionCloseArgs) -> Result<(), AppError> {
+pub async fn session_close(
+    app: tauri::AppHandle,
+    args: SessionCloseArgs,
+) -> Result<SessionCloseResult, AppError> {
     let ctx = ctx_of(&app)?;
     session::session_close_impl(&ctx, args.session_id, args.delete_worktree).await
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -26,9 +26,9 @@ use tauri::{Emitter, Manager};
 
 use crate::config_store::{list_instructions_for, ConfigStore};
 use crate::types::{
-    AppConfig, AppError, InstructionSet, PartialAppConfig, SessionCreateArgs, SessionId,
-    SessionIdArg, SessionInputArgs, SessionOutputEvent, SessionResizeArgs, SessionStatus,
-    SessionStatusEvent, SessionView, WorkspaceValidateArgs, WorkspaceValidateResult,
+    AppConfig, AppError, InstructionSet, PartialAppConfig, SessionCloseArgs, SessionCreateArgs,
+    SessionId, SessionIdArg, SessionInputArgs, SessionOutputEvent, SessionResizeArgs,
+    SessionStatus, SessionStatusEvent, SessionView, WorkspaceValidateArgs, WorkspaceValidateResult,
     WorktreeCreateArgs, WorktreeCreateResult,
 };
 
@@ -102,9 +102,9 @@ pub async fn session_list(app: tauri::AppHandle) -> Result<Vec<SessionView>, App
 }
 
 #[tauri::command]
-pub async fn session_close(app: tauri::AppHandle, args: SessionIdArg) -> Result<(), AppError> {
+pub async fn session_close(app: tauri::AppHandle, args: SessionCloseArgs) -> Result<(), AppError> {
     let ctx = ctx_of(&app)?;
-    session::session_close_impl(&ctx, args.session_id).await
+    session::session_close_impl(&ctx, args.session_id, args.delete_worktree).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -250,13 +250,25 @@ pub async fn session_close_impl(
 
     // Capture the worktree path *before* we drop the persisted record —
     // we need it for the optional `git worktree remove` step at the end.
-    let worktree_path: Option<PathBuf> = if delete_worktree {
-        ctx.store
-            .load_sessions()
-            .get(&id)
-            .map(|s| s.worktree_path.clone())
+    // Use a *strict* read here so that a corrupt or unreadable
+    // sessions.json doesn't silently translate "delete the worktree"
+    // into "skip silently and report success". On read failure or
+    // missing-record we surface a `worktree_delete_error` later instead
+    // of attempting deletion.
+    let worktree_intent: WorktreeDeleteIntent = if delete_worktree {
+        match ctx.store.try_load_sessions() {
+            Ok(map) => match map.get(&id) {
+                Some(s) => WorktreeDeleteIntent::Path(s.worktree_path.clone()),
+                None => WorktreeDeleteIntent::Refused(format!(
+                    "session {id} not found in store; cannot determine worktree to delete"
+                )),
+            },
+            Err(e) => WorktreeDeleteIntent::Refused(format!(
+                "could not read sessions snapshot reliably; refusing to attempt worktree deletion: {e}"
+            )),
+        }
     } else {
-        None
+        WorktreeDeleteIntent::None
     };
 
     // 1. Best-effort kill (NotFound from the pool is fine — the session
@@ -305,18 +317,44 @@ pub async fn session_close_impl(
     //    unable to converge on a "tab gone" state). Surface the error in
     //    the result instead.
     let mut result = SessionCloseResult::default();
-    if let Some(wt) = worktree_path {
-        if let Err(error) = delete_worktree_after_close(ctx, &id, &wt, &cfg.workspace_root) {
+    match worktree_intent {
+        WorktreeDeleteIntent::Path(wt) => {
+            if let Err(error) = delete_worktree_after_close(ctx, &id, &wt, &cfg.workspace_root) {
+                warn!(
+                    session_id = %id,
+                    worktree_path = %wt.display(),
+                    error = %error.message,
+                    "worktree deletion failed after session close",
+                );
+                result.worktree_delete_error = Some(error.message);
+            }
+        }
+        WorktreeDeleteIntent::Refused(msg) => {
             warn!(
                 session_id = %id,
-                worktree_path = %wt.display(),
-                error = %error.message,
-                "worktree deletion failed after session close",
+                error = %msg,
+                "worktree deletion was requested but refused before reaching git",
             );
-            result.worktree_delete_error = Some(error.message);
+            result.worktree_delete_error = Some(msg);
         }
+        WorktreeDeleteIntent::None => {}
     }
     Ok(result)
+}
+
+/// What `session_close_impl` decided to do about the optional `delete_worktree`
+/// flag, captured *before* the persisted session record is dropped so the
+/// decision is based on the pre-close state.
+enum WorktreeDeleteIntent {
+    /// Caller did not request a worktree deletion.
+    None,
+    /// Deletion was requested and the worktree path was resolved successfully.
+    Path(PathBuf),
+    /// Deletion was requested but cannot be attempted (e.g. the sessions
+    /// snapshot couldn't be read strictly, or the session record is missing).
+    /// The contained string is reported back to the frontend verbatim as
+    /// `worktree_delete_error` so the user knows why nothing was deleted.
+    Refused(String),
 }
 
 /// Helper: validate and execute `git worktree remove --force`. Refuses to
@@ -379,12 +417,15 @@ fn delete_worktree_after_close(
     // Safety 3: refuse if any *other* live session still references the
     // same worktree. The session being closed has already been removed
     // from the store at this point, so it cannot match itself. If a
-    // foreign session's path fails to canonicalize, we conservatively
-    // treat it as a match (better to refuse than to delete a worktree
-    // that another session may still depend on). The session snapshot
-    // itself must be loaded *strictly* — for a destructive operation, an
-    // unreadable or quarantined sessions.json cannot be silently treated
-    // as "no other sessions exist".
+    // foreign session's path fails to canonicalize we conservatively
+    // treat it as a match — for a destructive operation, an
+    // un-canonicalizable path could refer to the same directory we're
+    // about to delete (a different textual form, dangling junction, or
+    // path made temporarily inaccessible) and we'd rather refuse than
+    // delete a worktree another session may still depend on. The session
+    // snapshot itself must be loaded *strictly* — for a destructive
+    // operation, an unreadable or quarantined sessions.json cannot be
+    // silently treated as "no other sessions exist".
     let sessions = ctx.store.try_load_sessions().map_err(|e| {
         AppError::from(Error::Internal(format!(
             "refusing to delete worktree because the sessions snapshot could not be read reliably: {e}"
@@ -394,7 +435,7 @@ fn delete_worktree_after_close(
         .values()
         .any(|s| match dunce::canonicalize(&s.worktree_path) {
             Ok(other) => other == canon_wt,
-            Err(_) => s.worktree_path == worktree_path,
+            Err(_) => true,
         });
     if still_in_use {
         return Err(AppError::from(Error::Internal(format!(

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -20,7 +20,7 @@
 //! the on-disk session record converges automatically when the production
 //! sink is wired (see [`crate::lib::run`]).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -238,10 +238,25 @@ pub fn session_list_impl(ctx: &AppContext) -> Result<Vec<SessionView>, AppError>
 // session_close
 // ---------------------------------------------------------------------------
 
-pub async fn session_close_impl(ctx: &AppContext, id: SessionId) -> Result<(), AppError> {
+pub async fn session_close_impl(
+    ctx: &AppContext,
+    id: SessionId,
+    delete_worktree: bool,
+) -> Result<(), AppError> {
     // 0. Stop the metrics watcher (Issue #3) before tearing the rest down
     //    so it never observes a half-cleaned session.
     ctx.metrics.stop(&id);
+
+    // Capture the worktree path *before* we drop the persisted record —
+    // we need it for the optional `git worktree remove` step at the end.
+    let worktree_path: Option<PathBuf> = if delete_worktree {
+        ctx.store
+            .load_sessions()
+            .get(&id)
+            .map(|s| s.worktree_path.clone())
+    } else {
+        None
+    };
 
     // 1. Best-effort kill (NotFound from the pool is fine — the session
     //    may have exited on its own already).
@@ -282,6 +297,92 @@ pub async fn session_close_impl(ctx: &AppContext, id: SessionId) -> Result<(), A
             ..Default::default()
         })
         .map_err(AppError::from)?;
+
+    // 5. Optional: remove the git worktree from disk. The session is
+    //    already gone from the store at this point — failing here surfaces
+    //    a toast but does not resurrect the tab. The user explicitly
+    //    opted in via the close-confirm dialog.
+    if let Some(wt) = worktree_path {
+        delete_worktree_after_close(ctx, &id, &wt, &cfg.workspace_root)?;
+    }
+    Ok(())
+}
+
+/// Helper: validate and execute `git worktree remove --force`. Refuses to
+/// touch the configured `workspace_root` itself (i.e. the main checkout),
+/// any path that is not contained under the workspace root, or any path
+/// still claimed by another live session.
+fn delete_worktree_after_close(
+    ctx: &AppContext,
+    id: &SessionId,
+    worktree_path: &Path,
+    workspace_root: &Option<PathBuf>,
+) -> Result<(), AppError> {
+    // Require an explicit workspace root. Without it we have neither a
+    // safe `-C` directory to invoke git from (running git inside the
+    // worktree we're about to delete fails on Windows because the OS
+    // locks a process's CWD) nor a basis for the containment check below.
+    let root = workspace_root.as_ref().ok_or_else(|| {
+        AppError::from(Error::Internal(
+            "cannot delete worktree without a configured workspace root".to_owned(),
+        ))
+    })?;
+    if !root.is_dir() {
+        return Err(AppError::from(Error::WorktreeMissing(root.clone())));
+    }
+
+    // Compare canonical forms so case differences, trailing slashes, and
+    // 8.3 short names don't fool us.
+    let canon_wt =
+        dunce::canonicalize(worktree_path).unwrap_or_else(|_| worktree_path.to_path_buf());
+    let canon_root = dunce::canonicalize(root).unwrap_or_else(|_| root.clone());
+
+    // Safety 1: never remove the main worktree.
+    if canon_wt == canon_root {
+        return Err(AppError::from(Error::Internal(
+            "refusing to delete the workspace root (main worktree)".to_owned(),
+        )));
+    }
+    // Safety 2: only remove paths *under* the workspace root. A corrupted
+    // session record (or hostile caller) must not be able to use this code
+    // path to delete arbitrary directories.
+    if !canon_wt.starts_with(&canon_root) {
+        return Err(AppError::from(Error::Internal(format!(
+            "refusing to delete worktree outside workspace root: {}",
+            worktree_path.display()
+        ))));
+    }
+    // Safety 3: refuse if any *other* live session still references the
+    // same worktree. The session being closed has already been removed
+    // from the store at this point, so it cannot match itself.
+    let still_in_use = ctx.store.load_sessions().values().any(|s| {
+        let other =
+            dunce::canonicalize(&s.worktree_path).unwrap_or_else(|_| s.worktree_path.clone());
+        other == canon_wt
+    });
+    if still_in_use {
+        return Err(AppError::from(Error::Internal(format!(
+            "refusing to delete worktree still in use by another session: {}",
+            worktree_path.display()
+        ))));
+    }
+
+    let repo_root: PathBuf = root.clone();
+
+    if let Err(e) = ctx.git_runner.remove_worktree(&repo_root, worktree_path) {
+        warn!(
+            session_id = %id,
+            worktree = %worktree_path.display(),
+            error = ?e,
+            "git worktree remove failed",
+        );
+        return Err(AppError::from(e));
+    }
+    info!(
+        session_id = %id,
+        worktree = %worktree_path.display(),
+        "worktree removed after session close",
+    );
     Ok(())
 }
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -381,15 +381,21 @@ fn delete_worktree_after_close(
     // from the store at this point, so it cannot match itself. If a
     // foreign session's path fails to canonicalize, we conservatively
     // treat it as a match (better to refuse than to delete a worktree
-    // that another session may still depend on).
-    let still_in_use =
-        ctx.store
-            .load_sessions()
-            .values()
-            .any(|s| match dunce::canonicalize(&s.worktree_path) {
-                Ok(other) => other == canon_wt,
-                Err(_) => s.worktree_path == worktree_path,
-            });
+    // that another session may still depend on). The session snapshot
+    // itself must be loaded *strictly* — for a destructive operation, an
+    // unreadable or quarantined sessions.json cannot be silently treated
+    // as "no other sessions exist".
+    let sessions = ctx.store.try_load_sessions().map_err(|e| {
+        AppError::from(Error::Internal(format!(
+            "refusing to delete worktree because the sessions snapshot could not be read reliably: {e}"
+        )))
+    })?;
+    let still_in_use = sessions
+        .values()
+        .any(|s| match dunce::canonicalize(&s.worktree_path) {
+            Ok(other) => other == canon_wt,
+            Err(_) => s.worktree_path == worktree_path,
+        });
     if still_in_use {
         return Err(AppError::from(Error::Internal(format!(
             "refusing to delete worktree still in use by another session: {}",

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -35,8 +35,9 @@ use crate::git::{GitRunner, RealGitRunner};
 use crate::pty_pool::{cleanup_orphans, PtyPool, PtySink};
 use crate::session_metrics::{MetricsCb, MetricsRegistry};
 use crate::types::{
-    AppError, Error, InstructionSet, PartialAppConfig, Session, SessionCreateArgs, SessionId,
-    SessionInputArgs, SessionResizeArgs, SessionStatus, SessionView, Tool,
+    AppError, Error, InstructionSet, PartialAppConfig, Session, SessionCloseResult,
+    SessionCreateArgs, SessionId, SessionInputArgs, SessionResizeArgs, SessionStatus, SessionView,
+    Tool,
 };
 
 /// Wiring shared by every Phase 7 session command. Built once at startup
@@ -242,7 +243,7 @@ pub async fn session_close_impl(
     ctx: &AppContext,
     id: SessionId,
     delete_worktree: bool,
-) -> Result<(), AppError> {
+) -> Result<SessionCloseResult, AppError> {
     // 0. Stop the metrics watcher (Issue #3) before tearing the rest down
     //    so it never observes a half-cleaned session.
     ctx.metrics.stop(&id);
@@ -299,13 +300,23 @@ pub async fn session_close_impl(
         .map_err(AppError::from)?;
 
     // 5. Optional: remove the git worktree from disk. The session is
-    //    already gone from the store at this point — failing here surfaces
-    //    a toast but does not resurrect the tab. The user explicitly
-    //    opted in via the close-confirm dialog.
+    //    already gone from the store at this point, so deletion failure
+    //    must NOT fail the overall close (that would leave the frontend
+    //    unable to converge on a "tab gone" state). Surface the error in
+    //    the result instead.
+    let mut result = SessionCloseResult::default();
     if let Some(wt) = worktree_path {
-        delete_worktree_after_close(ctx, &id, &wt, &cfg.workspace_root)?;
+        if let Err(error) = delete_worktree_after_close(ctx, &id, &wt, &cfg.workspace_root) {
+            warn!(
+                session_id = %id,
+                worktree_path = %wt.display(),
+                error = %error.message,
+                "worktree deletion failed after session close",
+            );
+            result.worktree_delete_error = Some(error.message);
+        }
     }
-    Ok(())
+    Ok(result)
 }
 
 /// Helper: validate and execute `git worktree remove --force`. Refuses to

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -343,10 +343,23 @@ fn delete_worktree_after_close(
     }
 
     // Compare canonical forms so case differences, trailing slashes, and
-    // 8.3 short names don't fool us.
-    let canon_wt =
-        dunce::canonicalize(worktree_path).unwrap_or_else(|_| worktree_path.to_path_buf());
-    let canon_root = dunce::canonicalize(root).unwrap_or_else(|_| root.clone());
+    // 8.3 short names don't fool us. For a destructive operation we
+    // refuse on canonicalization failure rather than fall back to the raw
+    // path: a non-normalized form (`..`, dangling symlink, junction with
+    // a missing target) could otherwise slip past the equality and
+    // containment checks below.
+    let canon_wt = dunce::canonicalize(worktree_path).map_err(|e| {
+        AppError::from(Error::Internal(format!(
+            "cannot canonicalize worktree path {}: {e}",
+            worktree_path.display()
+        )))
+    })?;
+    let canon_root = dunce::canonicalize(root).map_err(|e| {
+        AppError::from(Error::Internal(format!(
+            "cannot canonicalize workspace root {}: {e}",
+            root.display()
+        )))
+    })?;
 
     // Safety 1: never remove the main worktree.
     if canon_wt == canon_root {
@@ -365,12 +378,18 @@ fn delete_worktree_after_close(
     }
     // Safety 3: refuse if any *other* live session still references the
     // same worktree. The session being closed has already been removed
-    // from the store at this point, so it cannot match itself.
-    let still_in_use = ctx.store.load_sessions().values().any(|s| {
-        let other =
-            dunce::canonicalize(&s.worktree_path).unwrap_or_else(|_| s.worktree_path.clone());
-        other == canon_wt
-    });
+    // from the store at this point, so it cannot match itself. If a
+    // foreign session's path fails to canonicalize, we conservatively
+    // treat it as a match (better to refuse than to delete a worktree
+    // that another session may still depend on).
+    let still_in_use =
+        ctx.store
+            .load_sessions()
+            .values()
+            .any(|s| match dunce::canonicalize(&s.worktree_path) {
+                Ok(other) => other == canon_wt,
+                Err(_) => s.worktree_path == worktree_path,
+            });
     if still_in_use {
         return Err(AppError::from(Error::Internal(format!(
             "refusing to delete worktree still in use by another session: {}",
@@ -380,15 +399,9 @@ fn delete_worktree_after_close(
 
     let repo_root: PathBuf = root.clone();
 
-    if let Err(e) = ctx.git_runner.remove_worktree(&repo_root, worktree_path) {
-        warn!(
-            session_id = %id,
-            worktree = %worktree_path.display(),
-            error = ?e,
-            "git worktree remove failed",
-        );
-        return Err(AppError::from(e));
-    }
+    ctx.git_runner
+        .remove_worktree(&repo_root, worktree_path)
+        .map_err(AppError::from)?;
     info!(
         session_id = %id,
         worktree = %worktree_path.display(),

--- a/src-tauri/src/config_store.rs
+++ b/src-tauri/src/config_store.rs
@@ -255,6 +255,28 @@ impl ConfigStore {
         }
     }
 
+    /// Strict variant of [`Self::load_sessions`] for callers that perform
+    /// destructive operations and cannot safely treat IO/parse failures as
+    /// "no sessions exist". Returns the full session map on success or the
+    /// underlying error otherwise. A missing file is still treated as an
+    /// empty map (a fresh install has no `sessions.json`).
+    pub fn try_load_sessions(&self) -> Result<BTreeMap<SessionId, Session>, Error> {
+        let path = self.sessions_path();
+        let raw = match fs::read_to_string(&path) {
+            Ok(v) => v,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
+            Err(e) => return Err(Error::Io(e)),
+        };
+        let mut m: BTreeMap<SessionId, Session> = serde_json::from_str(&raw).map_err(|e| {
+            Error::Internal(format!(
+                "sessions.json failed to parse: {} ({e})",
+                path.display()
+            ))
+        })?;
+        migrate_copilot_composed_commands(&mut m);
+        Ok(m)
+    }
+
     /// Persist a single session record (insert-or-replace).
     pub fn save_session(&self, session: &Session) -> Result<(), Error> {
         let mut all = self.load_sessions();
@@ -943,6 +965,47 @@ mod tests {
             })
             .collect();
         assert_eq!(badfiles.len(), 1);
+    }
+
+    #[test]
+    fn try_load_sessions_returns_ok_empty_when_file_missing() {
+        let td = TempDir::new().expect("td");
+        let store = ConfigStore::open(td.path()).expect("open");
+        let map = store.try_load_sessions().expect("ok on missing file");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn try_load_sessions_surfaces_parse_failure_without_quarantine() {
+        let td = TempDir::new().expect("td");
+        let store = ConfigStore::open(td.path()).expect("open");
+        let path = td.path().join(SESSIONS_FILENAME);
+        fs::write(&path, b"###bad###").expect("write");
+
+        let err = store
+            .try_load_sessions()
+            .expect_err("expected parse failure");
+        assert!(matches!(err, Error::Internal(_)), "got {err:?}");
+
+        // Strict variant must NOT quarantine — the caller (a destructive
+        // operation) needs the file intact so it can be inspected/repaired.
+        assert!(
+            path.exists(),
+            "try_load_sessions must not quarantine the bad file"
+        );
+        let badfiles: Vec<_> = fs::read_dir(td.path())
+            .expect("rd")
+            .filter_map(Result::ok)
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("sessions.json.bad-")
+            })
+            .collect();
+        assert!(
+            badfiles.is_empty(),
+            "try_load_sessions must not produce quarantine files"
+        );
     }
 
     #[test]

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -99,9 +99,11 @@ pub trait GitRunner: Send + Sync {
     /// deletion in the UI (CloseConfirmDialog) and we have just torn down
     /// the PTY that owned the cwd.
     ///
-    /// `repo_root` is any checkout of the same repository — typically the
-    /// configured `workspace_root`, but `worktree_path` itself works as a
-    /// fallback while it still exists on disk.
+    /// `repo_root` must be a stable checkout of the same repository
+    /// *outside* the target `worktree_path` — typically the configured
+    /// `workspace_root`. Callers must not pass `worktree_path` itself as
+    /// `repo_root`: the spawned `git` would inherit it as its CWD, and on
+    /// Windows the OS prevents deletion of a process's own CWD.
     ///
     /// Errors are surfaced as [`Error::Internal`] carrying git's stderr so
     /// the frontend can show the user a meaningful message.

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -93,6 +93,19 @@ pub trait GitRunner: Send + Sync {
         relative_path: &Path,
         branch: &str,
     ) -> Result<PathBuf, Error>;
+
+    /// Run `git -C <repo_root> worktree remove --force <worktree_path>`.
+    /// `--force` is used because the user has explicitly confirmed
+    /// deletion in the UI (CloseConfirmDialog) and we have just torn down
+    /// the PTY that owned the cwd.
+    ///
+    /// `repo_root` is any checkout of the same repository — typically the
+    /// configured `workspace_root`, but `worktree_path` itself works as a
+    /// fallback while it still exists on disk.
+    ///
+    /// Errors are surfaced as [`Error::Internal`] carrying git's stderr so
+    /// the frontend can show the user a meaningful message.
+    fn remove_worktree(&self, repo_root: &Path, worktree_path: &Path) -> Result<(), Error>;
 }
 
 /// Production [`GitRunner`] that shells out to the system `git`.
@@ -219,6 +232,32 @@ impl GitRunner for RealGitRunner {
                 new_path.display()
             ))
         })
+    }
+
+    fn remove_worktree(&self, repo_root: &Path, worktree_path: &Path) -> Result<(), Error> {
+        if !repo_root.is_dir() {
+            return Err(Error::WorktreeMissing(repo_root.to_path_buf()));
+        }
+        let output = git_command()
+            .current_dir(repo_root)
+            .arg("-C")
+            .arg(repo_root)
+            .args(["worktree", "remove", "--force"])
+            .arg(worktree_path)
+            .output()
+            .map_err(|e| Error::Internal(format!("git worktree remove: {e}")))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+            return Err(Error::Internal(format!(
+                "git worktree remove failed: {}",
+                if stderr.is_empty() {
+                    "<no stderr>".to_owned()
+                } else {
+                    stderr
+                }
+            )));
+        }
+        Ok(())
     }
 }
 

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -519,14 +519,34 @@ pub struct SessionCreateArgs {
     pub instruction_set_id: Option<InstructionSetId>,
 }
 
-/// Arguments for any command keyed only by session id (`session_close`,
-/// `session_focus`, `session_restart`).
+/// Arguments for any command keyed only by session id
+/// (`session_focus`, `session_restart`). `session_close` uses the richer
+/// [`SessionCloseArgs`] so the user can opt into worktree deletion.
 ///
 /// MIRROR: `src/lib/tauri-bridge.ts::SessionIdArg`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionIdArg {
     pub session_id: SessionId,
+}
+
+/// Arguments for `session_close`. Extends [`SessionIdArg`] with an opt-in
+/// flag that removes the session's git worktree from disk after the PTY is
+/// torn down. The backend gates removal behind safety checks (never the
+/// main worktree, never a path outside the configured workspace root); see
+/// `commands::session::session_close_impl`.
+///
+/// MIRROR: `src/lib/tauri-bridge.ts::SessionCloseArgs`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionCloseArgs {
+    pub session_id: SessionId,
+    /// When `true`, run `git worktree remove --force <worktree_path>` after
+    /// terminating the PTY. Defaults to `false` so legacy callers (and any
+    /// future code that forgets to set the flag) preserve existing
+    /// behaviour.
+    #[serde(default)]
+    pub delete_worktree: bool,
 }
 
 /// Arguments for `session_resize`.

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -549,6 +549,21 @@ pub struct SessionCloseArgs {
     pub delete_worktree: bool,
 }
 
+/// Result of `session_close`. The session record and PTY are always torn
+/// down on success; if the user opted into worktree deletion and the
+/// `git worktree remove` step failed, the failure is reported here as a
+/// warning string rather than as a hard error so callers can converge UI
+/// state regardless.
+///
+/// MIRROR: `src/lib/tauri-bridge.ts::SessionCloseResult`.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionCloseResult {
+    /// Human-readable error message from `git worktree remove`. `None`
+    /// when worktree deletion was not requested or succeeded.
+    pub worktree_delete_error: Option<String>,
+}
+
 /// Arguments for `session_resize`.
 ///
 /// MIRROR: `src/lib/tauri-bridge.ts::SessionResizeArgs`.

--- a/src-tauri/tests/session_lifecycle_fake.rs
+++ b/src-tauri/tests/session_lifecycle_fake.rs
@@ -600,6 +600,42 @@ async fn close_with_delete_worktree_refuses_when_no_workspace_root() {
 }
 
 #[tokio::test]
+async fn close_with_delete_worktree_refuses_when_sessions_snapshot_unreadable() {
+    let git = RecordingGitRunner::new();
+    let h = build_harness_with_git(git.clone() as Arc<dyn GitRunner>);
+    let ws_root = h.worktree.path().parent().unwrap().to_path_buf();
+    h.ctx
+        .store
+        .save_config(PartialAppConfig {
+            workspace_root: Some(Some(ws_root)),
+            ..Default::default()
+        })
+        .unwrap();
+    let view = session_create_impl(&h.ctx, create_args(&h)).unwrap();
+
+    // Corrupt sessions.json so the strict snapshot read at the start of
+    // close fails. The destructive worktree-delete path must refuse
+    // rather than treat the unreadable snapshot as "session not found,
+    // skip silently".
+    std::fs::write(h.ctx.store.dir().join("sessions.json"), b"###bad###").unwrap();
+
+    let result = session_close_impl(&h.ctx, view.id, true)
+        .await
+        .expect("close itself should succeed even when sessions.json is corrupt");
+    let msg = result
+        .worktree_delete_error
+        .expect("expected snapshot-read refusal in result");
+    assert!(
+        msg.contains("sessions snapshot"),
+        "expected snapshot-read refusal, got: {msg}",
+    );
+    assert!(
+        git.removes.lock().unwrap().is_empty(),
+        "remove_worktree must not be invoked when sessions snapshot is unreadable"
+    );
+}
+
+#[tokio::test]
 async fn close_with_delete_worktree_refuses_when_outside_workspace_root() {
     let git = RecordingGitRunner::new();
     let h = build_harness_with_git(git.clone() as Arc<dyn GitRunner>);

--- a/src-tauri/tests/session_lifecycle_fake.rs
+++ b/src-tauri/tests/session_lifecycle_fake.rs
@@ -26,12 +26,13 @@ use arborist_lib::commands::session::{
 };
 use arborist_lib::compose::session_temp_dir;
 use arborist_lib::config_store::ConfigStore;
+use arborist_lib::git::GitRunner;
 use arborist_lib::pty_pool::{
     ChildCommand, PtyKiller, PtyPool, PtyResize, PtySink, PtySpawner, PtyWaiter, SpawnedChild,
 };
 use arborist_lib::types::{
     InstructionSetId, PartialAppConfig, PartialDefaultInstructionSets, SessionCreateArgs,
-    SessionId, SessionInputArgs, SessionResizeArgs, SessionStatus, Tool,
+    SessionId, SessionInputArgs, SessionResizeArgs, SessionStatus, Tool, WorktreeInfo,
 };
 use portable_pty::{ExitStatus, PtySize};
 use tempfile::TempDir;
@@ -199,7 +200,56 @@ struct Harness {
     instruction_id: InstructionSetId,
 }
 
+/// Records `remove_worktree` invocations so a test can assert opt-in
+/// deletion was forwarded to the git layer.
+#[derive(Default)]
+struct RecordingGitRunner {
+    removes: Mutex<Vec<(PathBuf, PathBuf)>>,
+    fail_with: Mutex<Option<String>>,
+}
+
+impl RecordingGitRunner {
+    fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+}
+
+impl GitRunner for RecordingGitRunner {
+    fn list_worktrees(&self, _: &Path) -> Result<Vec<WorktreeInfo>, arborist_lib::types::Error> {
+        Ok(vec![])
+    }
+    fn git_toplevel(&self, p: &Path) -> Result<Option<PathBuf>, arborist_lib::types::Error> {
+        Ok(Some(p.to_path_buf()))
+    }
+    fn create_worktree(
+        &self,
+        repo_root: &Path,
+        relative_path: &Path,
+        _branch: &str,
+    ) -> Result<PathBuf, arborist_lib::types::Error> {
+        Ok(repo_root.join(relative_path))
+    }
+    fn remove_worktree(
+        &self,
+        repo_root: &Path,
+        worktree_path: &Path,
+    ) -> Result<(), arborist_lib::types::Error> {
+        self.removes
+            .lock()
+            .unwrap()
+            .push((repo_root.to_path_buf(), worktree_path.to_path_buf()));
+        if let Some(msg) = self.fail_with.lock().unwrap().clone() {
+            return Err(arborist_lib::types::Error::Internal(msg));
+        }
+        Ok(())
+    }
+}
+
 fn build_harness() -> Harness {
+    build_harness_with_git(Arc::new(arborist_lib::git::RealGitRunner) as Arc<dyn GitRunner>)
+}
+
+fn build_harness_with_git(git: Arc<dyn GitRunner>) -> Harness {
     let config_dir = TempDir::new().unwrap();
     let instructions_dir = TempDir::new().unwrap();
     let worktree = TempDir::new().unwrap();
@@ -226,7 +276,7 @@ fn build_harness() -> Harness {
     let pool = Arc::new(PtyPool::new(spawner.clone() as Arc<dyn PtySpawner>));
     let events = Arc::new(CapturedEvents::default());
     let sink = capture_sink(Arc::clone(&events), store.clone());
-    let ctx = Arc::new(AppContext::with_real_git(pool, store, sink));
+    let ctx = Arc::new(AppContext::new(pool, store, sink, git, Arc::new(|_| {})));
 
     Harness {
         ctx,
@@ -394,7 +444,7 @@ async fn close_kills_pty_removes_record_and_clears_active() {
     let temp = session_temp_dir(&view.id);
     assert!(temp.exists(), "Claude temp dir must exist after create");
 
-    session_close_impl(&h.ctx, view.id).await.unwrap();
+    session_close_impl(&h.ctx, view.id, false).await.unwrap();
 
     assert!(!h.ctx.pool.contains(&view.id));
     assert!(session_list_impl(&h.ctx).unwrap().is_empty());
@@ -407,6 +457,167 @@ async fn close_kills_pty_removes_record_and_clears_active() {
     // cleanup. Allow a beat for filesystem to settle on Windows.
     let cleared = wait_until(|| !temp.exists(), Duration::from_secs(2));
     assert!(cleared, "session temp dir {temp:?} should be removed");
+}
+
+#[tokio::test]
+async fn close_with_delete_worktree_invokes_git_runner_remove() {
+    let git = RecordingGitRunner::new();
+    let h = build_harness_with_git(git.clone() as Arc<dyn GitRunner>);
+    // Configure a workspace root that *contains* the session's worktree so
+    // the containment check passes.
+    let ws_root = h.worktree.path().parent().unwrap().to_path_buf();
+    h.ctx
+        .store
+        .save_config(PartialAppConfig {
+            workspace_root: Some(Some(ws_root.clone())),
+            ..Default::default()
+        })
+        .unwrap();
+    let view = session_create_impl(&h.ctx, create_args(&h)).unwrap();
+    let worktree_path = h.worktree.path().to_path_buf();
+
+    session_close_impl(&h.ctx, view.id, true).await.unwrap();
+
+    let removes = git.removes.lock().unwrap().clone();
+    assert_eq!(removes.len(), 1, "expected one remove_worktree call");
+    let (_repo, wt) = &removes[0];
+    let wt_canon = dunce::canonicalize(wt).unwrap_or_else(|_| wt.clone());
+    let expected_canon =
+        dunce::canonicalize(&worktree_path).unwrap_or_else(|_| worktree_path.clone());
+    assert_eq!(
+        wt_canon, expected_canon,
+        "remove_worktree must be called with the session's worktree path"
+    );
+    // Session record is gone regardless.
+    assert!(session_list_impl(&h.ctx).unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn close_without_delete_worktree_does_not_invoke_remove() {
+    let git = RecordingGitRunner::new();
+    let h = build_harness_with_git(git.clone() as Arc<dyn GitRunner>);
+    let view = session_create_impl(&h.ctx, create_args(&h)).unwrap();
+
+    session_close_impl(&h.ctx, view.id, false).await.unwrap();
+
+    assert!(
+        git.removes.lock().unwrap().is_empty(),
+        "remove_worktree must NOT be called when delete_worktree is false"
+    );
+}
+
+#[tokio::test]
+async fn close_with_delete_worktree_refuses_main_workspace_root() {
+    let git = RecordingGitRunner::new();
+    let h = build_harness_with_git(git.clone() as Arc<dyn GitRunner>);
+    // Point workspace_root at the same path as the session's worktree so
+    // the safety check trips.
+    h.ctx
+        .store
+        .save_config(PartialAppConfig {
+            workspace_root: Some(Some(h.worktree.path().to_path_buf())),
+            ..Default::default()
+        })
+        .unwrap();
+    let view = session_create_impl(&h.ctx, create_args(&h)).unwrap();
+
+    let err = session_close_impl(&h.ctx, view.id, true)
+        .await
+        .expect_err("must refuse to delete the main worktree");
+    assert!(
+        err.message.contains("workspace root") || err.message.contains("main worktree"),
+        "expected a workspace-root refusal message, got: {}",
+        err.message
+    );
+    assert!(
+        git.removes.lock().unwrap().is_empty(),
+        "remove_worktree must not be invoked when refused"
+    );
+    // The session is still removed because the kill+config cleanup happens
+    // before the worktree-deletion attempt — the user opted in to losing
+    // the session even if the worktree is preserved.
+    assert!(session_list_impl(&h.ctx).unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn close_with_delete_worktree_propagates_git_failure() {
+    let git = RecordingGitRunner::new();
+    *git.fail_with.lock().unwrap() = Some("fatal: not a working tree".into());
+    let h = build_harness_with_git(git.clone() as Arc<dyn GitRunner>);
+    let ws_root = h.worktree.path().parent().unwrap().to_path_buf();
+    h.ctx
+        .store
+        .save_config(PartialAppConfig {
+            workspace_root: Some(Some(ws_root)),
+            ..Default::default()
+        })
+        .unwrap();
+    let view = session_create_impl(&h.ctx, create_args(&h)).unwrap();
+
+    let err = session_close_impl(&h.ctx, view.id, true)
+        .await
+        .expect_err("git failure must surface to caller");
+    assert!(
+        err.message.contains("not a working tree"),
+        "expected the git stderr to bubble up, got: {}",
+        err.message
+    );
+    assert_eq!(
+        git.removes.lock().unwrap().len(),
+        1,
+        "remove_worktree should still have been attempted"
+    );
+}
+
+#[tokio::test]
+async fn close_with_delete_worktree_refuses_when_no_workspace_root() {
+    let git = RecordingGitRunner::new();
+    let h = build_harness_with_git(git.clone() as Arc<dyn GitRunner>);
+    // No workspace_root configured.
+    let view = session_create_impl(&h.ctx, create_args(&h)).unwrap();
+
+    let err = session_close_impl(&h.ctx, view.id, true)
+        .await
+        .expect_err("must refuse without workspace_root");
+    assert!(
+        err.message.contains("workspace root"),
+        "expected workspace-root error, got: {}",
+        err.message
+    );
+    assert!(
+        git.removes.lock().unwrap().is_empty(),
+        "remove_worktree must not be invoked"
+    );
+}
+
+#[tokio::test]
+async fn close_with_delete_worktree_refuses_when_outside_workspace_root() {
+    let git = RecordingGitRunner::new();
+    let h = build_harness_with_git(git.clone() as Arc<dyn GitRunner>);
+    // Configure workspace_root at an unrelated TempDir so the session's
+    // worktree is *not* contained under it.
+    let unrelated_root = TempDir::new().unwrap();
+    h.ctx
+        .store
+        .save_config(PartialAppConfig {
+            workspace_root: Some(Some(unrelated_root.path().to_path_buf())),
+            ..Default::default()
+        })
+        .unwrap();
+    let view = session_create_impl(&h.ctx, create_args(&h)).unwrap();
+
+    let err = session_close_impl(&h.ctx, view.id, true)
+        .await
+        .expect_err("must refuse paths outside workspace_root");
+    assert!(
+        err.message.contains("outside workspace root"),
+        "expected containment error, got: {}",
+        err.message
+    );
+    assert!(
+        git.removes.lock().unwrap().is_empty(),
+        "remove_worktree must not be invoked"
+    );
 }
 
 #[tokio::test]

--- a/src-tauri/tests/session_lifecycle_fake.rs
+++ b/src-tauri/tests/session_lifecycle_fake.rs
@@ -521,13 +521,15 @@ async fn close_with_delete_worktree_refuses_main_workspace_root() {
         .unwrap();
     let view = session_create_impl(&h.ctx, create_args(&h)).unwrap();
 
-    let err = session_close_impl(&h.ctx, view.id, true)
+    let result = session_close_impl(&h.ctx, view.id, true)
         .await
-        .expect_err("must refuse to delete the main worktree");
+        .expect("close itself should succeed even when worktree deletion is refused");
+    let msg = result
+        .worktree_delete_error
+        .expect("expected a worktree-delete-error in the result");
     assert!(
-        err.message.contains("workspace root") || err.message.contains("main worktree"),
-        "expected a workspace-root refusal message, got: {}",
-        err.message
+        msg.contains("workspace root") || msg.contains("main worktree"),
+        "expected a workspace-root refusal message, got: {msg}",
     );
     assert!(
         git.removes.lock().unwrap().is_empty(),
@@ -554,19 +556,23 @@ async fn close_with_delete_worktree_propagates_git_failure() {
         .unwrap();
     let view = session_create_impl(&h.ctx, create_args(&h)).unwrap();
 
-    let err = session_close_impl(&h.ctx, view.id, true)
+    let result = session_close_impl(&h.ctx, view.id, true)
         .await
-        .expect_err("git failure must surface to caller");
+        .expect("close itself should succeed even when git fails");
+    let msg = result
+        .worktree_delete_error
+        .expect("git failure must surface as a worktree-delete-error");
     assert!(
-        err.message.contains("not a working tree"),
-        "expected the git stderr to bubble up, got: {}",
-        err.message
+        msg.contains("not a working tree"),
+        "expected the git stderr to bubble up, got: {msg}",
     );
     assert_eq!(
         git.removes.lock().unwrap().len(),
         1,
         "remove_worktree should still have been attempted"
     );
+    // Session record is gone regardless of the post-close worktree failure.
+    assert!(session_list_impl(&h.ctx).unwrap().is_empty());
 }
 
 #[tokio::test]
@@ -576,18 +582,21 @@ async fn close_with_delete_worktree_refuses_when_no_workspace_root() {
     // No workspace_root configured.
     let view = session_create_impl(&h.ctx, create_args(&h)).unwrap();
 
-    let err = session_close_impl(&h.ctx, view.id, true)
+    let result = session_close_impl(&h.ctx, view.id, true)
         .await
-        .expect_err("must refuse without workspace_root");
+        .expect("close itself should succeed even without workspace_root");
+    let msg = result
+        .worktree_delete_error
+        .expect("expected workspace-root error in result");
     assert!(
-        err.message.contains("workspace root"),
-        "expected workspace-root error, got: {}",
-        err.message
+        msg.contains("workspace root"),
+        "expected workspace-root error, got: {msg}",
     );
     assert!(
         git.removes.lock().unwrap().is_empty(),
         "remove_worktree must not be invoked"
     );
+    assert!(session_list_impl(&h.ctx).unwrap().is_empty());
 }
 
 #[tokio::test]
@@ -606,13 +615,15 @@ async fn close_with_delete_worktree_refuses_when_outside_workspace_root() {
         .unwrap();
     let view = session_create_impl(&h.ctx, create_args(&h)).unwrap();
 
-    let err = session_close_impl(&h.ctx, view.id, true)
+    let result = session_close_impl(&h.ctx, view.id, true)
         .await
-        .expect_err("must refuse paths outside workspace_root");
+        .expect("close itself should succeed even when path is outside workspace_root");
+    let msg = result
+        .worktree_delete_error
+        .expect("expected containment error in result");
     assert!(
-        err.message.contains("outside workspace root"),
-        "expected containment error, got: {}",
-        err.message
+        msg.contains("outside workspace root"),
+        "expected containment error, got: {msg}",
     );
     assert!(
         git.removes.lock().unwrap().is_empty(),

--- a/src-tauri/tests/session_lifecycle_real.rs
+++ b/src-tauri/tests/session_lifecycle_real.rs
@@ -159,7 +159,7 @@ async fn real_spawner_drives_create_input_close_round_trip() {
 
     // Close. The pool kills the child and removes the persisted record;
     // tearDown should be clean within a couple of seconds even on Windows.
-    session_close_impl(&ctx, view.id).await.unwrap();
+    session_close_impl(&ctx, view.id, false).await.unwrap();
     assert!(!ctx.pool.contains(&view.id));
 
     // Restore parity for any later tests sharing this process. The test

--- a/src-tauri/tests/workspace_command.rs
+++ b/src-tauri/tests/workspace_command.rs
@@ -68,6 +68,9 @@ impl GitRunner for FakeGitRunner {
             Err(msg) => Err(Error::Internal(msg.clone())),
         }
     }
+    fn remove_worktree(&self, _repo_root: &Path, _worktree_path: &Path) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 fn null_sink() -> PtySink {

--- a/src-tauri/tests/worktrees_command.rs
+++ b/src-tauri/tests/worktrees_command.rs
@@ -49,6 +49,9 @@ impl GitRunner for FakeGitRunner {
     ) -> Result<PathBuf, Error> {
         Ok(repo_root.join(relative_path))
     }
+    fn remove_worktree(&self, _repo_root: &Path, _worktree_path: &Path) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 /// Minimal sink that swallows everything — we don't exercise the PTY here.

--- a/src/components/CloseConfirmDialog.tsx
+++ b/src/components/CloseConfirmDialog.tsx
@@ -2,7 +2,7 @@
 // presses `Delete` on a focused tab. Uses the native <dialog> element so
 // we get a focus trap and Esc-to-close for free, no extra deps.
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { usePendingClose, useSessionActions, useSessionById } from '@/store/session-store';
 
@@ -13,11 +13,15 @@ export function CloseConfirmDialog(): JSX.Element | null {
 
   const dialogRef = useRef<HTMLDialogElement | null>(null);
   const cancelRef = useRef<HTMLButtonElement | null>(null);
+  const [deleteWorktree, setDeleteWorktree] = useState<boolean>(false);
 
   useEffect(() => {
     const dialog = dialogRef.current;
     if (!dialog) return;
     if (pendingId !== undefined) {
+      // Reset the opt-in checkbox every time the dialog opens — deletion
+      // is destructive and should never be sticky across tabs.
+      setDeleteWorktree(false);
       if (!dialog.open) {
         // Some test environments (jsdom) don't ship a working showModal.
         if (typeof dialog.showModal === 'function') {
@@ -45,7 +49,7 @@ export function CloseConfirmDialog(): JSX.Element | null {
 
   const onConfirm = async (): Promise<void> => {
     try {
-      await actions.close(pendingId);
+      await actions.close(pendingId, deleteWorktree);
     } finally {
       actions.cancelClose();
     }
@@ -66,6 +70,30 @@ export function CloseConfirmDialog(): JSX.Element | null {
       <h2 id="close-confirm-title" className="mb-3 text-base font-semibold">
         Terminate session &ldquo;{session.label}&rdquo;?
       </h2>
+      <label className="mb-4 flex items-start gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={deleteWorktree}
+          onChange={(e) => setDeleteWorktree(e.target.checked)}
+          className="mt-0.5 h-4 w-4 cursor-pointer accent-red-600"
+        />
+        <span className="flex flex-col">
+          <span>
+            Also delete the worktree directory
+            {deleteWorktree ? (
+              <span className="ml-1 font-medium text-red-700 dark:text-red-400">
+                (cannot be undone)
+              </span>
+            ) : null}
+          </span>
+          <span
+            className="mt-0.5 break-all font-mono text-xs text-slate-500 dark:text-slate-400"
+            title={session.worktreePath}
+          >
+            {session.worktreePath}
+          </span>
+        </span>
+      </label>
       <div className="flex justify-end gap-2">
         <button
           ref={cancelRef}
@@ -82,7 +110,7 @@ export function CloseConfirmDialog(): JSX.Element | null {
           }}
           className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
         >
-          Terminate
+          {deleteWorktree ? 'Terminate & delete worktree' : 'Terminate'}
         </button>
       </div>
     </dialog>

--- a/src/components/CloseConfirmDialog.tsx
+++ b/src/components/CloseConfirmDialog.tsx
@@ -48,10 +48,25 @@ export function CloseConfirmDialog(): JSX.Element | null {
   };
 
   const onConfirm = async (): Promise<void> => {
+    let alertMessage: string | null = null;
     try {
-      await actions.close(pendingId, deleteWorktree);
+      const result = await actions.close(pendingId, deleteWorktree);
+      if (result.worktreeDeleteError !== null) {
+        alertMessage = `Session terminated, but deleting the worktree failed:\n\n${result.worktreeDeleteError}`;
+      }
+    } catch (error: unknown) {
+      const detail =
+        error instanceof Error && error.message.length > 0 ? error.message : String(error);
+      alertMessage = `Failed to terminate session:\n\n${detail}`;
     } finally {
       actions.cancelClose();
+    }
+    if (
+      alertMessage !== null &&
+      typeof window !== 'undefined' &&
+      typeof window.alert === 'function'
+    ) {
+      window.alert(alertMessage);
     }
   };
 

--- a/src/components/CloseConfirmDialog.tsx
+++ b/src/components/CloseConfirmDialog.tsx
@@ -57,7 +57,7 @@ export function CloseConfirmDialog(): JSX.Element | null {
     } catch (error: unknown) {
       const detail =
         error instanceof Error && error.message.length > 0 ? error.message : String(error);
-      alertMessage = `Failed to terminate session:\n\n${detail}`;
+      alertMessage = `Close request failed (the session may already be terminated):\n\n${detail}`;
     } finally {
       actions.cancelClose();
     }

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -181,6 +181,48 @@ describe('Sidebar', () => {
     expect(checkbox2).not.toBeChecked();
   });
 
+  it('alerts the user and still removes the tab when the worktree-delete step fails', async () => {
+    seed([makeView('a', { worktreePath: '/repo/.worktrees/feature-x' })], 'a');
+    bridgeMock.sessionClose.mockResolvedValueOnce({
+      worktreeDeleteError: 'git worktree remove failed: locked',
+    });
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    render(<Sidebar />);
+
+    fireEvent.click(screen.getByRole('button', { name: /close session a/i }));
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('checkbox', { name: /delete the worktree/i }));
+    await act(async () => {
+      fireEvent.click(within(dialog).getByRole('button', { name: /terminate.*delete worktree/i }));
+    });
+
+    // Tab is gone (UI converged on "session closed") even though deletion failed.
+    expect(useSessionStore.getState().sessions).toHaveLength(0);
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    expect(alertSpy.mock.calls[0]?.[0]).toMatch(/worktree remove failed: locked/);
+    alertSpy.mockRestore();
+  });
+
+  it('alerts the user and still removes the tab when sessionClose throws', async () => {
+    seed([makeView('a')], 'a');
+    bridgeMock.sessionClose.mockRejectedValueOnce(new Error('pty kill timed out'));
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    render(<Sidebar />);
+
+    fireEvent.click(screen.getByRole('button', { name: /close session a/i }));
+    await act(async () => {
+      fireEvent.click(
+        within(screen.getByRole('dialog')).getByRole('button', { name: /terminate/i }),
+      );
+    });
+
+    // UI converges to "tab gone" so the user is never stuck with a stale row.
+    expect(useSessionStore.getState().sessions).toHaveLength(0);
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    expect(alertSpy.mock.calls[0]?.[0]).toMatch(/pty kill timed out/);
+    alertSpy.mockRestore();
+  });
+
   it('keyboard nav: ArrowDown / Home / End / Enter / Delete', () => {
     seed([makeView('a'), makeView('b'), makeView('c')], 'a');
     render(<Sidebar />);

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -133,8 +133,52 @@ describe('Sidebar', () => {
       );
     });
 
-    expect(bridgeMock.sessionClose).toHaveBeenCalledWith({ sessionId: 'a' });
+    expect(bridgeMock.sessionClose).toHaveBeenCalledWith({ sessionId: 'a', deleteWorktree: false });
     expect(useSessionStore.getState().sessions.map((s) => s.id)).toEqual(['b']);
+  });
+
+  it('passes deleteWorktree=true when the checkbox is ticked before confirming', async () => {
+    seed([makeView('a', { worktreePath: '/repo/.worktrees/feature-x' })], 'a');
+    render(<Sidebar />);
+
+    fireEvent.click(screen.getByRole('button', { name: /close session a/i }));
+    const dialog = screen.getByRole('dialog');
+    const checkbox = within(dialog).getByRole('checkbox', { name: /delete the worktree/i });
+    expect(checkbox).not.toBeChecked();
+    expect(within(dialog).getByText('/repo/.worktrees/feature-x')).toBeInTheDocument();
+
+    fireEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    await act(async () => {
+      fireEvent.click(within(dialog).getByRole('button', { name: /terminate.*delete worktree/i }));
+    });
+
+    expect(bridgeMock.sessionClose).toHaveBeenCalledWith({
+      sessionId: 'a',
+      deleteWorktree: true,
+    });
+  });
+
+  it('resets the delete-worktree checkbox each time the dialog reopens', async () => {
+    seed([makeView('a'), makeView('b')], 'a');
+    render(<Sidebar />);
+
+    // Open for "a", tick, cancel.
+    fireEvent.click(screen.getByRole('button', { name: /close session a/i }));
+    const checkbox1 = within(screen.getByRole('dialog')).getByRole('checkbox', {
+      name: /delete the worktree/i,
+    });
+    fireEvent.click(checkbox1);
+    expect(checkbox1).toBeChecked();
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /cancel/i }));
+
+    // Reopen for "b" — checkbox should NOT carry over its prior tick.
+    fireEvent.click(screen.getByRole('button', { name: /close session b/i }));
+    const checkbox2 = within(screen.getByRole('dialog')).getByRole('checkbox', {
+      name: /delete the worktree/i,
+    });
+    expect(checkbox2).not.toBeChecked();
   });
 
   it('keyboard nav: ArrowDown / Home / End / Enter / Delete', () => {

--- a/src/lib/tauri-bridge.mock.ts
+++ b/src/lib/tauri-bridge.mock.ts
@@ -155,6 +155,7 @@ export type {
   SessionCreateArgs,
   SessionIdArg,
   SessionCloseArgs,
+  SessionCloseResult,
   SessionResizeArgs,
   SessionInputArgs,
 } from './tauri-bridge';
@@ -167,7 +168,7 @@ export function resetBridgeMocks(): void {
   ping.mockReset().mockImplementation(() => Promise.resolve('pong'));
   sessionCreate.mockReset().mockImplementation(rejectNotImplemented);
   sessionList.mockReset().mockImplementation(() => Promise.resolve([]));
-  sessionClose.mockReset().mockImplementation(() => Promise.resolve());
+  sessionClose.mockReset().mockImplementation(() => Promise.resolve({ worktreeDeleteError: null }));
   sessionFocus.mockReset().mockImplementation(() => Promise.resolve());
   sessionResize.mockReset().mockImplementation(() => Promise.resolve());
   sessionInput.mockReset().mockImplementation(() => Promise.resolve());

--- a/src/lib/tauri-bridge.mock.ts
+++ b/src/lib/tauri-bridge.mock.ts
@@ -154,6 +154,7 @@ export const onSessionMetrics: Mock<
 export type {
   SessionCreateArgs,
   SessionIdArg,
+  SessionCloseArgs,
   SessionResizeArgs,
   SessionInputArgs,
 } from './tauri-bridge';

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -69,6 +69,19 @@ export interface SessionCloseArgs {
   deleteWorktree?: boolean;
 }
 
+/**
+ * Result of `session_close`. The session record + PTY are always torn
+ * down on success; if the user opted into worktree deletion and the
+ * `git worktree remove` step failed, that failure is reported here as a
+ * warning string instead of as a hard error so the UI can converge on a
+ * "tab gone" state regardless.
+ *
+ * MIRROR: `src-tauri/src/types.rs::SessionCloseResult`.
+ */
+export interface SessionCloseResult {
+  worktreeDeleteError: string | null;
+}
+
 export interface SessionResizeArgs {
   sessionId: SessionId;
   cols: number;
@@ -118,10 +131,13 @@ export function sessionList(): Promise<SessionView[]> {
  * session out of `lastOpenSessions`/`tabOrder`/`activeSessionId`. Idempotent
  * for already-exited sessions. When `deleteWorktree` is `true`, the backend
  * additionally runs `git worktree remove --force` on the session's
- * worktree.
+ * worktree; failures of that step surface in
+ * [`SessionCloseResult.worktreeDeleteError`] rather than as a thrown
+ * error, so callers can always treat a fulfilled promise as "session
+ * gone".
  */
-export function sessionClose(args: SessionCloseArgs): Promise<void> {
-  return invoke<void>('session_close', { args });
+export function sessionClose(args: SessionCloseArgs): Promise<SessionCloseResult> {
+  return invoke<SessionCloseResult>('session_close', { args });
 }
 
 /**

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -56,6 +56,19 @@ export interface SessionIdArg {
   sessionId: SessionId;
 }
 
+/**
+ * Arguments for `session_close`. The optional `deleteWorktree` flag asks
+ * the backend to run `git worktree remove --force` on the session's
+ * worktree after the PTY is torn down. The backend refuses to delete the
+ * configured workspace root (main worktree).
+ *
+ * MIRROR: `src-tauri/src/types.rs::SessionCloseArgs`.
+ */
+export interface SessionCloseArgs {
+  sessionId: SessionId;
+  deleteWorktree?: boolean;
+}
+
 export interface SessionResizeArgs {
   sessionId: SessionId;
   cols: number;
@@ -103,9 +116,11 @@ export function sessionList(): Promise<SessionView[]> {
 /**
  * Kill the PTY child, drop the persisted session record, and trim the
  * session out of `lastOpenSessions`/`tabOrder`/`activeSessionId`. Idempotent
- * for already-exited sessions.
+ * for already-exited sessions. When `deleteWorktree` is `true`, the backend
+ * additionally runs `git worktree remove --force` on the session's
+ * worktree.
  */
-export function sessionClose(args: SessionIdArg): Promise<void> {
+export function sessionClose(args: SessionCloseArgs): Promise<void> {
   return invoke<void>('session_close', { args });
 }
 

--- a/src/lib/workspace-switch.ts
+++ b/src/lib/workspace-switch.ts
@@ -16,7 +16,7 @@ export async function changeWorkspace(path: string): Promise<void> {
   const failures: string[] = [];
   for (const session of sessions) {
     try {
-      await actions.close(session.id);
+      await actions.close(session.id, false, { pruneOnError: false });
     } catch (err) {
       failures.push(session.label);
       console.error('Failed to close session before workspace switch', session.id, err);

--- a/src/store/session-store.test.ts
+++ b/src/store/session-store.test.ts
@@ -516,7 +516,9 @@ describe('close + metrics', () => {
         a: { sessionId: 'a', contextUsedPct: 50, observedAt: 1 },
       },
     });
-    bridgeMock.sessionClose.mockImplementation(() => Promise.resolve());
+    bridgeMock.sessionClose.mockImplementation(() =>
+      Promise.resolve({ worktreeDeleteError: null }),
+    );
     await useSessionStore.getState().actions.close('a');
     expect(useSessionStore.getState().metrics['a']).toBeUndefined();
   });

--- a/src/store/session-store.test.ts
+++ b/src/store/session-store.test.ts
@@ -159,6 +159,46 @@ describe('close', () => {
 
     expect(useSessionStore.getState().pendingClose).toBeUndefined();
   });
+
+  it('prunes the session locally even when the backend close rejects', async () => {
+    useSessionStore.setState({
+      sessions: [makeView({ id: 'a' }), makeView({ id: 'b' })],
+      activeId: 'a',
+    });
+    bridgeMock.sessionClose.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(useSessionStore.getState().actions.close('a')).rejects.toThrow('boom');
+
+    expect(useSessionStore.getState().sessions.map((s) => s.id)).toEqual(['b']);
+  });
+
+  it('keeps the session visible when the backend close rejects and pruneOnError is false', async () => {
+    useSessionStore.setState({
+      sessions: [makeView({ id: 'a' }), makeView({ id: 'b' })],
+      activeId: 'a',
+    });
+    bridgeMock.sessionClose.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(
+      useSessionStore.getState().actions.close('a', false, { pruneOnError: false }),
+    ).rejects.toThrow('boom');
+
+    // Session row remains so the caller (e.g. workspace switch) can ask
+    // the user to resolve and retry.
+    expect(useSessionStore.getState().sessions.map((s) => s.id)).toEqual(['a', 'b']);
+    expect(useSessionStore.getState().activeId).toBe('a');
+  });
+
+  it('still prunes on success even with pruneOnError: false', async () => {
+    useSessionStore.setState({
+      sessions: [makeView({ id: 'a' }), makeView({ id: 'b' })],
+      activeId: 'a',
+    });
+
+    await useSessionStore.getState().actions.close('a', false, { pruneOnError: false });
+
+    expect(useSessionStore.getState().sessions.map((s) => s.id)).toEqual(['b']);
+  });
 });
 
 describe('focus', () => {

--- a/src/store/session-store.test.ts
+++ b/src/store/session-store.test.ts
@@ -103,7 +103,7 @@ describe('close', () => {
 
     await useSessionStore.getState().actions.close('a');
 
-    expect(bridgeMock.sessionClose).toHaveBeenCalledWith({ sessionId: 'a' });
+    expect(bridgeMock.sessionClose).toHaveBeenCalledWith({ sessionId: 'a', deleteWorktree: false });
     expect(useSessionStore.getState().sessions.map((s) => s.id)).toEqual(['b']);
   });
 

--- a/src/store/session-store.ts
+++ b/src/store/session-store.ts
@@ -87,7 +87,7 @@ export type SessionActivity = 'working' | 'idle' | 'attention';
 export interface SessionStoreActions {
   hydrate: () => Promise<void>;
   create: (args: SessionCreateArgs) => Promise<SessionView>;
-  close: (id: SessionId) => Promise<void>;
+  close: (id: SessionId, deleteWorktree?: boolean) => Promise<void>;
   focus: (id: SessionId) => Promise<void>;
   reorder: (ids: SessionId[]) => Promise<void>;
   requestClose: (id: SessionId) => void;
@@ -170,8 +170,8 @@ export const useSessionStore = create<Store>((set, get) => {
       return view;
     },
 
-    close: async (id) => {
-      await sessionClose({ sessionId: id });
+    close: async (id, deleteWorktree) => {
+      await sessionClose({ sessionId: id, deleteWorktree: deleteWorktree ?? false });
       const previous = get().sessions;
       const wasActive = get().activeId === id;
       const nextSessions = previous.filter((s) => s.id !== id);

--- a/src/store/session-store.ts
+++ b/src/store/session-store.ts
@@ -180,21 +180,28 @@ export const useSessionStore = create<Store>((set, get) => {
       // failures arrive as a non-throwing `worktreeDeleteError` field;
       // hard backend failures still propagate to the caller AFTER local
       // pruning.
-      const previous = get().sessions;
-      const wasActive = get().activeId === id;
       const pruneLocal = (): void => {
-        const nextSessions = previous.filter((s) => s.id !== id);
+        // Read state *inside* the prune so we don't clobber any
+        // concurrent updates (e.g. a session created while sessionClose
+        // was in flight).
+        const { sessions, activeId, pendingClose, statusMessages, hasUnread, activity, metrics } =
+          get();
+        if (!sessions.some((s) => s.id === id)) {
+          // Already pruned by some other path — nothing to do.
+          return;
+        }
+        const wasActive = activeId === id;
+        const nextSessions = sessions.filter((s) => s.id !== id);
         const patch: Partial<SessionStoreState> = { sessions: nextSessions };
         if (wasActive) {
           // Always assign explicitly so `activeId` is cleared when the last
           // session closes.
-          patch.activeId = pickNeighbour(previous, id);
+          patch.activeId = pickNeighbour(sessions, id);
         }
         // `pendingClose` is closed automatically when the session it
         // referenced is gone.
-        if (get().pendingClose === id) patch.pendingClose = undefined;
+        if (pendingClose === id) patch.pendingClose = undefined;
         // Drop any orphan status-message keyed under this session id.
-        const { statusMessages, hasUnread, activity, metrics } = get();
         if (id in statusMessages) {
           const next = { ...statusMessages };
           delete next[id];

--- a/src/store/session-store.ts
+++ b/src/store/session-store.ts
@@ -30,6 +30,7 @@ import {
   sessionCreate,
   sessionFocus,
   sessionList,
+  type SessionCloseResult,
   type SessionCreateArgs,
 } from '@/lib/tauri-bridge';
 import type {
@@ -87,7 +88,7 @@ export type SessionActivity = 'working' | 'idle' | 'attention';
 export interface SessionStoreActions {
   hydrate: () => Promise<void>;
   create: (args: SessionCreateArgs) => Promise<SessionView>;
-  close: (id: SessionId, deleteWorktree?: boolean) => Promise<void>;
+  close: (id: SessionId, deleteWorktree?: boolean) => Promise<SessionCloseResult>;
   focus: (id: SessionId) => Promise<void>;
   reorder: (ids: SessionId[]) => Promise<void>;
   requestClose: (id: SessionId) => void;
@@ -171,42 +172,61 @@ export const useSessionStore = create<Store>((set, get) => {
     },
 
     close: async (id, deleteWorktree) => {
-      await sessionClose({ sessionId: id, deleteWorktree: deleteWorktree ?? false });
+      // Always converge local state to "session gone" even if the backend
+      // call rejects. The PTY may have been killed and the persisted
+      // record removed before the failure (e.g. a transient disk error in
+      // a later step), and leaving a stale row in the sidebar is a worse
+      // UX than briefly out-of-sync with the backend. Worktree-deletion
+      // failures arrive as a non-throwing `worktreeDeleteError` field;
+      // hard backend failures still propagate to the caller AFTER local
+      // pruning.
       const previous = get().sessions;
       const wasActive = get().activeId === id;
-      const nextSessions = previous.filter((s) => s.id !== id);
-      const patch: Partial<SessionStoreState> = { sessions: nextSessions };
-      if (wasActive) {
-        // Always assign explicitly so `activeId` is cleared when the last
-        // session closes.
-        patch.activeId = pickNeighbour(previous, id);
+      const pruneLocal = (): void => {
+        const nextSessions = previous.filter((s) => s.id !== id);
+        const patch: Partial<SessionStoreState> = { sessions: nextSessions };
+        if (wasActive) {
+          // Always assign explicitly so `activeId` is cleared when the last
+          // session closes.
+          patch.activeId = pickNeighbour(previous, id);
+        }
+        // `pendingClose` is closed automatically when the session it
+        // referenced is gone.
+        if (get().pendingClose === id) patch.pendingClose = undefined;
+        // Drop any orphan status-message keyed under this session id.
+        const { statusMessages, hasUnread, activity, metrics } = get();
+        if (id in statusMessages) {
+          const next = { ...statusMessages };
+          delete next[id];
+          patch.statusMessages = next;
+        }
+        if (id in hasUnread) {
+          const nextUnread = { ...hasUnread };
+          delete nextUnread[id];
+          patch.hasUnread = nextUnread;
+        }
+        if (id in activity) {
+          const nextActivity = { ...activity };
+          delete nextActivity[id];
+          patch.activity = nextActivity;
+        }
+        if (id in metrics) {
+          const nextMetrics = { ...metrics };
+          delete nextMetrics[id];
+          patch.metrics = nextMetrics;
+        }
+        set(patch);
+      };
+
+      try {
+        const result = await sessionClose({
+          sessionId: id,
+          deleteWorktree: deleteWorktree ?? false,
+        });
+        return result;
+      } finally {
+        pruneLocal();
       }
-      // `pendingClose` is closed automatically when the session it referenced
-      // is gone.
-      if (get().pendingClose === id) patch.pendingClose = undefined;
-      // Drop any orphan status-message keyed under this session id.
-      const { statusMessages, hasUnread, activity, metrics } = get();
-      if (id in statusMessages) {
-        const next = { ...statusMessages };
-        delete next[id];
-        patch.statusMessages = next;
-      }
-      if (id in hasUnread) {
-        const nextUnread = { ...hasUnread };
-        delete nextUnread[id];
-        patch.hasUnread = nextUnread;
-      }
-      if (id in activity) {
-        const nextActivity = { ...activity };
-        delete nextActivity[id];
-        patch.activity = nextActivity;
-      }
-      if (id in metrics) {
-        const nextMetrics = { ...metrics };
-        delete nextMetrics[id];
-        patch.metrics = nextMetrics;
-      }
-      set(patch);
     },
 
     focus: async (id) => {

--- a/src/store/session-store.ts
+++ b/src/store/session-store.ts
@@ -88,7 +88,11 @@ export type SessionActivity = 'working' | 'idle' | 'attention';
 export interface SessionStoreActions {
   hydrate: () => Promise<void>;
   create: (args: SessionCreateArgs) => Promise<SessionView>;
-  close: (id: SessionId, deleteWorktree?: boolean) => Promise<SessionCloseResult>;
+  close: (
+    id: SessionId,
+    deleteWorktree?: boolean,
+    opts?: { pruneOnError?: boolean },
+  ) => Promise<SessionCloseResult>;
   focus: (id: SessionId) => Promise<void>;
   reorder: (ids: SessionId[]) => Promise<void>;
   requestClose: (id: SessionId) => void;
@@ -171,15 +175,22 @@ export const useSessionStore = create<Store>((set, get) => {
       return view;
     },
 
-    close: async (id, deleteWorktree) => {
-      // Always converge local state to "session gone" even if the backend
-      // call rejects. The PTY may have been killed and the persisted
-      // record removed before the failure (e.g. a transient disk error in
-      // a later step), and leaving a stale row in the sidebar is a worse
-      // UX than briefly out-of-sync with the backend. Worktree-deletion
-      // failures arrive as a non-throwing `worktreeDeleteError` field;
-      // hard backend failures still propagate to the caller AFTER local
-      // pruning.
+    close: async (id, deleteWorktree, opts) => {
+      // By default, converge local state to "session gone" even if the
+      // backend call rejects. The PTY may have been killed and the
+      // persisted record removed before the failure (e.g. a transient
+      // disk error in a later step), and leaving a stale row in the
+      // sidebar is a worse UX than briefly out-of-sync with the backend.
+      // Worktree-deletion failures arrive as a non-throwing
+      // `worktreeDeleteError` field; hard backend failures still
+      // propagate to the caller AFTER local pruning.
+      //
+      // Callers that need failed sessions to remain visible/retryable
+      // (e.g. the workspace-switch flow, which wants the user to resolve
+      // problems on the original workspace before changing it) can pass
+      // `{ pruneOnError: false }` to suppress the pruning side-effect on
+      // backend failure. Successful closes always prune.
+      const pruneOnError = opts?.pruneOnError ?? true;
       const pruneLocal = (): void => {
         // Read state *inside* the prune so we don't clobber any
         // concurrent updates (e.g. a session created while sessionClose
@@ -225,14 +236,18 @@ export const useSessionStore = create<Store>((set, get) => {
         set(patch);
       };
 
+      let succeeded = false;
       try {
         const result = await sessionClose({
           sessionId: id,
           deleteWorktree: deleteWorktree ?? false,
         });
+        succeeded = true;
         return result;
       } finally {
-        pruneLocal();
+        if (succeeded || pruneOnError) {
+          pruneLocal();
+        }
       }
     },
 


### PR DESCRIPTION
## Summary
Adds an opt-in `Also delete the worktree directory` checkbox to the close-confirm dialog. When ticked, after the PTY is killed and the session record removed, the backend runs `git worktree remove --force` on the session's worktree.

## Safety guards in `delete_worktree_after_close`
- Requires a configured `workspace_root` (no fallback to the worktree as cwd — that breaks on Windows since the OS locks a process's CWD).
- Refuses if the canonical worktree path equals the workspace root (main checkout).
- Refuses if the canonical worktree path is not contained under the workspace root (defends against corrupted session records).
- Refuses if any other live session still references the same worktree.

## Plumbing
- New `SessionCloseArgs { sessionId, deleteWorktree }` (`SessionIdArg` retained for focus/restart).
- `GitRunner::remove_worktree` added to the trait + `RealGitRunner` impl.
- Bridge -> store -> dialog wiring; dialog resets the checkbox each open.
- DESIGN.md S6 row for `session_close` updated.

## Tests
- 6 backend tests in `session_lifecycle_fake.rs` (invoke, no-invoke, main-root refusal, outside-root refusal, no-workspace-root refusal, git-failure propagation).
- 2 frontend tests in `Sidebar.test.tsx` (checkbox passes flag through; checkbox resets between opens).
- All existing tests updated for new arg shape.

## Verification
`cargo test` (all suites green) - `cargo clippy -D warnings` clean - `cargo fmt` - `npm run lint` - `vitest run` (207 pass).