### PR TITLE
feat(sidebar): icon-based session status driven by OTel turn events

### DIFF
--- a/src-tauri/src/activity.rs
+++ b/src-tauri/src/activity.rs
@@ -76,6 +76,11 @@ pub enum ActivityEvent {
     /// `OSC 133;D[;<exit>]` — command ended with optional exit code.
     /// Future-proofed.
     CommandEnd { exit: Option<i32> },
+    /// An agent turn just completed. Emitted by the per-tool metrics
+    /// watcher (Copilot OTel `invoke_agent` span close; Claude transcript
+    /// `assistant`-line arrival), not by the PTY-stream scanner. Carries
+    /// the wall-clock duration of the turn when the source provides it.
+    TurnEnd { duration_ms: Option<u64> },
 }
 
 #[derive(Debug)]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -268,6 +268,24 @@ pub fn build_production_metrics_emit(app: tauri::AppHandle) -> crate::session_me
     })
 }
 
+/// Build the production turn-end emitter — fires a
+/// [`crate::activity::ActivityEvent::TurnEnd`] over the existing
+/// `session://activity` channel so the frontend's activity reducer
+/// handles it the same way as PTY-derived activity events. Tests
+/// substitute a capturing closure.
+#[must_use]
+pub fn build_production_turn_emit(app: tauri::AppHandle) -> crate::session_metrics::TurnCb {
+    Arc::new(move |session_id: SessionId, duration_ms: Option<u64>| {
+        let payload = crate::types::SessionActivityEvent {
+            session_id,
+            event: crate::activity::ActivityEvent::TurnEnd { duration_ms },
+        };
+        if let Err(e) = app.emit("session://activity", payload) {
+            tracing::debug!(session_id = %session_id, error = %e, "emit session://activity (turnEnd) failed");
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -33,7 +33,7 @@ use crate::config_store::{
 };
 use crate::git::{GitRunner, RealGitRunner};
 use crate::pty_pool::{cleanup_orphans, PtyPool, PtySink};
-use crate::session_metrics::{MetricsCb, MetricsRegistry};
+use crate::session_metrics::{MetricsCb, MetricsRegistry, TurnCb};
 use crate::types::{
     AppError, Error, InstructionSet, PartialAppConfig, Session, SessionCreateArgs, SessionId,
     SessionInputArgs, SessionResizeArgs, SessionStatus, SessionView, Tool,
@@ -61,6 +61,12 @@ pub struct AppContext {
     /// Production wires this into `app.emit("session://metrics", …)`;
     /// tests substitute a capturing closure.
     pub metrics_emit: MetricsCb,
+    /// Callback the metrics watchers invoke when an agent turn completes
+    /// (Copilot OTel `invoke_agent` close; Claude transcript assistant
+    /// line). Production wires this into the existing
+    /// `session://activity` channel as a `TurnEnd` variant; tests
+    /// substitute a capturing closure.
+    pub turn_emit: TurnCb,
 }
 
 impl AppContext {
@@ -71,6 +77,7 @@ impl AppContext {
         sink: PtySink,
         git_runner: Arc<dyn GitRunner>,
         metrics_emit: MetricsCb,
+        turn_emit: TurnCb,
     ) -> Self {
         Self {
             pool,
@@ -80,6 +87,7 @@ impl AppContext {
             restored: AtomicBool::new(false),
             metrics: Arc::new(MetricsRegistry::new()),
             metrics_emit,
+            turn_emit,
         }
     }
 
@@ -89,7 +97,14 @@ impl AppContext {
     /// fake [`GitRunner`].
     #[must_use]
     pub fn with_real_git(pool: Arc<PtyPool>, store: ConfigStore, sink: PtySink) -> Self {
-        Self::new(pool, store, sink, Arc::new(RealGitRunner), Arc::new(|_| {}))
+        Self::new(
+            pool,
+            store,
+            sink,
+            Arc::new(RealGitRunner),
+            Arc::new(|_| {}),
+            Arc::new(|_, _| {}),
+        )
     }
 }
 
@@ -214,6 +229,7 @@ pub fn session_create_impl(
         session.worktree_path.clone(),
         SystemTime::now(),
         Arc::clone(&ctx.metrics_emit),
+        Arc::clone(&ctx.turn_emit),
     );
 
     info!(session_id = %session.id, pid, label = %label, "session created");
@@ -382,6 +398,7 @@ pub fn session_restart_impl(ctx: &AppContext, id: SessionId) -> Result<(), AppEr
         session.worktree_path.clone(),
         SystemTime::now(),
         Arc::clone(&ctx.metrics_emit),
+        Arc::clone(&ctx.turn_emit),
     );
     Ok(())
 }
@@ -467,6 +484,7 @@ pub fn restore_all_sessions(ctx: &AppContext) {
                     session.worktree_path.clone(),
                     SystemTime::now(),
                     Arc::clone(&ctx.metrics_emit),
+                    Arc::clone(&ctx.turn_emit),
                 );
             }
             Err(e) => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -125,6 +125,7 @@ pub fn run() {
             )));
             let sink = commands::build_production_sink(app.handle().clone(), store.clone());
             let metrics_emit = commands::build_production_metrics_emit(app.handle().clone());
+            let turn_emit = commands::build_production_turn_emit(app.handle().clone());
             let git_runner: std::sync::Arc<dyn git::GitRunner> =
                 std::sync::Arc::new(git::RealGitRunner);
             let ctx = std::sync::Arc::new(commands::AppContext::new(
@@ -133,6 +134,7 @@ pub fn run() {
                 sink,
                 git_runner,
                 metrics_emit,
+                turn_emit,
             ));
             app.manage(ctx);
             Ok(())

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -85,6 +85,17 @@ pub const POLL_INTERVAL: Duration = Duration::from_millis(2000);
 /// channel sender.
 pub type MetricsCb = Arc<dyn Fn(SessionMetricsEvent) + Send + Sync>;
 
+/// Callback the watcher invokes when an agent turn completes. Production
+/// wires this into `app.emit("session://activity", { kind: "turnEnd", ... })`
+/// via [`crate::activity::ActivityEvent::TurnEnd`]. Tests pass a channel
+/// sender.
+///
+/// `duration_ms` is the wall-clock duration of the turn when the source
+/// reports it (Copilot OTel `invoke_agent` span), or `None` when it does
+/// not (Claude transcript — we only see per-message timestamps, not a
+/// reliable turn-start marker).
+pub type TurnCb = Arc<dyn Fn(SessionId, Option<u64>) + Send + Sync>;
+
 /// Per-session running watcher handle. Drop semantics: clearing the
 /// `running` flag stops the watcher thread on its next poll iteration; the
 /// thread's `JoinHandle` is detached so dropping the registry entry never
@@ -122,6 +133,7 @@ impl MetricsRegistry {
         cwd: PathBuf,
         spawn_instant: SystemTime,
         emit: MetricsCb,
+        emit_turn: TurnCb,
     ) -> bool {
         // Stop any existing watcher first so the per-tool worker starts
         // from a clean slate (used by session restart).
@@ -145,6 +157,7 @@ impl MetricsRegistry {
                             cwd_for_thread,
                             spawn_instant,
                             emit,
+                            emit_turn,
                             running_for_thread,
                         );
                     })
@@ -154,7 +167,13 @@ impl MetricsRegistry {
                 thread::Builder::new()
                     .name(format!("arborist-metrics-{}", session_id))
                     .spawn(move || {
-                        run_copilot_watcher(session_id, otel_path, emit, running_for_thread);
+                        run_copilot_watcher(
+                            session_id,
+                            otel_path,
+                            emit,
+                            emit_turn,
+                            running_for_thread,
+                        );
                     })
             }
         };
@@ -210,6 +229,7 @@ fn run_claude_watcher(
     cwd: PathBuf,
     spawn_instant: SystemTime,
     emit: MetricsCb,
+    emit_turn: TurnCb,
     running: Arc<AtomicBool>,
 ) {
     let project_dir = home.join(".claude").join("projects").join(encode_cwd(&cwd));
@@ -252,6 +272,11 @@ fn run_claude_watcher(
                             if let Some(m) = model {
                                 last_model = Some(m);
                             }
+                            // Each new assistant line is one completed agent
+                            // turn. Claude's transcript does not carry a
+                            // reliable turn-start timestamp distinct from
+                            // the user message, so duration is omitted.
+                            emit_turn(session_id, None);
                         }
                     });
                 }
@@ -285,6 +310,7 @@ fn run_copilot_watcher(
     session_id: SessionId,
     otel_path: PathBuf,
     emit: MetricsCb,
+    emit_turn: TurnCb,
     running: Arc<AtomicBool>,
 ) {
     let mut state = CopilotState::default();
@@ -305,6 +331,9 @@ fn run_copilot_watcher(
             if len > cursor {
                 cursor = tail_lines(&otel_path, cursor, len, |line| {
                     ingest_otel_line(line, &mut state);
+                    if let Some(d) = parse_invoke_agent_duration_ms(line) {
+                        emit_turn(session_id, Some(d));
+                    }
                 });
             }
         }
@@ -790,6 +819,43 @@ pub(crate) fn ingest_otel_line(line: &[u8], state: &mut CopilotState) {
     state.seen = true;
 }
 
+/// Extract the wall-clock duration of an `invoke_agent` span (one full
+/// agent turn) in milliseconds. Returns `None` for any other line — chat
+/// spans, metric lines, malformed JSON — so the caller can call this on
+/// every JSONL line it tails.
+///
+/// We deliberately key on `invoke_agent` (not `chat`): one agent turn can
+/// involve multiple `chat` round-trips, but exactly one `invoke_agent`.
+/// This matches the user's intuition of "the agent finished" — the icon
+/// flips to *awaiting* on the outer span close, not on each LLM hop.
+pub(crate) fn parse_invoke_agent_duration_ms(line: &[u8]) -> Option<u64> {
+    #[derive(Deserialize)]
+    struct Outer {
+        #[serde(default)]
+        r#type: String,
+        #[serde(default)]
+        name: String,
+        #[serde(default, rename = "startTime")]
+        start_time: Option<[u64; 2]>,
+        #[serde(default, rename = "endTime")]
+        end_time: Option<[u64; 2]>,
+    }
+    let outer: Outer = serde_json::from_slice(line).ok()?;
+    if outer.r#type != "span" || outer.name != "invoke_agent" {
+        return None;
+    }
+    let start = outer.start_time?;
+    let end = outer.end_time?;
+    // OTel times are `[seconds, nanos]`. Compute `end - start` in ns,
+    // saturating at 0 (some test/edge writers can produce slightly out-of-
+    // order timestamps).
+    let start_ns = start[0]
+        .saturating_mul(1_000_000_000)
+        .saturating_add(start[1]);
+    let end_ns = end[0].saturating_mul(1_000_000_000).saturating_add(end[1]);
+    Some(end_ns.saturating_sub(start_ns) / 1_000_000)
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -1000,12 +1066,14 @@ mod tests {
         let reg = MetricsRegistry::new();
         let id = SessionId::new();
         let cb: MetricsCb = Arc::new(|_| {});
+        let turn_cb: TurnCb = Arc::new(|_, _| {});
         let started = reg.start(
             id,
             Tool::Copilot,
             PathBuf::from("/tmp"),
             SystemTime::now(),
             cb,
+            turn_cb,
         );
         assert!(started, "Copilot watcher must start");
         assert!(
@@ -1208,6 +1276,59 @@ mod tests {
         assert!(snap.context_tokens_limit.is_none());
     }
 
+    #[test]
+    fn parse_invoke_agent_duration_extracts_ms() {
+        // Real fixture: invoke_agent span starts at [1777474197, 905_000_000]
+        // and ends at [1777474200, 749_237_700]. Difference is
+        // 2_844_237_700 ns ≈ 2844 ms.
+        let line = fixture_lines()
+            .into_iter()
+            .find(|l| {
+                let needle = b"invoke_agent";
+                l.starts_with(br#"{"type":"span","traceId"#)
+                    && l.windows(needle.len()).any(|w| w == needle)
+            })
+            .expect("invoke_agent span in fixture");
+        let ms = parse_invoke_agent_duration_ms(line).expect("duration parsed");
+        assert!(
+            (2_840..=2_850).contains(&ms),
+            "duration_ms ~= 2844, got {ms}",
+        );
+    }
+
+    #[test]
+    fn parse_invoke_agent_duration_ignores_chat_span() {
+        // chat <model> spans are excluded — they are LLM round-trips, not
+        // turn boundaries.
+        let line = fixture_lines()
+            .into_iter()
+            .find(|l| {
+                let needle: &[u8] = br#""name":"chat "#;
+                l.starts_with(br#"{"type":"span","#) && l.windows(needle.len()).any(|w| w == needle)
+            })
+            .expect("chat span in fixture");
+        assert!(parse_invoke_agent_duration_ms(line).is_none());
+    }
+
+    #[test]
+    fn parse_invoke_agent_duration_ignores_metric_lines() {
+        let line = b"{\"type\":\"metric\",\"name\":\"gen_ai.client.token.usage\"}";
+        assert!(parse_invoke_agent_duration_ms(line).is_none());
+    }
+
+    #[test]
+    fn parse_invoke_agent_duration_handles_missing_times() {
+        let line = br#"{"type":"span","name":"invoke_agent"}"#;
+        assert!(parse_invoke_agent_duration_ms(line).is_none());
+    }
+
+    #[test]
+    fn parse_invoke_agent_duration_saturates_for_inverted_times() {
+        // Defensive: out-of-order timestamps must yield 0, not panic.
+        let line = br#"{"type":"span","name":"invoke_agent","startTime":[10,0],"endTime":[5,0]}"#;
+        assert_eq!(parse_invoke_agent_duration_ms(line), Some(0));
+    }
+
     // -- Copilot watcher integration -------------------------------------
 
     /// Run a Copilot watcher against an evolving JSONL file in a tempdir.
@@ -1234,7 +1355,13 @@ mod tests {
         });
         let path_for_thread = path.clone();
         let handle = std::thread::spawn(move || {
-            run_copilot_watcher(session_id, path_for_thread, cb, running_for_thread);
+            run_copilot_watcher(
+                session_id,
+                path_for_thread,
+                cb,
+                Arc::new(|_, _| {}),
+                running_for_thread,
+            );
         });
 
         // Append the fixture (one chat span + invoke_agent + metrics) and
@@ -1250,6 +1377,49 @@ mod tests {
         assert_eq!(snap.model.as_deref(), Some("claude-opus-4.7"));
 
         // Shut the watcher down.
+        running.store(false, Ordering::SeqCst);
+        handle.join().expect("watcher thread joined");
+    }
+
+    #[test]
+    fn copilot_watcher_emits_turn_end_for_invoke_agent_span() {
+        use std::sync::mpsc;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("otel.jsonl");
+        std::fs::write(&path, b"").unwrap();
+
+        let session_id = SessionId::new();
+        let running = Arc::new(AtomicBool::new(true));
+        let running_for_thread = Arc::clone(&running);
+        let (tx, rx) = mpsc::channel::<(SessionId, Option<u64>)>();
+        let metrics_cb: MetricsCb = Arc::new(|_| {});
+        let turn_cb: TurnCb = Arc::new(move |sid, dur| {
+            let _ = tx.send((sid, dur));
+        });
+        let path_for_thread = path.clone();
+        let handle = std::thread::spawn(move || {
+            run_copilot_watcher(
+                session_id,
+                path_for_thread,
+                metrics_cb,
+                turn_cb,
+                running_for_thread,
+            );
+        });
+
+        // The full fixture contains exactly one invoke_agent span.
+        std::fs::write(&path, COPILOT_OTEL_FIXTURE).unwrap();
+        let (sid, dur) = rx
+            .recv_timeout(Duration::from_secs(8))
+            .expect("watcher emitted turn-end");
+        assert_eq!(sid, session_id);
+        let dur = dur.expect("invoke_agent carries a duration");
+        assert!(
+            (2_840..=2_850).contains(&dur),
+            "expected ~2844ms duration, got {dur}",
+        );
+
         running.store(false, Ordering::SeqCst);
         handle.join().expect("watcher thread joined");
     }
@@ -1271,7 +1441,13 @@ mod tests {
         });
         let path_for_thread = path.clone();
         let handle = std::thread::spawn(move || {
-            run_copilot_watcher(session_id, path_for_thread, cb, running_for_thread);
+            run_copilot_watcher(
+                session_id,
+                path_for_thread,
+                cb,
+                Arc::new(|_, _| {}),
+                running_for_thread,
+            );
         });
 
         // 1) Initial usage from the full fixture.
@@ -1476,6 +1652,7 @@ mod tests {
                 cwd_for_thread,
                 spawn_instant,
                 cb,
+                Arc::new(|_, _| {}),
                 running_for_thread,
             );
         });

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -331,8 +331,15 @@ fn run_copilot_watcher(
             if len > cursor {
                 cursor = tail_lines(&otel_path, cursor, len, |line| {
                     ingest_otel_line(line, &mut state);
-                    if let Some(d) = parse_invoke_agent_duration_ms(line) {
-                        emit_turn(session_id, Some(d));
+                    // Cheap byte-level pre-filter — we don't want to
+                    // re-parse every JSONL line as JSON just to discover
+                    // it isn't an `invoke_agent` span. Real Copilot OTel
+                    // logs are dominated by metric/log lines, so this
+                    // saves a full serde_json::from_slice on the hot path.
+                    if maybe_invoke_agent_span(line) {
+                        if let Some(d) = parse_invoke_agent_duration_ms(line) {
+                            emit_turn(session_id, Some(d));
+                        }
                     }
                 });
             }
@@ -856,6 +863,20 @@ pub(crate) fn parse_invoke_agent_duration_ms(line: &[u8]) -> Option<u64> {
     Some(end_ns.saturating_sub(start_ns) / 1_000_000)
 }
 
+/// Cheap byte-level prefilter used to skip a full JSON parse on the
+/// majority of OTel lines (metrics, logs, chat spans). Tolerates either
+/// `"name":"invoke_agent"` or `"name": "invoke_agent"` spacing — real
+/// emitters use the compact form, but the OTel SDK is allowed to insert
+/// a space and we'd rather over-accept here and let
+/// [`parse_invoke_agent_duration_ms`] reject than miss a legitimate
+/// turn-end.
+fn maybe_invoke_agent_span(line: &[u8]) -> bool {
+    fn contains(hay: &[u8], needle: &[u8]) -> bool {
+        hay.len() >= needle.len() && hay.windows(needle.len()).any(|w| w == needle)
+    }
+    contains(line, b"\"invoke_agent\"")
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -1327,6 +1348,24 @@ mod tests {
         // Defensive: out-of-order timestamps must yield 0, not panic.
         let line = br#"{"type":"span","name":"invoke_agent","startTime":[10,0],"endTime":[5,0]}"#;
         assert_eq!(parse_invoke_agent_duration_ms(line), Some(0));
+    }
+
+    #[test]
+    fn maybe_invoke_agent_span_skips_unrelated_lines() {
+        // The cheap prefilter must reject anything that doesn't even
+        // mention "invoke_agent" — that's the whole point of avoiding a
+        // serde_json::from_slice on the hot path.
+        assert!(!maybe_invoke_agent_span(b""));
+        assert!(!maybe_invoke_agent_span(b"{\"type\":\"metric\"}"));
+        assert!(!maybe_invoke_agent_span(
+            br#"{"type":"span","name":"chat claude-opus"}"#
+        ));
+    }
+
+    #[test]
+    fn maybe_invoke_agent_span_admits_real_invoke_agent_lines() {
+        let line = br#"{"type":"span","name":"invoke_agent","startTime":[1,0],"endTime":[2,0]}"#;
+        assert!(maybe_invoke_agent_span(line));
     }
 
     // -- Copilot watcher integration -------------------------------------

--- a/src-tauri/tests/workspace_command.rs
+++ b/src-tauri/tests/workspace_command.rs
@@ -85,6 +85,7 @@ fn build_ctx(git: Arc<dyn GitRunner>, store_dir: &TempDir) -> Arc<AppContext> {
         null_sink(),
         git,
         Arc::new(|_| {}),
+        Arc::new(|_, _| {}),
     ))
 }
 

--- a/src-tauri/tests/worktrees_command.rs
+++ b/src-tauri/tests/worktrees_command.rs
@@ -68,6 +68,7 @@ fn build_ctx(git: Arc<dyn GitRunner>, store_dir: &TempDir) -> Arc<AppContext> {
         null_sink(),
         git,
         Arc::new(|_| {}),
+        Arc::new(|_, _| {}),
     ))
 }
 

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -283,6 +283,26 @@ describe('Sidebar', () => {
   });
 });
 
+describe('Sidebar unread accessibility', () => {
+  it("appends '(unread output)' to inactive tabs' aria-label so screen readers hear it", () => {
+    seed([makeView('a'), makeView('b')], 'b');
+    useSessionStore.setState({ hasUnread: { a: true } });
+    render(<Sidebar />);
+    expect(tabByLabel('claude session a')).toHaveAttribute(
+      'aria-label',
+      'claude session a (unread output)',
+    );
+    // Active tab never carries the unread suffix — focusing it clears the flag.
+    expect(tabByLabel('claude session b')).toHaveAttribute('aria-label', 'claude session b');
+  });
+
+  it('does not append the suffix when hasUnread is false', () => {
+    seed([makeView('a')], 'a');
+    render(<Sidebar />);
+    expect(tabByLabel('claude session a')).toHaveAttribute('aria-label', 'claude session a');
+  });
+});
+
 describe('Sidebar metrics indicator (Issue #3)', () => {
   it('renders a compact metrics line under the label when metrics are present', () => {
     seed([makeView('a')], 'a');

--- a/src/components/SidebarTab.tsx
+++ b/src/components/SidebarTab.tsx
@@ -9,13 +9,17 @@
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
+import { StatusIcon } from './StatusIcon';
 import { ToolIcon } from './ToolIcon';
 import {
-  useActivity,
+  useDisplayStatus,
   useHasUnread,
+  useLastTurnDurationMs,
+  useLastTurnEndAt,
   useMetrics,
   useSessionActions,
   useSessionById,
+  type DisplayStatus,
 } from '@/store/session-store';
 import type { SessionId, SessionMetrics, Tool } from '@/types/arborist';
 
@@ -34,7 +38,9 @@ export function SidebarTab({
 }: SidebarTabProps): JSX.Element | null {
   const session = useSessionById(id);
   const hasUnread = useHasUnread(id);
-  const activity = useActivity(id);
+  const displayStatus = useDisplayStatus(id);
+  const lastTurnEndAt = useLastTurnEndAt(id);
+  const lastTurnDurationMs = useLastTurnDurationMs(id);
   const metrics = useMetrics(id);
   const actions = useSessionActions();
 
@@ -83,53 +89,12 @@ export function SidebarTab({
             }
           />
           <span className="min-w-0 flex-1 truncate">{session.label}</span>
-          {activity === 'attention' && session.status !== 'error' && (
-            <span
-              role="img"
-              aria-label="Attention required"
-              data-testid="status-attention"
-              className="h-2 w-2 shrink-0 rounded-full bg-amber-500"
-            />
-          )}
-          {activity === 'working' && session.status === 'running' && (
-            <span
-              role="img"
-              aria-label="Working"
-              data-testid="status-working"
-              className="h-2 w-2 shrink-0 animate-pulse rounded-full bg-emerald-500"
-            />
-          )}
-          {hasUnread && !isActive && session.status !== 'error' && activity !== 'attention' && (
-            <span
-              role="img"
-              aria-label="Unread output"
-              data-testid="status-unread"
-              className="h-2 w-2 shrink-0 rounded-full bg-sky-500"
-            />
-          )}
-          {session.status === 'starting' && (
-            <span
-              role="img"
-              aria-label="Starting"
-              data-testid="status-starting"
-              className="h-2.5 w-2.5 shrink-0 animate-pulse rounded-full border-2 border-sky-500 border-t-transparent"
-            />
-          )}
-          {session.status === 'exited' && (
-            <span
-              role="img"
-              aria-label="Exited"
-              data-testid="status-exited"
-              className="h-2 w-2 shrink-0 rounded-full bg-slate-400 dark:bg-slate-500"
-            />
-          )}
-          {session.status === 'error' && (
-            <span
-              role="img"
-              aria-label="Error"
-              className="h-2 w-2 shrink-0 rounded-full bg-red-500"
-            />
-          )}
+          <SessionStatusIndicator
+            status={displayStatus}
+            hasUnread={hasUnread && !isActive}
+            lastTurnEndAt={lastTurnEndAt}
+            lastTurnDurationMs={lastTurnDurationMs}
+          />
         </span>
         <MetricsLine
           metrics={session.status === 'running' ? metrics : undefined}
@@ -239,4 +204,125 @@ function formatTokens(n: number): string {
   if (n < 1000) return String(n);
   const k = n / 1000;
   return k >= 100 ? `${Math.round(k)}k` : `${k.toFixed(1).replace(/\.0$/, '')}k`;
+}
+
+// ---------------------------------------------------------------------------
+// SessionStatusIndicator — single icon glyph for the derived display state,
+// plus a small unread-overlay dot when the tab has unseen output. The icon
+// owns the per-state colour and animation; the unread dot is a separate
+// element so the two stack naturally.
+// ---------------------------------------------------------------------------
+
+interface SessionStatusIndicatorProps {
+  status: DisplayStatus;
+  hasUnread: boolean;
+  lastTurnEndAt: number | undefined;
+  lastTurnDurationMs: number | undefined;
+}
+
+function SessionStatusIndicator({
+  status,
+  hasUnread,
+  lastTurnEndAt,
+  lastTurnDurationMs,
+}: SessionStatusIndicatorProps): JSX.Element | null {
+  const iconClasses = statusIconClasses(status);
+  const tooltip = statusTooltip(status, lastTurnEndAt, lastTurnDurationMs);
+
+  // When the icon collapses to nothing (idle), still show the unread dot
+  // on its own so the user has *some* signal that output arrived.
+  if (status === 'idle') {
+    return hasUnread ? (
+      <span
+        role="img"
+        aria-label="Unread output"
+        data-testid="status-unread"
+        className="h-2 w-2 shrink-0 rounded-full bg-sky-500"
+      />
+    ) : null;
+  }
+
+  return (
+    <span className="relative inline-flex shrink-0">
+      <StatusIcon status={status} title={tooltip} className={iconClasses} />
+      {hasUnread && status !== 'attention' && status !== 'error' && (
+        <span
+          aria-hidden="true"
+          data-testid="status-unread"
+          className="absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full bg-sky-500 ring-1 ring-white dark:ring-slate-900"
+        />
+      )}
+    </span>
+  );
+}
+
+function statusIconClasses(status: DisplayStatus): string {
+  // Uniform geometry; only color and animation vary by state.
+  const base = 'h-3.5 w-3.5 shrink-0';
+  switch (status) {
+    case 'starting':
+      return `${base} animate-spin text-sky-500`;
+    case 'working':
+      return `${base} animate-pulse text-emerald-500`;
+    case 'awaiting':
+      return `${base} text-sky-500 dark:text-sky-400`;
+    case 'attention':
+      return `${base} text-amber-500`;
+    case 'exited':
+      return `${base} text-slate-400 dark:text-slate-500`;
+    case 'error':
+      return `${base} text-red-500`;
+    case 'idle':
+      return base;
+  }
+}
+
+function statusTooltip(
+  status: DisplayStatus,
+  lastTurnEndAt: number | undefined,
+  lastTurnDurationMs: number | undefined,
+): string {
+  const headline = (() => {
+    switch (status) {
+      case 'starting':
+        return 'Starting';
+      case 'working':
+        return 'Working';
+      case 'awaiting':
+        return 'Awaiting input';
+      case 'attention':
+        return 'Attention required';
+      case 'exited':
+        return 'Exited';
+      case 'error':
+        return 'Error';
+      case 'idle':
+        return 'Idle';
+    }
+  })();
+
+  const parts: string[] = [headline];
+  if (status === 'awaiting' && lastTurnEndAt !== undefined) {
+    const ageSec = Math.max(0, Math.floor(Date.now() / 1000) - lastTurnEndAt);
+    parts.push(`Last turn ${formatDuration(ageSec)} ago`);
+  }
+  if (typeof lastTurnDurationMs === 'number' && status !== 'starting' && status !== 'error') {
+    parts.push(`Took ${formatDurationMs(lastTurnDurationMs)}`);
+  }
+  return parts.join(' · ');
+}
+
+function formatDuration(sec: number): string {
+  if (sec < 60) return `${sec}s`;
+  const m = Math.floor(sec / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  return `${h}h`;
+}
+
+function formatDurationMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(s < 10 ? 1 : 0)}s`;
+  return formatDuration(Math.round(s));
 }

--- a/src/components/SidebarTab.tsx
+++ b/src/components/SidebarTab.tsx
@@ -228,21 +228,22 @@ function SessionStatusIndicator({
   lastTurnEndAt,
   lastTurnDurationMs,
 }: SessionStatusIndicatorProps): JSX.Element | null {
-  const iconClasses = statusIconClasses(status);
-  const tooltip = statusTooltip(status, lastTurnEndAt, lastTurnDurationMs);
-
   // When the icon collapses to nothing (idle), still show the unread dot
-  // on its own so the user has *some* signal that output arrived.
+  // on its own so the user has *some* signal that output arrived. The
+  // dot is decorative — the parent tab's aria-label already conveys
+  // unread state to assistive tech, so no role/aria-label here.
   if (status === 'idle') {
     return hasUnread ? (
       <span
-        role="img"
-        aria-label="Unread output"
+        aria-hidden="true"
         data-testid="status-unread"
         className="h-2 w-2 shrink-0 rounded-full bg-sky-500"
       />
     ) : null;
   }
+
+  const iconClasses = statusIconClasses(status);
+  const tooltip = statusTooltip(status, lastTurnEndAt, lastTurnDurationMs);
 
   return (
     <span className="relative inline-flex shrink-0">

--- a/src/components/SidebarTab.tsx
+++ b/src/components/SidebarTab.tsx
@@ -72,7 +72,9 @@ export function SidebarTab({
         role="tab"
         id={`session-tab-${id}`}
         aria-selected={isActive}
-        aria-label={`${session.tool} session ${session.label}`}
+        aria-label={`${session.tool} session ${session.label}${
+          hasUnread && !isActive ? ' (unread output)' : ''
+        }`}
         tabIndex={isFocused ? 0 : -1}
         onClick={() => {
           void actions.focus(id);

--- a/src/components/StatusIcon.test.tsx
+++ b/src/components/StatusIcon.test.tsx
@@ -35,4 +35,23 @@ describe('StatusIcon', () => {
     const svg = screen.getByTestId('status-icon-awaiting');
     expect(svg.querySelector('title')?.textContent).toBe('Awaiting input');
   });
+
+  it('hides the icon from assistive tech when no title is supplied', () => {
+    // Mixing aria-label with aria-hidden=true is a contradiction; the
+    // sidebar tab itself is the labelled element, so an unlabelled icon
+    // should be silently decorative.
+    render(<StatusIcon status="working" />);
+    const svg = screen.getByTestId('status-icon-working');
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+    expect(svg).not.toHaveAttribute('aria-label');
+    expect(svg).not.toHaveAttribute('role');
+  });
+
+  it('promotes to role=img and exposes aria-label when titled', () => {
+    render(<StatusIcon status="working" title="Working" />);
+    const svg = screen.getByTestId('status-icon-working');
+    expect(svg).toHaveAttribute('aria-label', 'Working');
+    expect(svg).toHaveAttribute('role', 'img');
+    expect(svg).not.toHaveAttribute('aria-hidden');
+  });
 });

--- a/src/components/StatusIcon.test.tsx
+++ b/src/components/StatusIcon.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { StatusIcon } from './StatusIcon';
+import type { DisplayStatus } from '@/store/session-store';
+
+describe('StatusIcon', () => {
+  const cases: Array<Exclude<DisplayStatus, 'idle'>> = [
+    'starting',
+    'working',
+    'awaiting',
+    'attention',
+    'exited',
+    'error',
+  ];
+
+  it.each(cases)('renders the %s glyph with a stable testid', (status) => {
+    render(<StatusIcon status={status} />);
+    expect(screen.getByTestId(`status-icon-${status}`)).toBeInTheDocument();
+  });
+
+  it('renders nothing for idle (quiescent sessions stay quiet)', () => {
+    const { container } = render(<StatusIcon status="idle" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('forwards the className to the rendered svg', () => {
+    render(<StatusIcon status="working" className="text-emerald-500" />);
+    const svg = screen.getByTestId('status-icon-working');
+    expect(svg).toHaveClass('text-emerald-500');
+  });
+
+  it('emits the title as an accessible <title> element for tooltips', () => {
+    render(<StatusIcon status="awaiting" title="Awaiting input" />);
+    const svg = screen.getByTestId('status-icon-awaiting');
+    expect(svg.querySelector('title')?.textContent).toBe('Awaiting input');
+  });
+});

--- a/src/components/StatusIcon.tsx
+++ b/src/components/StatusIcon.tsx
@@ -31,9 +31,13 @@ export function StatusIcon({ status, className, title }: StatusIconProps): JSX.E
     strokeWidth: 2,
     strokeLinecap: 'round' as const,
     strokeLinejoin: 'round' as const,
-    'aria-label': title ?? status,
+    // Provide an a11y label only when the caller supplied a meaningful
+    // tooltip; otherwise hide from assistive tech entirely (the parent
+    // tab already announces the session). Mixing aria-label with
+    // aria-hidden=true is a contradiction screen readers will warn on.
+    'aria-label': title ?? undefined,
     'aria-hidden': title ? undefined : true,
-    role: 'img',
+    role: title ? ('img' as const) : undefined,
     className,
   };
 

--- a/src/components/StatusIcon.tsx
+++ b/src/components/StatusIcon.tsx
@@ -1,0 +1,109 @@
+// Inline SVG status glyphs for the sidebar. Replaces the colored-dot
+// indicators that lived in `SidebarTab` with one icon per
+// [`DisplayStatus`]. Kept as inline SVGs (no icon-library dependency)
+// to match the convention established by `ToolIcon.tsx`.
+//
+// Each icon paints from `currentColor` so Tailwind text-color classes
+// recolour them; the per-state color is owned by the caller and is set
+// via the `className` prop. Sizes are uniform (h-3.5 w-3.5 by default
+// at the call site) so swapping states does not nudge layout.
+
+import type { DisplayStatus } from '@/store/session-store';
+
+interface StatusIconProps {
+  status: DisplayStatus;
+  className?: string;
+  /** Set as `<title>` for hover-tooltip + assistive-tech label. */
+  title?: string;
+}
+
+export function StatusIcon({ status, className, title }: StatusIconProps): JSX.Element | null {
+  // `idle` intentionally renders nothing — a quiescent session shouldn't
+  // shout at the user. Returning null keeps the icon column blank rather
+  // than reserving space for an absent glyph.
+  if (status === 'idle') return null;
+
+  const common = {
+    xmlns: 'http://www.w3.org/2000/svg',
+    viewBox: '0 0 24 24',
+    fill: 'none',
+    stroke: 'currentColor',
+    strokeWidth: 2,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+    'aria-label': title ?? status,
+    'aria-hidden': title ? undefined : true,
+    role: 'img',
+    className,
+  };
+
+  switch (status) {
+    case 'starting':
+      // Three-quarter ring with the gap pointing up-right; pairs with
+      // an `animate-spin` class supplied by the caller for the spinner
+      // effect.
+      return (
+        <svg {...common} data-testid="status-icon-starting">
+          {title ? <title>{title}</title> : null}
+          <path d="M12 3 a9 9 0 1 1 -9 9" />
+        </svg>
+      );
+
+    case 'working':
+      // Sparkles — evokes "the model is generating".
+      return (
+        <svg {...common} data-testid="status-icon-working">
+          {title ? <title>{title}</title> : null}
+          <path d="M12 3 l1.6 4.4 L18 9 l-4.4 1.6 L12 15 l-1.6-4.4 L6 9 l4.4-1.6 z" />
+          <path d="M18 14 l0.8 2.2 L21 17 l-2.2 0.8 L18 20 l-0.8-2.2 L15 17 l2.2-0.8 z" />
+        </svg>
+      );
+
+    case 'awaiting':
+      // Speech bubble — "the agent has finished and is waiting for you
+      // to say something".
+      return (
+        <svg {...common} data-testid="status-icon-awaiting">
+          {title ? <title>{title}</title> : null}
+          <path d="M4 5 h16 a1 1 0 0 1 1 1 v10 a1 1 0 0 1 -1 1 h-9 l-4 3 v-3 H4 a1 1 0 0 1 -1 -1 V6 a1 1 0 0 1 1 -1 z" />
+        </svg>
+      );
+
+    case 'attention':
+      // Bell — matches OSC 9 / OSC 777 / standalone BEL semantics.
+      return (
+        <svg {...common} data-testid="status-icon-attention">
+          {title ? <title>{title}</title> : null}
+          <path d="M6 16 V11 a6 6 0 0 1 12 0 v5 l1.5 2 H4.5 z" />
+          <path d="M10 20 a2 2 0 0 0 4 0" />
+        </svg>
+      );
+
+    case 'exited':
+      // Filled stop square — terminal-state indicator.
+      return (
+        <svg {...common} fill="currentColor" data-testid="status-icon-exited">
+          {title ? <title>{title}</title> : null}
+          <rect x="6" y="6" width="12" height="12" rx="1.5" />
+        </svg>
+      );
+
+    case 'error':
+      // Triangle with a bang — universal "something went wrong".
+      return (
+        <svg {...common} data-testid="status-icon-error">
+          {title ? <title>{title}</title> : null}
+          <path d="M12 3 L22 20 H2 z" />
+          <line x1="12" y1="10" x2="12" y2="14" />
+          <line x1="12" y1="17" x2="12" y2="17.01" />
+        </svg>
+      );
+
+    default: {
+      // Exhaustive: TS will flag a new DisplayStatus variant here.
+      const _exhaustive: never = status;
+      void _exhaustive;
+      return null;
+    }
+  }
+}

--- a/src/store/session-store.test.ts
+++ b/src/store/session-store.test.ts
@@ -546,6 +546,20 @@ describe('applyActivity (turnEnd)', () => {
     expect(useSessionStore.getState().lastTurnDurationMs['a']).toBeUndefined();
   });
 
+  it('clears a previously-recorded duration when a no-duration turn arrives', () => {
+    // Guards against tooltip showing a stale "ended in 3.4s" after an
+    // agent swap (Copilot → Claude) or a transcript-only second turn.
+    useSessionStore.setState({
+      sessions: [makeView({ id: 'a' })],
+      activeId: 'a',
+      lastTurnDurationMs: { a: 3400 },
+    });
+    useSessionStore
+      .getState()
+      .actions.applyActivity({ sessionId: 'a', kind: 'turnEnd', durationMs: null });
+    expect(useSessionStore.getState().lastTurnDurationMs['a']).toBeUndefined();
+  });
+
   it('clears a stale `working` activity flag so the icon flips to awaiting', () => {
     useSessionStore.setState({
       sessions: [makeView({ id: 'a' })],

--- a/src/store/session-store.test.ts
+++ b/src/store/session-store.test.ts
@@ -8,7 +8,7 @@ vi.mock('@/lib/tauri-bridge', async () => await import('@/lib/tauri-bridge.mock'
 import * as bridgeMock from '@/lib/tauri-bridge.mock';
 import type { SessionStatusEvent, SessionView } from '@/types/arborist';
 
-import { useSessionStore } from './session-store';
+import { useSessionStore, selectDisplayStatus, type DisplayStatus } from './session-store';
 
 function makeView(overrides: Partial<SessionView> & Pick<SessionView, 'id'>): SessionView {
   return {
@@ -34,6 +34,8 @@ function resetStore(): void {
     hasUnread: {},
     activity: {},
     metrics: {},
+    lastTurnEndAt: {},
+    lastTurnDurationMs: {},
   });
 }
 
@@ -519,5 +521,158 @@ describe('close + metrics', () => {
     bridgeMock.sessionClose.mockImplementation(() => Promise.resolve());
     await useSessionStore.getState().actions.close('a');
     expect(useSessionStore.getState().metrics['a']).toBeUndefined();
+  });
+});
+
+describe('applyActivity (turnEnd)', () => {
+  it('records the wall-clock arrival time and (when present) the source duration', () => {
+    useSessionStore.setState({ sessions: [makeView({ id: 'a' })], activeId: 'a' });
+    const beforeSec = Math.floor(Date.now() / 1000);
+    useSessionStore
+      .getState()
+      .actions.applyActivity({ sessionId: 'a', kind: 'turnEnd', durationMs: 4321 });
+    const ts = useSessionStore.getState().lastTurnEndAt['a'];
+    expect(ts).toBeDefined();
+    expect(ts!).toBeGreaterThanOrEqual(beforeSec);
+    expect(useSessionStore.getState().lastTurnDurationMs['a']).toBe(4321);
+  });
+
+  it('omits duration when the source did not provide one (Claude transcript)', () => {
+    useSessionStore.setState({ sessions: [makeView({ id: 'a' })], activeId: 'a' });
+    useSessionStore
+      .getState()
+      .actions.applyActivity({ sessionId: 'a', kind: 'turnEnd', durationMs: null });
+    expect(useSessionStore.getState().lastTurnEndAt['a']).toBeDefined();
+    expect(useSessionStore.getState().lastTurnDurationMs['a']).toBeUndefined();
+  });
+
+  it('clears a stale `working` activity flag so the icon flips to awaiting', () => {
+    useSessionStore.setState({
+      sessions: [makeView({ id: 'a' })],
+      activeId: 'a',
+      activity: { a: 'working' },
+    });
+    useSessionStore
+      .getState()
+      .actions.applyActivity({ sessionId: 'a', kind: 'turnEnd', durationMs: 100 });
+    expect(useSessionStore.getState().activity['a']).toBeUndefined();
+  });
+
+  it('does not clear an `attention` flag', () => {
+    useSessionStore.setState({
+      sessions: [makeView({ id: 'a' }), makeView({ id: 'b' })],
+      activeId: 'a',
+      activity: { b: 'attention' },
+    });
+    useSessionStore
+      .getState()
+      .actions.applyActivity({ sessionId: 'b', kind: 'turnEnd', durationMs: 100 });
+    expect(useSessionStore.getState().activity['b']).toBe('attention');
+  });
+
+  it('drops events for unknown sessions', () => {
+    useSessionStore.setState({ sessions: [makeView({ id: 'a' })], activeId: 'a' });
+    useSessionStore
+      .getState()
+      .actions.applyActivity({ sessionId: 'ghost', kind: 'turnEnd', durationMs: 100 });
+    expect(useSessionStore.getState().lastTurnEndAt).toEqual({});
+  });
+
+  it('a status restart clears lastTurnEndAt + lastTurnDurationMs', () => {
+    useSessionStore.setState({
+      sessions: [makeView({ id: 'a' })],
+      lastTurnEndAt: { a: 1700000000 },
+      lastTurnDurationMs: { a: 500 },
+    });
+    useSessionStore.getState().actions.applyStatus({ sessionId: 'a', status: 'starting' });
+    expect(useSessionStore.getState().lastTurnEndAt['a']).toBeUndefined();
+    expect(useSessionStore.getState().lastTurnDurationMs['a']).toBeUndefined();
+  });
+
+  it('close drops both lastTurnEndAt and lastTurnDurationMs', async () => {
+    useSessionStore.setState({
+      sessions: [makeView({ id: 'a' })],
+      lastTurnEndAt: { a: 1700000000 },
+      lastTurnDurationMs: { a: 500 },
+    });
+    bridgeMock.sessionClose.mockImplementation(() => Promise.resolve());
+    await useSessionStore.getState().actions.close('a');
+    expect(useSessionStore.getState().lastTurnEndAt).toEqual({});
+    expect(useSessionStore.getState().lastTurnDurationMs).toEqual({});
+  });
+});
+
+describe('selectDisplayStatus', () => {
+  // Per-state derivation table. `nowSec` is pinned so the boot grace
+  // window is deterministic.
+  const NOW = 2_000_000_000;
+
+  function setup(opts: {
+    status?: SessionView['status'];
+    activity?: 'working' | 'idle' | 'attention';
+    lastTurnEndAt?: number;
+    createdAt?: number;
+  }): void {
+    useSessionStore.setState({
+      sessions: [
+        makeView({
+          id: 'a',
+          status: opts.status ?? 'running',
+          createdAt: opts.createdAt ?? NOW - 60,
+        }),
+      ],
+      activity: opts.activity ? { a: opts.activity } : {},
+      lastTurnEndAt: opts.lastTurnEndAt !== undefined ? { a: opts.lastTurnEndAt } : {},
+    });
+  }
+
+  function status(): DisplayStatus {
+    return selectDisplayStatus('a', NOW)(useSessionStore.getState());
+  }
+
+  it('error overrides everything', () => {
+    setup({ status: 'error', activity: 'working', lastTurnEndAt: NOW - 1 });
+    expect(status()).toBe('error');
+  });
+
+  it('starting before activity', () => {
+    setup({ status: 'starting' });
+    expect(status()).toBe('starting');
+  });
+
+  it('exited before activity', () => {
+    setup({ status: 'exited', activity: 'working' });
+    expect(status()).toBe('exited');
+  });
+
+  it('attention beats working and awaiting', () => {
+    setup({ activity: 'attention', lastTurnEndAt: NOW - 1 });
+    expect(status()).toBe('attention');
+  });
+
+  it('working beats awaiting', () => {
+    setup({ activity: 'working', lastTurnEndAt: NOW - 1 });
+    expect(status()).toBe('working');
+  });
+
+  it('awaiting after a confirmed turnEnd', () => {
+    setup({ lastTurnEndAt: NOW - 10 });
+    expect(status()).toBe('awaiting');
+  });
+
+  it('awaiting for a fresh-but-quiescent session past the grace window', () => {
+    // createdAt is well outside AWAITING_GRACE_SECONDS (5s).
+    setup({ createdAt: NOW - 30 });
+    expect(status()).toBe('awaiting');
+  });
+
+  it('idle inside the grace window', () => {
+    setup({ createdAt: NOW - 1 });
+    expect(status()).toBe('idle');
+  });
+
+  it('idle when no session matches the id', () => {
+    useSessionStore.setState({ sessions: [] });
+    expect(status()).toBe('idle');
   });
 });

--- a/src/store/session-store.ts
+++ b/src/store/session-store.ts
@@ -558,11 +558,11 @@ export const useLastTurnDurationMs = (id: SessionId | undefined): number | undef
 
 /**
  * Subscribe to the derived `DisplayStatus` for `id`. Recomputes (and
- * re-renders the caller) every minute via a tick so the time-based
- * `idle → awaiting` promotion eventually fires even if no other event
- * touches the session. The 60s cadence is fine because the only
- * threshold we care about is [`AWAITING_GRACE_SECONDS`] and the
- * derivation is pure / cheap.
+ * re-renders the caller) once a second via a tick so the time-based
+ * `idle → awaiting` promotion fires within ~1s of the
+ * [`AWAITING_GRACE_SECONDS`] boundary even if no other event touches
+ * the session. The 1s cadence is cheap (one shared timer for the whole
+ * app) and keeps the displayed status close to its documented timing.
  */
 export function useDisplayStatus(id: SessionId | undefined): DisplayStatus {
   const tickedNow = useNowTickSeconds();
@@ -571,25 +571,28 @@ export function useDisplayStatus(id: SessionId | undefined): DisplayStatus {
 
 /**
  * Returns `Math.floor(Date.now() / 1000)` and re-renders the caller
- * roughly once a minute. Used by [`useDisplayStatus`] to drive the
+ * roughly once a second. Used by [`useDisplayStatus`] to drive the
  * boot-grace transition.
  *
  * Implemented as a single shared interval with reference-counted
  * subscribers — N tabs ⇒ N components ⇒ one timer, not N. The interval
  * is created lazily on first subscribe and torn down when the last
- * subscriber unmounts. Internal — not exported as part of the public
- * store API.
+ * subscriber unmounts. The cadence is intentionally well below
+ * [`AWAITING_GRACE_SECONDS`] (5s) so the documented transition lands
+ * close to its boundary rather than potentially trailing it. Internal —
+ * not exported as part of the public store API.
  */
 let nowTickSubscribers = 0;
 let nowTickHandle: number | undefined;
 const nowTickListeners = new Set<(value: number) => void>();
+const NOW_TICK_INTERVAL_MS = 1_000;
 
 function ensureNowTickRunning(): void {
   if (nowTickHandle !== undefined) return;
   nowTickHandle = window.setInterval(() => {
     const value = Math.floor(Date.now() / 1000);
     for (const listener of nowTickListeners) listener(value);
-  }, 60_000);
+  }, NOW_TICK_INTERVAL_MS);
 }
 
 function teardownNowTickIfUnused(): void {

--- a/src/store/session-store.ts
+++ b/src/store/session-store.ts
@@ -20,7 +20,7 @@
 // * `useSessionActions()` returns a stable action bag so callers can pull it
 //   once and not re-render when state changes.
 
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
 
@@ -80,9 +80,49 @@ export interface SessionStoreState {
    * don't linger in the sidebar.
    */
   metrics: Record<SessionId, SessionMetrics>;
+  /**
+   * Per-session unix-seconds timestamp of the most recent agent-turn
+   * completion. Set when a `session://activity` event with
+   * `kind: "turnEnd"` arrives. Drives the `awaiting` display state via
+   * [`selectDisplayStatus`]. Frontend-only — not persisted; cleared on
+   * close and on `starting` (restart) so the indicator goes back to
+   * `idle` until the new run finishes its first turn.
+   */
+  lastTurnEndAt: Record<SessionId, number>;
+  /**
+   * Most recently observed agent-turn duration in milliseconds, as
+   * reported by the `kind: "turnEnd"` event when the source includes it
+   * (Copilot OTel `invoke_agent` span — Claude omits). Surfaced only in
+   * tooltips; not part of any layout-affecting state.
+   */
+  lastTurnDurationMs: Record<SessionId, number>;
 }
 
 export type SessionActivity = 'working' | 'idle' | 'attention';
+
+/**
+ * Single derived state the sidebar renders as one icon. Combines
+ * lifecycle (`session.status`), PTY-derived activity, the most recent
+ * agent-turn-end timestamp, and how long the session has been alive. See
+ * [`selectDisplayStatus`] for the priority order.
+ */
+export type DisplayStatus =
+  | 'starting'
+  | 'error'
+  | 'exited'
+  | 'attention'
+  | 'working'
+  | 'awaiting'
+  | 'idle';
+
+/**
+ * Time (in seconds) a freshly-spawned, never-active session must live
+ * before the sidebar promotes it from `idle` to `awaiting` ("the agent
+ * has booted and is waiting for input"). Without this grace period the
+ * tab would flicker to `awaiting` during the first frame of a normal
+ * spawn.
+ */
+export const AWAITING_GRACE_SECONDS = 5;
 
 export interface SessionStoreActions {
   hydrate: () => Promise<void>;
@@ -124,6 +164,8 @@ const INITIAL_STATE: SessionStoreState = {
   hasUnread: {},
   activity: {},
   metrics: {},
+  lastTurnEndAt: {},
+  lastTurnDurationMs: {},
 };
 
 /**
@@ -158,6 +200,8 @@ export const useSessionStore = create<Store>((set, get) => {
         hasUnread: {},
         activity: {},
         metrics: {},
+        lastTurnEndAt: {},
+        lastTurnDurationMs: {},
       });
     },
 
@@ -185,7 +229,8 @@ export const useSessionStore = create<Store>((set, get) => {
       // is gone.
       if (get().pendingClose === id) patch.pendingClose = undefined;
       // Drop any orphan status-message keyed under this session id.
-      const { statusMessages, hasUnread, activity, metrics } = get();
+      const { statusMessages, hasUnread, activity, metrics, lastTurnEndAt, lastTurnDurationMs } =
+        get();
       if (id in statusMessages) {
         const next = { ...statusMessages };
         delete next[id];
@@ -205,6 +250,16 @@ export const useSessionStore = create<Store>((set, get) => {
         const nextMetrics = { ...metrics };
         delete nextMetrics[id];
         patch.metrics = nextMetrics;
+      }
+      if (id in lastTurnEndAt) {
+        const next = { ...lastTurnEndAt };
+        delete next[id];
+        patch.lastTurnEndAt = next;
+      }
+      if (id in lastTurnDurationMs) {
+        const next = { ...lastTurnDurationMs };
+        delete next[id];
+        patch.lastTurnDurationMs = next;
       }
       set(patch);
     },
@@ -291,11 +346,26 @@ export const useSessionStore = create<Store>((set, get) => {
         statusMessages: nextMessages,
       };
       // On restart (back to `starting`), drop any stale metrics so the
-      // sidebar doesn't show numbers from the previous run.
-      if (evt.status === 'starting' && evt.sessionId in metrics) {
-        const nextMetrics = { ...metrics };
-        delete nextMetrics[evt.sessionId];
-        patch.metrics = nextMetrics;
+      // sidebar doesn't show numbers from the previous run. Same logic
+      // applies to the turn-end markers — a new run hasn't completed any
+      // turns yet, so the sidebar should fall back to `idle`.
+      if (evt.status === 'starting') {
+        if (evt.sessionId in metrics) {
+          const nextMetrics = { ...metrics };
+          delete nextMetrics[evt.sessionId];
+          patch.metrics = nextMetrics;
+        }
+        const { lastTurnEndAt, lastTurnDurationMs } = get();
+        if (evt.sessionId in lastTurnEndAt) {
+          const next = { ...lastTurnEndAt };
+          delete next[evt.sessionId];
+          patch.lastTurnEndAt = next;
+        }
+        if (evt.sessionId in lastTurnDurationMs) {
+          const next = { ...lastTurnDurationMs };
+          delete next[evt.sessionId];
+          patch.lastTurnDurationMs = next;
+        }
       }
       set(patch);
     },
@@ -310,9 +380,38 @@ export const useSessionStore = create<Store>((set, get) => {
     },
 
     applyActivity: (evt) => {
-      const { sessions, activity, activeId } = get();
+      const { sessions, activity, activeId, lastTurnEndAt, lastTurnDurationMs } = get();
       // Defensive: drop events for unknown sessions (race with close).
       if (!sessions.some((s) => s.id === evt.sessionId)) return;
+
+      // Turn-end is a fire-and-forget marker — it doesn't compete with the
+      // PTY-driven working/idle/attention state machine, so handle it
+      // first and return. We record both the wall-clock arrival time
+      // (drives the `awaiting` display state) and the source-reported
+      // duration (tooltip only).
+      if (evt.kind === 'turnEnd') {
+        const nowSec = Math.floor(Date.now() / 1000);
+        const patch: Partial<SessionStoreState> = {
+          lastTurnEndAt: { ...lastTurnEndAt, [evt.sessionId]: nowSec },
+        };
+        if (typeof evt.durationMs === 'number') {
+          patch.lastTurnDurationMs = {
+            ...lastTurnDurationMs,
+            [evt.sessionId]: evt.durationMs,
+          };
+        }
+        // A completed turn implies the agent is no longer producing
+        // output — drop a stale `working` flag so the icon flips to
+        // `awaiting` immediately rather than waiting for the PTY-stream
+        // idle tick. Don't clobber `attention` (still user-relevant).
+        if (activity[evt.sessionId] === 'working') {
+          const nextActivity = { ...activity };
+          delete nextActivity[evt.sessionId];
+          patch.activity = nextActivity;
+        }
+        set(patch);
+        return;
+      }
 
       const current = activity[evt.sessionId];
       let next: SessionActivity | undefined;
@@ -382,6 +481,55 @@ export const selectMetrics =
   (id: SessionId | undefined) =>
   (s: Store): SessionMetrics | undefined =>
     id === undefined ? undefined : s.metrics[id];
+export const selectLastTurnEndAt =
+  (id: SessionId | undefined) =>
+  (s: Store): number | undefined =>
+    id === undefined ? undefined : s.lastTurnEndAt[id];
+export const selectLastTurnDurationMs =
+  (id: SessionId | undefined) =>
+  (s: Store): number | undefined =>
+    id === undefined ? undefined : s.lastTurnDurationMs[id];
+
+/**
+ * Derive the single icon-state the sidebar should render for `id`. The
+ * priority order is intentional and reflects what a user most needs to
+ * notice first:
+ *
+ *  1. Lifecycle terminals (`error`, `exited`) — the session can't do
+ *     anything until the user reacts.
+ *  2. `starting` — the spinner; nothing else is meaningful yet.
+ *  3. `attention` — the agent (or the OS) explicitly asked the user to
+ *     look here.
+ *  4. `working` — the PTY is streaming output, i.e. the agent is
+ *     producing tokens.
+ *  5. `awaiting` — the agent finished a turn and is parked at its
+ *     prompt, OR the session has booted but never produced a turn and
+ *     the [`AWAITING_GRACE_SECONDS`] window has elapsed (a CLI typically
+ *     drops to its REPL prompt by then).
+ *  6. `idle` — fallback for the brief boot window before
+ *     [`AWAITING_GRACE_SECONDS`] expires.
+ *
+ * `nowSec` is injected so tests can pin time deterministically.
+ */
+export function selectDisplayStatus(
+  id: SessionId | undefined,
+  nowSec: number = Math.floor(Date.now() / 1000),
+): (s: Store) => DisplayStatus {
+  return (s: Store): DisplayStatus => {
+    if (id === undefined) return 'idle';
+    const session = s.sessions.find((x) => x.id === id);
+    if (!session) return 'idle';
+    if (session.status === 'error') return 'error';
+    if (session.status === 'starting') return 'starting';
+    if (session.status === 'exited') return 'exited';
+    const activity = s.activity[id];
+    if (activity === 'attention') return 'attention';
+    if (activity === 'working') return 'working';
+    if (s.lastTurnEndAt[id] !== undefined) return 'awaiting';
+    if (nowSec - session.createdAt >= AWAITING_GRACE_SECONDS) return 'awaiting';
+    return 'idle';
+  };
+}
 
 export const useSessions = (): SessionView[] => useSessionStore(selectSessions);
 export const useActiveSessionId = (): SessionId | undefined => useSessionStore(selectActiveId);
@@ -395,6 +543,67 @@ export const useActivity = (id: SessionId | undefined): SessionActivity | undefi
   useSessionStore(selectActivity(id));
 export const useMetrics = (id: SessionId | undefined): SessionMetrics | undefined =>
   useSessionStore(selectMetrics(id));
+export const useLastTurnEndAt = (id: SessionId | undefined): number | undefined =>
+  useSessionStore(selectLastTurnEndAt(id));
+export const useLastTurnDurationMs = (id: SessionId | undefined): number | undefined =>
+  useSessionStore(selectLastTurnDurationMs(id));
+
+/**
+ * Subscribe to the derived `DisplayStatus` for `id`. Recomputes (and
+ * re-renders the caller) every minute via a tick so the time-based
+ * `idle → awaiting` promotion eventually fires even if no other event
+ * touches the session. The 60s cadence is fine because the only
+ * threshold we care about is [`AWAITING_GRACE_SECONDS`] and the
+ * derivation is pure / cheap.
+ */
+export function useDisplayStatus(id: SessionId | undefined): DisplayStatus {
+  const tickedNow = useNowTickSeconds();
+  return useSessionStore(selectDisplayStatus(id, tickedNow));
+}
+
+/**
+ * Returns `Math.floor(Date.now() / 1000)` and re-renders the caller
+ * roughly once a minute. Used by [`useDisplayStatus`] to drive the
+ * boot-grace transition.
+ *
+ * Implemented as a single shared interval with reference-counted
+ * subscribers — N tabs ⇒ N components ⇒ one timer, not N. The interval
+ * is created lazily on first subscribe and torn down when the last
+ * subscriber unmounts. Internal — not exported as part of the public
+ * store API.
+ */
+let nowTickSubscribers = 0;
+let nowTickHandle: number | undefined;
+const nowTickListeners = new Set<(value: number) => void>();
+
+function ensureNowTickRunning(): void {
+  if (nowTickHandle !== undefined) return;
+  nowTickHandle = window.setInterval(() => {
+    const value = Math.floor(Date.now() / 1000);
+    for (const listener of nowTickListeners) listener(value);
+  }, 60_000);
+}
+
+function teardownNowTickIfUnused(): void {
+  if (nowTickSubscribers > 0 || nowTickHandle === undefined) return;
+  window.clearInterval(nowTickHandle);
+  nowTickHandle = undefined;
+}
+
+function useNowTickSeconds(): number {
+  const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
+  useEffect(() => {
+    nowTickSubscribers += 1;
+    nowTickListeners.add(setNow);
+    ensureNowTickRunning();
+    return () => {
+      nowTickListeners.delete(setNow);
+      nowTickSubscribers -= 1;
+      teardownNowTickIfUnused();
+    };
+  }, []);
+  return now;
+}
 
 export function useActiveSession(): SessionView | undefined {
   const sessions = useSessions();

--- a/src/store/session-store.ts
+++ b/src/store/session-store.ts
@@ -601,6 +601,22 @@ function teardownNowTickIfUnused(): void {
   nowTickHandle = undefined;
 }
 
+// Vite HMR: when this module is hot-replaced in dev, the old module's
+// setInterval keeps firing while the new module instance creates a
+// fresh one — left unchecked, every save accumulates another ticker.
+// Clear the handle and drop subscribers on dispose so the new module
+// starts from a clean slate.
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    if (nowTickHandle !== undefined) {
+      window.clearInterval(nowTickHandle);
+      nowTickHandle = undefined;
+    }
+    nowTickListeners.clear();
+    nowTickSubscribers = 0;
+  });
+}
+
 function useNowTickSeconds(): number {
   const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
   useEffect(() => {

--- a/src/store/session-store.ts
+++ b/src/store/session-store.ts
@@ -399,6 +399,13 @@ export const useSessionStore = create<Store>((set, get) => {
             ...lastTurnDurationMs,
             [evt.sessionId]: evt.durationMs,
           };
+        } else if (lastTurnDurationMs[evt.sessionId] !== undefined) {
+          // Source did not report a duration this time. Drop any prior
+          // value so the tooltip doesn't show a stale number from an
+          // earlier turn (or from the other tool, after an agent swap).
+          const next = { ...lastTurnDurationMs };
+          delete next[evt.sessionId];
+          patch.lastTurnDurationMs = next;
         }
         // A completed turn implies the agent is no longer producing
         // output — drop a stale `working` flag so the icon flips to
@@ -495,18 +502,19 @@ export const selectLastTurnDurationMs =
  * priority order is intentional and reflects what a user most needs to
  * notice first:
  *
- *  1. Lifecycle terminals (`error`, `exited`) — the session can't do
- *     anything until the user reacts.
+ *  1. `error` — the session can't do anything until the user reacts.
  *  2. `starting` — the spinner; nothing else is meaningful yet.
- *  3. `attention` — the agent (or the OS) explicitly asked the user to
+ *  3. `exited` — the session has terminated and won't make progress
+ *     until the user restarts or recreates it.
+ *  4. `attention` — the agent (or the OS) explicitly asked the user to
  *     look here.
- *  4. `working` — the PTY is streaming output, i.e. the agent is
+ *  5. `working` — the PTY is streaming output, i.e. the agent is
  *     producing tokens.
- *  5. `awaiting` — the agent finished a turn and is parked at its
+ *  6. `awaiting` — the agent finished a turn and is parked at its
  *     prompt, OR the session has booted but never produced a turn and
  *     the [`AWAITING_GRACE_SECONDS`] window has elapsed (a CLI typically
  *     drops to its REPL prompt by then).
- *  6. `idle` — fallback for the brief boot window before
+ *  7. `idle` — fallback for the brief boot window before
  *     [`AWAITING_GRACE_SECONDS`] expires.
  *
  * `nowSec` is injected so tests can pin time deterministically.

--- a/src/types/arborist.ts
+++ b/src/types/arborist.ts
@@ -159,7 +159,8 @@ export type ActivityEvent =
   | { kind: 'idle' }
   | { kind: 'promptStart' }
   | { kind: 'commandStart' }
-  | { kind: 'commandEnd'; exit: number | null };
+  | { kind: 'commandEnd'; exit: number | null }
+  | { kind: 'turnEnd'; durationMs: number | null };
 
 // MIRROR: src-tauri/src/types.rs::SessionActivityEvent
 // Payload of the `session://activity` Tauri event (DESIGN §6). The


### PR DESCRIPTION
Replaces the colored-dot session status indicators with proper inline-SVG icons and derives the displayed state from a new `TurnEnd` activity event surfaced by the OTel/transcript watchers.

## Why

The old indicator was a single colored circle inferred mostly from PTY byterate. It couldn't distinguish `the model is generating` from `the model finished and is waiting on me`, and had no glyph language for non-active states (starting / exited / attention / error).

## What changed

**Backend**
- New `ActivityEvent::TurnEnd { duration_ms }` variant.
- Copilot OTel watcher parses `invoke_agent` span `startTime` / `endTime` (`[secs, nanos]` pairs) into a duration and emits `TurnEnd` when the span closes.
- Claude transcript watcher emits `TurnEnd { None }` per new assistant line (Claude's JSONL has no clean turn-start anchor; reporting a duration would be misleading).
- Reuses the existing `session://activity` channel — no new Tauri command/event/permission.

**Frontend**
- Store tracks `lastTurnEndAt` / `lastTurnDurationMs` and exposes a derived `DisplayStatus` via `selectDisplayStatus` + `useDisplayStatus`. Priority: `error` > `starting`/`exited` > `attention` > `working` > `awaiting` > `idle`.
- A singleton 60s ticker (reference-counted across subscribers — N tabs share one timer) drives the boot-grace transition into `awaiting`.
- New `<StatusIcon>` component renders one inline SVG per state (starting=spinner, working=sparkles, awaiting=speech-bubble, attention=bell, exited=stop-square, error=alert-triangle). Unread remains a small overlay badge so the new-output cue is preserved.

## Tests
- 6 Rust tests for `parse_invoke_agent_duration_ms` (fixture extraction, span-type filtering, missing/inverted times).
- Watcher integration test asserts `TurnEnd` fires for the `invoke_agent` span in the real fixture.
- Frontend: `selectDisplayStatus` priority-table tests, `applyActivity('turnEnd')` store semantics (clears stale `working`, preserves `attention`, cleared on close/restart), 9 `StatusIcon` rendering tests.

## Verification
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test` 100% pass (43 unit + 11 commands + 3 integration)
- `npm run lint` clean
- `npx vitest run` 230/230 pass

Reviewed twice with the code-review agent; both rounds' real findings were addressed (singleton ticker, trait removal).