### PR TITLE
feat(session): resume AI conversation across app restart

### DIFF
--- a/dev/docs/DESIGN.md
+++ b/dev/docs/DESIGN.md
@@ -76,6 +76,12 @@ struct Session {
                                    // (e.g. Claude's --system-prompt file). Persisted so
                                    // respawn_existing can rematerialise them after a
                                    // crash/restart. Omitted from SessionView.
+    ai_session_id: Option<String>, // Backend-only; the underlying CLI's session id
+                                   // (Claude's JSONL stem; Copilot's gen_ai.conversation.id).
+                                   // Discovered by the metrics watcher post-spawn and
+                                   // persisted so restore_all_sessions can append
+                                   // `--resume <id>` and continue the conversation
+                                   // across an app restart. Cleared on session_create.
 }
 
 struct TempFileSpec {
@@ -245,6 +251,11 @@ User clicks "Restart"
   → Frontend clears error overlay, re-attaches xterm.js to new PTY stream
 ```
 
+User-initiated restart deliberately starts a fresh AI conversation —
+`Session.aiSessionId` is **not** appended on this path. The user clicked
+"Restart" (not "Resume"); honouring that contract avoids surprising them
+when a session has gotten into a bad state mid-conversation.
+
 ### 5.5 Session Restore on Launch
 
 ```
@@ -271,8 +282,15 @@ App.tsx mounts (frontend)
              2. flips the persisted status to Starting and emits
                 session://status,
              3. calls pty_pool::respawn_existing using the stored
-                composedCommand and worktreePath verbatim (DESIGN §5.4 —
-                never re-composes); the wait thread later flips the
+                composedCommand and worktreePath; if Session.aiSessionId
+                is set and the underlying transcript still exists on disk
+                (`~/.claude/projects/<encoded-cwd>/<id>.jsonl` for Claude,
+                `~/.copilot/session-state/<id>/` for Copilot), the spawn
+                command is *augmented* (not recomposed) by appending
+                `--resume <quoted-id>` to the trailing CLI invocation so
+                the AI conversation continues across the restart. The
+                persisted Session.composedCommand is never mutated by
+                this augmentation. The wait thread later flips the
                 status to Running / Exited / Error as the child reports.
            Spawn or temp-file failures map per-session to Error and
            never abort the loop.

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -42,6 +42,13 @@ pub async fn ping() -> Result<String, AppError> {
 }
 
 /// Resolve the [`ConfigStore`] for the current Tauri app instance.
+///
+/// **Avoid in command handlers** — prefer `ctx_of(&app)?.store.clone()`
+/// so all writes share the managed `AppContext`'s mutex (otherwise each
+/// fresh `ConfigStore::open` gets its own mutex and load-modify-write
+/// races between command threads silently lose updates). This helper
+/// remains for boot-time wiring in `lib.rs`, before `AppContext` is
+/// constructed.
 pub fn store_for(app: &tauri::AppHandle) -> Result<ConfigStore, AppError> {
     let dir: PathBuf = app
         .path()
@@ -53,15 +60,15 @@ pub fn store_for(app: &tauri::AppHandle) -> Result<ConfigStore, AppError> {
 /// Returns the persisted [`AppConfig`].
 #[tauri::command]
 pub async fn config_get(app: tauri::AppHandle) -> Result<AppConfig, AppError> {
-    let store = store_for(&app)?;
-    Ok(store.load_config())
+    let ctx = ctx_of(&app)?;
+    Ok(ctx.store.load_config())
 }
 
 /// Deep-merges `partial` into the persisted [`AppConfig`].
 #[tauri::command]
 pub async fn config_set(app: tauri::AppHandle, partial: PartialAppConfig) -> Result<(), AppError> {
-    let store = store_for(&app)?;
-    store.save_config(partial).map_err(AppError::from)?;
+    let ctx = ctx_of(&app)?;
+    ctx.store.save_config(partial).map_err(AppError::from)?;
     Ok(())
 }
 
@@ -69,8 +76,8 @@ pub async fn config_set(app: tauri::AppHandle, partial: PartialAppConfig) -> Res
 /// configured `instructionSetsDir`.
 #[tauri::command]
 pub async fn instructions_list(app: tauri::AppHandle) -> Result<Vec<InstructionSet>, AppError> {
-    let store = store_for(&app)?;
-    let cfg = store.load_config();
+    let ctx = ctx_of(&app)?;
+    let cfg = ctx.store.load_config();
     list_instructions_for(&cfg)
 }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -268,6 +268,33 @@ pub fn build_production_metrics_emit(app: tauri::AppHandle) -> crate::session_me
     })
 }
 
+/// Production AI-session discovery callback. Persists the discovered AI
+/// session id on the matching `Session` record so the next app-restart
+/// restore can `--resume <id>` and continue the conversation.
+///
+/// Errors are intentionally swallowed (with a debug log) — discovery is
+/// a best-effort signal that fires every metrics-watcher poll, and a
+/// transient store error must not crash the watcher thread or surface
+/// to the UI.
+#[must_use]
+pub fn build_production_ai_session_discover(
+    store: crate::config_store::ConfigStore,
+) -> crate::session_metrics::AiSessionDiscoveryCb {
+    Arc::new(
+        move |session_id: crate::types::SessionId, ai_session_id: String| match store
+            .update_session_ai_session_id(&session_id, Some(ai_session_id.clone()))
+        {
+            Ok(true) => {
+                tracing::debug!(%session_id, %ai_session_id, "ai session id discovered");
+            }
+            Ok(false) => {}
+            Err(e) => {
+                tracing::debug!(%session_id, error = ?e, "failed to persist ai session id");
+            }
+        },
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -383,6 +383,23 @@ pub fn session_restart_impl(ctx: &AppContext, id: SessionId) -> Result<(), AppEr
         .map_err(AppError::from)?;
     (ctx.sink.status)(&id, SessionStatus::Starting, None, None);
 
+    // Restart starts a fresh AI conversation (DESIGN §5.4). The previous
+    // ai_session_id refers to a transcript the new CLI invocation will
+    // not be writing to, so we clear it eagerly — otherwise a crash
+    // between restart and the new watcher's first discovery would let
+    // the next restore `--resume` the *pre-restart* conversation.
+    //
+    // Order matters: stop the OLD watcher first, *then* clear. If we
+    // cleared while the old watcher was still polling, it could discover
+    // the (still-on-disk) old transcript one more time and persist the
+    // stale id back, undoing the clear. After this stop the new watcher
+    // is started below by `metrics.start`, which will repopulate the
+    // field with the new conversation's id once the CLI starts writing.
+    ctx.metrics.stop(&id);
+    if let Err(e) = ctx.store.update_session_ai_session_id(&id, None) {
+        warn!(session_id = %id, error = ?e, "restart: failed to clear ai_session_id");
+    }
+
     if let Err(e) = ctx.pool.respawn_existing(&session, ctx.sink.clone()) {
         let msg = format!("Failed to restart session: {e}");
         let _ = ctx

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -440,24 +440,25 @@ fn ai_session_transcript_exists(
     let Some(home) = crate::session_metrics::home_dir() else {
         return true;
     };
-    match tool {
-        Tool::Claude => {
-            // ~/.claude/projects/<encoded-cwd>/<id>.jsonl
-            let path = home
-                .join(".claude")
-                .join("projects")
-                .join(crate::session_metrics::encode_cwd(worktree_path))
-                .join(format!("{ai_session_id}.jsonl"));
-            path.is_file()
-        }
-        Tool::Copilot => {
-            // ~/.copilot/session-state/<id>/
-            let path = home
-                .join(".copilot")
-                .join("session-state")
-                .join(ai_session_id);
-            path.is_dir()
-        }
+    let path = match tool {
+        Tool::Claude => home
+            .join(".claude")
+            .join("projects")
+            .join(crate::session_metrics::encode_cwd(worktree_path))
+            .join(format!("{ai_session_id}.jsonl")),
+        Tool::Copilot => home
+            .join(".copilot")
+            .join("session-state")
+            .join(ai_session_id),
+    };
+    // `try_exists` distinguishes "definitely missing" from "couldn't tell"
+    // (e.g. permission denied on a parent dir). `Path::is_file`/`is_dir`
+    // would conflate both as `false`, which would silently strip a valid
+    // `--resume` whenever the home dir is briefly unreadable.
+    match path.try_exists() {
+        Ok(true) => true,
+        Ok(false) => false,
+        Err(_) => true,
     }
 }
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -33,7 +33,7 @@ use crate::config_store::{
 };
 use crate::git::{GitRunner, RealGitRunner};
 use crate::pty_pool::{cleanup_orphans, PtyPool, PtySink};
-use crate::session_metrics::{MetricsCb, MetricsRegistry};
+use crate::session_metrics::{AiSessionDiscoveryCb, MetricsCb, MetricsRegistry};
 use crate::types::{
     AppError, Error, InstructionSet, PartialAppConfig, Session, SessionCreateArgs, SessionId,
     SessionInputArgs, SessionResizeArgs, SessionStatus, SessionView, Tool,
@@ -61,6 +61,12 @@ pub struct AppContext {
     /// Production wires this into `app.emit("session://metrics", …)`;
     /// tests substitute a capturing closure.
     pub metrics_emit: MetricsCb,
+    /// Callback the metrics watchers invoke when they discover (or learn
+    /// of a change to) the AI-side session id. Production wires this to
+    /// persist via `ConfigStore::update_session_ai_session_id` so the next
+    /// app-restart restore can `--resume <id>`. Tests substitute a
+    /// capturing closure.
+    pub ai_session_discover: AiSessionDiscoveryCb,
 }
 
 impl AppContext {
@@ -71,6 +77,7 @@ impl AppContext {
         sink: PtySink,
         git_runner: Arc<dyn GitRunner>,
         metrics_emit: MetricsCb,
+        ai_session_discover: AiSessionDiscoveryCb,
     ) -> Self {
         Self {
             pool,
@@ -80,6 +87,7 @@ impl AppContext {
             restored: AtomicBool::new(false),
             metrics: Arc::new(MetricsRegistry::new()),
             metrics_emit,
+            ai_session_discover,
         }
     }
 
@@ -89,7 +97,14 @@ impl AppContext {
     /// fake [`GitRunner`].
     #[must_use]
     pub fn with_real_git(pool: Arc<PtyPool>, store: ConfigStore, sink: PtySink) -> Self {
-        Self::new(pool, store, sink, Arc::new(RealGitRunner), Arc::new(|_| {}))
+        Self::new(
+            pool,
+            store,
+            sink,
+            Arc::new(RealGitRunner),
+            Arc::new(|_| {}),
+            Arc::new(|_, _| {}),
+        )
     }
 }
 
@@ -173,6 +188,7 @@ pub fn session_create_impl(
         created_at: now_unix_seconds(),
         tab_index,
         temp_files: composed.temp_files,
+        ai_session_id: None,
     };
 
     // 8. Persist before spawning so a crash mid-spawn still leaves an
@@ -214,6 +230,7 @@ pub fn session_create_impl(
         session.worktree_path.clone(),
         SystemTime::now(),
         Arc::clone(&ctx.metrics_emit),
+        Arc::clone(&ctx.ai_session_discover),
     );
 
     info!(session_id = %session.id, pid, label = %label, "session created");
@@ -382,6 +399,7 @@ pub fn session_restart_impl(ctx: &AppContext, id: SessionId) -> Result<(), AppEr
         session.worktree_path.clone(),
         SystemTime::now(),
         Arc::clone(&ctx.metrics_emit),
+        Arc::clone(&ctx.ai_session_discover),
     );
     Ok(())
 }
@@ -403,6 +421,51 @@ pub fn frontend_ready_impl(ctx: &AppContext) -> bool {
 /// both restore and restart so the wording stays consistent.
 fn stale_worktree_message(path: &std::path::Path) -> String {
     format!("Worktree path is no longer available: {}", path.display())
+}
+
+/// Best-effort preflight check that the AI tool's transcript for
+/// `ai_session_id` still exists on disk. If it doesn't (user deleted it
+/// between launches, OS tmp clean, etc.), `restore_all_sessions` skips
+/// the `--resume` augmentation rather than handing the CLI a stale id
+/// that would error out before the user sees anything useful.
+///
+/// On any I/O failure we conservatively return `true` so the worst case
+/// is the CLI reports its own "no such session" error, which is no worse
+/// than today's behaviour.
+fn ai_session_transcript_exists(
+    tool: Tool,
+    worktree_path: &std::path::Path,
+    ai_session_id: &str,
+) -> bool {
+    let Some(home) = home_dir() else {
+        return true;
+    };
+    match tool {
+        Tool::Claude => {
+            // ~/.claude/projects/<encoded-cwd>/<id>.jsonl
+            let path = home
+                .join(".claude")
+                .join("projects")
+                .join(crate::session_metrics::encode_cwd(worktree_path))
+                .join(format!("{ai_session_id}.jsonl"));
+            path.is_file()
+        }
+        Tool::Copilot => {
+            // ~/.copilot/session-state/<id>/
+            let path = home
+                .join(".copilot")
+                .join("session-state")
+                .join(ai_session_id);
+            path.is_dir()
+        }
+    }
+}
+
+fn home_dir() -> Option<std::path::PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(std::path::PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
 }
 
 /// Re-spawn every persisted session. Called once after the frontend signals
@@ -455,7 +518,33 @@ pub fn restore_all_sessions(ctx: &AppContext) {
         }
         (ctx.sink.status)(&id, SessionStatus::Starting, None, None);
 
-        match ctx.pool.respawn_existing(&session, ctx.sink.clone()) {
+        // AI-session resume — DESIGN §5.5. Augment composed_command with
+        // `--resume <ai_session_id>` so the underlying CLI continues the
+        // prior conversation. We *augment*, never *recompose from inputs*
+        // (DESIGN §5.4 still holds for the persisted record). We only
+        // resume on app-restart restore — user-initiated `session_restart`
+        // intentionally launches a fresh CLI conversation.
+        let mut session_to_spawn = session.clone();
+        if let Some(aid) = session.ai_session_id.as_deref() {
+            if ai_session_transcript_exists(session.tool, &session.worktree_path, aid) {
+                session_to_spawn.composed_command =
+                    compose::with_resume(&session.composed_command, session.tool, aid);
+            } else {
+                // Transcript was deleted between launches. Drop the stored
+                // id so we don't keep trying to resume it, and start fresh.
+                warn!(
+                    session_id = %id,
+                    ai_session_id = %aid,
+                    "restore: AI transcript missing on disk; starting fresh conversation",
+                );
+                let _ = ctx.store.update_session_ai_session_id(&id, None);
+            }
+        }
+
+        match ctx
+            .pool
+            .respawn_existing(&session_to_spawn, ctx.sink.clone())
+        {
             Ok(pid) => {
                 info!(session_id = %id, pid, "restored session");
                 // Issue #3: spin up the metrics watcher for restored sessions
@@ -467,6 +556,7 @@ pub fn restore_all_sessions(ctx: &AppContext) {
                     session.worktree_path.clone(),
                     SystemTime::now(),
                     Arc::clone(&ctx.metrics_emit),
+                    Arc::clone(&ctx.ai_session_discover),
                 );
             }
             Err(e) => {

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -437,7 +437,7 @@ fn ai_session_transcript_exists(
     worktree_path: &std::path::Path,
     ai_session_id: &str,
 ) -> bool {
-    let Some(home) = home_dir() else {
+    let Some(home) = crate::session_metrics::home_dir() else {
         return true;
     };
     match tool {
@@ -459,13 +459,6 @@ fn ai_session_transcript_exists(
             path.is_dir()
         }
     }
-}
-
-fn home_dir() -> Option<std::path::PathBuf> {
-    std::env::var_os("HOME")
-        .or_else(|| std::env::var_os("USERPROFILE"))
-        .map(std::path::PathBuf::from)
-        .filter(|p| !p.as_os_str().is_empty())
 }
 
 /// Re-spawn every persisted session. Called once after the frontend signals
@@ -524,6 +517,19 @@ pub fn restore_all_sessions(ctx: &AppContext) {
         // (DESIGN §5.4 still holds for the persisted record). We only
         // resume on app-restart restore — user-initiated `session_restart`
         // intentionally launches a fresh CLI conversation.
+        //
+        // Known limitation (ROADMAP §4.5): for Claude, the `ai_session_id`
+        // is discovered heuristically from the newest JSONL in the project
+        // dir post-spawn. If two Arborist sessions share the same worktree
+        // (same `<encoded-cwd>`), the watchers can converge on the same
+        // file and persist the same id for both. On restart, both sessions
+        // would then try to `--resume` the same Claude conversation; only
+        // one resumes faithfully and the other will see Claude's own "no
+        // such session" / "conversation in use" error in its terminal.
+        // The fix is a hook-driven session-id source (tracked in #4); the
+        // single-session-per-worktree case (the common one) is unaffected.
+        // Copilot is not affected — its OTel file is per-Arborist-session,
+        // so `gen_ai.conversation.id` is unambiguous.
         let mut session_to_spawn = session.clone();
         if let Some(aid) = session.ai_session_id.as_deref() {
             if ai_session_transcript_exists(session.tool, &session.worktree_path, aid) {

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -389,13 +389,15 @@ pub fn session_restart_impl(ctx: &AppContext, id: SessionId) -> Result<(), AppEr
     // between restart and the new watcher's first discovery would let
     // the next restore `--resume` the *pre-restart* conversation.
     //
-    // Order matters: stop the OLD watcher first, *then* clear. If we
-    // cleared while the old watcher was still polling, it could discover
-    // the (still-on-disk) old transcript one more time and persist the
-    // stale id back, undoing the clear. After this stop the new watcher
-    // is started below by `metrics.start`, which will repopulate the
-    // field with the new conversation's id once the CLI starts writing.
-    ctx.metrics.stop(&id);
+    // Order matters: stop the OLD watcher first, *then* clear. We need
+    // `stop_and_join` (not just `stop`) because the worker only re-checks
+    // its `running` flag at the top of each poll iteration — a fire-and-
+    // forget stop would let the in-flight iteration call `discover()` one
+    // more time and persist the stale id back, undoing the clear. After
+    // join returns, the worker thread has fully exited; the new watcher
+    // started below by `metrics.start` will repopulate the field with
+    // the new conversation's id once the CLI starts writing.
+    ctx.metrics.stop_and_join(&id);
     if let Err(e) = ctx.store.update_session_ai_session_id(&id, None) {
         warn!(session_id = %id, error = ?e, "restart: failed to clear ai_session_id");
     }

--- a/src-tauri/src/compose.rs
+++ b/src-tauri/src/compose.rs
@@ -296,6 +296,29 @@ pub fn env_for_tool(tool: Tool, session_id: &SessionId) -> Vec<(String, std::ffi
     }
 }
 
+/// Augment a stored `composed_command` with `--resume <ai_session_id>` so
+/// the AI conversation continues across an app restart. Used by
+/// `restore_all_sessions`; **not** by `session_create` (which has no AI
+/// id yet) and **not** by user-initiated `session_restart` (DESIGN §5.4 —
+/// restart is fresh from the user's POV).
+///
+/// We append at the end of the command rather than parse and re-emit the
+/// CLI invocation. Both `claude` and `copilot` accept positional flags
+/// in any order, and the trailing token of `composed_command` is always
+/// the CLI invocation (DESIGN §5.6 step 3 — `[prelaunch && ]<cli>`),
+/// so appending binds correctly even when the user has prelaunch hooks
+/// that themselves contain `&&` inside quoted strings.
+///
+/// `ai_session_id` is shell-quoted using the host quoter; in practice
+/// CLI session ids are UUIDs, but defensive quoting keeps a future
+/// non-UUID id (e.g. Copilot's session-by-name resume) from corrupting
+/// the command.
+#[must_use]
+pub fn with_resume(composed_command: &str, _tool: Tool, ai_session_id: &str) -> String {
+    let quoter = platform_shell().quoter;
+    format!("{composed_command} --resume {}", quoter(ai_session_id))
+}
+
 // ---------------------------------------------------------------------------
 // Shell quoting
 // ---------------------------------------------------------------------------
@@ -766,6 +789,45 @@ mod tests {
         // pre-removal behaviour where we used to interpolate the path into
         // a quoted `--interactive` argument.
         assert_eq!(r.composed_command, "copilot");
+    }
+
+    // -- with_resume ----------------------------------------------------
+
+    #[test]
+    fn with_resume_appends_quoted_id_to_bare_claude() {
+        let out = with_resume("claude", Tool::Claude, "abc-123");
+        assert_eq!(out, format!("claude --resume {}", host_quote("abc-123")));
+    }
+
+    #[test]
+    fn with_resume_appends_after_system_prompt() {
+        let base = "claude --system-prompt /tmp/x.txt";
+        let out = with_resume(base, Tool::Claude, "uuid-1");
+        assert_eq!(
+            out,
+            format!("{base} --resume {}", host_quote("uuid-1")),
+            "resume must be appended after existing flags"
+        );
+    }
+
+    #[test]
+    fn with_resume_keeps_prelaunch_chain_intact() {
+        // Prelaunch commands chained via && precede the CLI invocation.
+        // Appending --resume at the end binds to the trailing CLI token.
+        let base = "echo hi && nvm use 20 && copilot";
+        let out = with_resume(base, Tool::Copilot, "sess-9");
+        assert_eq!(out, format!("{base} --resume {}", host_quote("sess-9")));
+    }
+
+    #[test]
+    fn with_resume_quotes_ids_with_shell_metachars() {
+        // Defensive: a future name-based resume id must not corrupt the
+        // command. The host quoter should fully escape it.
+        let nasty = "id with space&danger";
+        let out = with_resume("claude", Tool::Claude, nasty);
+        assert_eq!(out, format!("claude --resume {}", host_quote(nasty)));
+        // Extra sanity: the raw id substring must not appear unquoted.
+        assert!(!out.ends_with(nasty));
     }
 
     // -- POSIX quoting --------------------------------------------------

--- a/src-tauri/src/config_store.rs
+++ b/src-tauri/src/config_store.rs
@@ -44,6 +44,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use tempfile::NamedTempFile;
@@ -67,9 +68,19 @@ pub const MAX_INSTRUCTION_FILE_BYTES: u64 = 1024 * 1024;
 // ---------------------------------------------------------------------------
 
 /// Handle to the on-disk store directory. Cheap to construct and clone.
+///
+/// All write paths (`save_config`, `save_session`, `remove_session`,
+/// `update_session_status`, `update_session_ai_session_id`) are
+/// serialized through a process-wide mutex shared by clones of the same
+/// handle. Without this, load-modify-write paths called from different
+/// threads (e.g. the PTY wait thread updating `status` while a metrics
+/// watcher updates `ai_session_id`) would race and silently lose
+/// updates. Atomic file writes alone protect against torn files but
+/// not against lost updates.
 #[derive(Debug, Clone)]
 pub struct ConfigStore {
     dir: PathBuf,
+    write_lock: Arc<Mutex<()>>,
 }
 
 impl ConfigStore {
@@ -78,7 +89,10 @@ impl ConfigStore {
     pub fn open(dir: impl Into<PathBuf>) -> Result<Self, Error> {
         let dir = dir.into();
         fs::create_dir_all(&dir).map_err(Error::Io)?;
-        Ok(Self { dir })
+        Ok(Self {
+            dir,
+            write_lock: Arc::new(Mutex::new(())),
+        })
     }
 
     /// Filesystem directory backing this store. Mostly useful for tests and
@@ -209,6 +223,7 @@ impl ConfigStore {
     /// are canonicalized; keys that fail canonicalization are dropped with a
     /// warning rather than poisoning the whole call.
     pub fn save_config(&self, patch: PartialAppConfig) -> Result<AppConfig, Error> {
+        let _guard = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
         let mut cfg = self.load_config();
         merge_partial(&mut cfg, patch)?;
         cfg.config_version = CONFIG_VERSION_CURRENT;
@@ -257,6 +272,7 @@ impl ConfigStore {
 
     /// Persist a single session record (insert-or-replace).
     pub fn save_session(&self, session: &Session) -> Result<(), Error> {
+        let _guard = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
         let mut all = self.load_sessions();
         all.insert(session.id, session.clone());
         write_atomic(&self.sessions_path(), &all)
@@ -264,6 +280,7 @@ impl ConfigStore {
 
     /// Remove a session record by ID. Missing IDs are a no-op success.
     pub fn remove_session(&self, id: &SessionId) -> Result<(), Error> {
+        let _guard = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
         let mut all = self.load_sessions();
         if all.remove(id).is_none() {
             return Ok(());
@@ -280,6 +297,7 @@ impl ConfigStore {
         status: SessionStatus,
         pid: Option<u32>,
     ) -> Result<(), Error> {
+        let _guard = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
         let mut all = self.load_sessions();
         let Some(session) = all.get_mut(id) else {
             return Err(Error::NotFound(format!("session {id} not found")));
@@ -287,6 +305,30 @@ impl ConfigStore {
         session.status = status;
         session.pid = pid;
         write_atomic(&self.sessions_path(), &all)
+    }
+
+    /// Mutate the persisted `ai_session_id` of a session record. Used by
+    /// the metrics watchers' discovery callback so app-restart restore
+    /// can resume the AI conversation. Returns `Ok(true)` when the value
+    /// changed (and was therefore persisted), `Ok(false)` when the value
+    /// was already current — the latter avoids a redundant disk write
+    /// every poll once the watcher has converged.
+    pub fn update_session_ai_session_id(
+        &self,
+        id: &SessionId,
+        ai_session_id: Option<String>,
+    ) -> Result<bool, Error> {
+        let _guard = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
+        let mut all = self.load_sessions();
+        let Some(session) = all.get_mut(id) else {
+            return Err(Error::NotFound(format!("session {id} not found")));
+        };
+        if session.ai_session_id == ai_session_id {
+            return Ok(false);
+        }
+        session.ai_session_id = ai_session_id;
+        write_atomic(&self.sessions_path(), &all)?;
+        Ok(true)
     }
 }
 
@@ -804,6 +846,7 @@ mod tests {
                 path: dir.join("sp.md"),
                 contents: "ctx".to_owned(),
             }],
+            ai_session_id: None,
         }
     }
 
@@ -1198,6 +1241,77 @@ mod tests {
             .update_session_status(&SessionId::new(), SessionStatus::Exited, None)
             .expect_err("must fail");
         assert!(matches!(err, Error::NotFound(_)));
+    }
+
+    // ----- update_session_ai_session_id --------------------------------
+
+    #[test]
+    fn update_ai_session_id_persists_value() {
+        let td = TempDir::new().expect("td");
+        let store = ConfigStore::open(td.path()).expect("open");
+        let s = make_session(Uuid::new_v4(), "x", td.path());
+        store.save_session(&s).expect("save");
+
+        let changed = store
+            .update_session_ai_session_id(&s.id, Some("ai-123".to_owned()))
+            .expect("update");
+        assert!(changed, "first set must report a change");
+
+        let after = store.load_sessions();
+        assert_eq!(
+            after.get(&s.id).expect("present").ai_session_id.as_deref(),
+            Some("ai-123"),
+        );
+    }
+
+    #[test]
+    fn update_ai_session_id_is_idempotent() {
+        let td = TempDir::new().expect("td");
+        let store = ConfigStore::open(td.path()).expect("open");
+        let s = make_session(Uuid::new_v4(), "x", td.path());
+        store.save_session(&s).expect("save");
+
+        store
+            .update_session_ai_session_id(&s.id, Some("same".to_owned()))
+            .expect("first update");
+        let changed = store
+            .update_session_ai_session_id(&s.id, Some("same".to_owned()))
+            .expect("second update");
+        assert!(!changed, "no-op write must report no change");
+    }
+
+    #[test]
+    fn update_ai_session_id_returns_not_found_for_unknown_id() {
+        let td = TempDir::new().expect("td");
+        let store = ConfigStore::open(td.path()).expect("open");
+        let err = store
+            .update_session_ai_session_id(&SessionId::new(), Some("x".to_owned()))
+            .expect_err("must fail");
+        assert!(matches!(err, Error::NotFound(_)));
+    }
+
+    #[test]
+    fn update_ai_session_id_can_clear_value() {
+        let td = TempDir::new().expect("td");
+        let store = ConfigStore::open(td.path()).expect("open");
+        let s = make_session(Uuid::new_v4(), "x", td.path());
+        store.save_session(&s).expect("save");
+
+        store
+            .update_session_ai_session_id(&s.id, Some("ai-1".to_owned()))
+            .expect("set");
+        let changed = store
+            .update_session_ai_session_id(&s.id, None)
+            .expect("clear");
+        assert!(changed);
+        assert_eq!(
+            store
+                .load_sessions()
+                .get(&s.id)
+                .expect("present")
+                .ai_session_id,
+            None,
+        );
     }
 
     // ----- Copilot composed_command migration --------------------------

--- a/src-tauri/src/config_store.rs
+++ b/src-tauri/src/config_store.rs
@@ -73,10 +73,18 @@ pub const MAX_INSTRUCTION_FILE_BYTES: u64 = 1024 * 1024;
 /// `update_session_status`, `update_session_ai_session_id`) are
 /// serialized through a process-wide mutex shared by clones of the same
 /// handle. Without this, load-modify-write paths called from different
-/// threads (e.g. the PTY wait thread updating `status` while a metrics
-/// watcher updates `ai_session_id`) would race and silently lose
-/// updates. Atomic file writes alone protect against torn files but
-/// not against lost updates.
+/// threads in the same process (e.g. the PTY wait thread updating
+/// `status` while a metrics watcher updates `ai_session_id`) would race
+/// and silently lose updates. Atomic file writes (`tempfile::persist`)
+/// only protect against torn reads, not against lost updates.
+///
+/// Scope: this guard covers **intra-process** races only. Concurrent
+/// access from a second Arborist process (or a user editing
+/// `sessions.json` by hand while the app is running) is **not**
+/// supported — those races would require OS-level advisory file locking
+/// or a single-writer daemon, neither of which we implement today. The
+/// app is designed for one running instance per user; the store path
+/// itself is per-user via `tauri-plugin-store`.
 #[derive(Debug, Clone)]
 pub struct ConfigStore {
     dir: PathBuf,

--- a/src-tauri/src/config_store.rs
+++ b/src-tauri/src/config_store.rs
@@ -71,20 +71,27 @@ pub const MAX_INSTRUCTION_FILE_BYTES: u64 = 1024 * 1024;
 ///
 /// All write paths (`save_config`, `save_session`, `remove_session`,
 /// `update_session_status`, `update_session_ai_session_id`) are
-/// serialized through a process-wide mutex shared by clones of the same
-/// handle. Without this, load-modify-write paths called from different
-/// threads in the same process (e.g. the PTY wait thread updating
-/// `status` while a metrics watcher updates `ai_session_id`) would race
-/// and silently lose updates. Atomic file writes (`tempfile::persist`)
-/// only protect against torn reads, not against lost updates.
+/// serialized through a mutex shared by clones of the same handle.
+/// Without this, load-modify-write paths called from different threads
+/// using the same `ConfigStore` instance (e.g. the PTY wait thread
+/// updating `status` while a metrics watcher updates `ai_session_id`)
+/// would race and silently lose updates. Atomic file writes
+/// (`tempfile::persist`) only protect against torn reads, not against
+/// lost updates.
 ///
-/// Scope: this guard covers **intra-process** races only. Concurrent
-/// access from a second Arborist process (or a user editing
-/// `sessions.json` by hand while the app is running) is **not**
-/// supported — those races would require OS-level advisory file locking
-/// or a single-writer daemon, neither of which we implement today. The
-/// app is designed for one running instance per user; the store path
-/// itself is per-user via `tauri-plugin-store`.
+/// Scope: this guard covers writes performed through clones of the same
+/// `ConfigStore` only. Separately opened `ConfigStore` instances
+/// pointing at the same directory do **not** share this mutex and are
+/// therefore not serialized against each other — which is why
+/// command handlers route through the managed `AppContext`'s store
+/// (see `commands::store_for` rustdoc) rather than calling
+/// `ConfigStore::open` per request. Concurrent access from a second
+/// Arborist process (or a user editing `sessions.json` by hand while
+/// the app is running) is also **not** supported — those races would
+/// require OS-level advisory file locking or a single-writer daemon,
+/// neither of which we implement today. The app is designed for one
+/// running instance per user; the store path itself is per-user via
+/// `tauri-plugin-store`.
 #[derive(Debug, Clone)]
 pub struct ConfigStore {
     dir: PathBuf,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -125,6 +125,7 @@ pub fn run() {
             )));
             let sink = commands::build_production_sink(app.handle().clone(), store.clone());
             let metrics_emit = commands::build_production_metrics_emit(app.handle().clone());
+            let ai_session_discover = commands::build_production_ai_session_discover(store.clone());
             let git_runner: std::sync::Arc<dyn git::GitRunner> =
                 std::sync::Arc::new(git::RealGitRunner);
             let ctx = std::sync::Arc::new(commands::AppContext::new(
@@ -133,6 +134,7 @@ pub fn run() {
                 sink,
                 git_runner,
                 metrics_emit,
+                ai_session_discover,
             ));
             app.manage(ctx);
             Ok(())

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -220,11 +220,11 @@ impl MetricsRegistry {
     /// `Session.ai_session_id`) that the worker's discovery callback
     /// could otherwise overwrite from a final in-flight poll iteration.
     ///
-    /// Worst-case wait is one `POLL_INTERVAL` (~200ms) since the worker
-    /// only re-checks `running` at the top of its loop. Errors from the
-    /// underlying thread `join()` are swallowed — there is nothing
-    /// meaningful the caller can do, and the registry entry has already
-    /// been removed.
+    /// Worst-case wait is one `POLL_INTERVAL` (~2s with the current
+    /// configuration) since the worker only re-checks `running` at the
+    /// top of its loop. Errors from the underlying thread `join()` are
+    /// swallowed — there is nothing meaningful the caller can do, and
+    /// the registry entry has already been removed.
     pub fn stop_and_join(&self, session_id: &SessionId) {
         let removed = self
             .inner

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -392,7 +392,7 @@ pub fn encode_cwd(cwd: &Path) -> String {
     out
 }
 
-fn home_dir() -> Option<PathBuf> {
+pub(crate) fn home_dir() -> Option<PathBuf> {
     if let Ok(p) = std::env::var("HOME") {
         if !p.is_empty() {
             return Some(PathBuf::from(p));

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -85,6 +85,17 @@ pub const POLL_INTERVAL: Duration = Duration::from_millis(2000);
 /// channel sender.
 pub type MetricsCb = Arc<dyn Fn(SessionMetricsEvent) + Send + Sync>;
 
+/// Callback the watcher invokes when it discovers (or learns of a change
+/// to) the AI-side session id for an Arborist session. Production wires
+/// this into `ConfigStore::update_session_ai_session_id` so the next
+/// app-restart restore can inject `--resume <id>` and continue the AI
+/// conversation. Tests substitute a capturing closure.
+///
+/// Idempotent: the watcher fires this on every detected change, but
+/// `update_session_ai_session_id` is a no-op when the value already
+/// matches.
+pub type AiSessionDiscoveryCb = Arc<dyn Fn(SessionId, String) + Send + Sync>;
+
 /// Per-session running watcher handle. Drop semantics: clearing the
 /// `running` flag stops the watcher thread on its next poll iteration; the
 /// thread's `JoinHandle` is detached so dropping the registry entry never
@@ -122,6 +133,7 @@ impl MetricsRegistry {
         cwd: PathBuf,
         spawn_instant: SystemTime,
         emit: MetricsCb,
+        discover: AiSessionDiscoveryCb,
     ) -> bool {
         // Stop any existing watcher first so the per-tool worker starts
         // from a clean slate (used by session restart).
@@ -145,6 +157,7 @@ impl MetricsRegistry {
                             cwd_for_thread,
                             spawn_instant,
                             emit,
+                            discover,
                             running_for_thread,
                         );
                     })
@@ -154,7 +167,13 @@ impl MetricsRegistry {
                 thread::Builder::new()
                     .name(format!("arborist-metrics-{}", session_id))
                     .spawn(move || {
-                        run_copilot_watcher(session_id, otel_path, emit, running_for_thread);
+                        run_copilot_watcher(
+                            session_id,
+                            otel_path,
+                            emit,
+                            discover,
+                            running_for_thread,
+                        );
                     })
             }
         };
@@ -210,6 +229,7 @@ fn run_claude_watcher(
     cwd: PathBuf,
     spawn_instant: SystemTime,
     emit: MetricsCb,
+    discover: AiSessionDiscoveryCb,
     running: Arc<AtomicBool>,
 ) {
     let project_dir = home.join(".claude").join("projects").join(encode_cwd(&cwd));
@@ -233,6 +253,13 @@ fn run_claude_watcher(
                 tracked_len = 0;
                 totals = TurnTotals::default();
                 last_model = None;
+                // The tracked file's stem is Claude's session id (the
+                // directory layout is `<encoded-cwd>/<sessionId>.jsonl`).
+                // Fire the AI-session discovery callback so the next
+                // app-restart restore can `--resume <id>`.
+                if let Some(stem) = c.file_stem().and_then(|s| s.to_str()) {
+                    discover(session_id, stem.to_owned());
+                }
             }
 
             if let Ok(meta) = std::fs::metadata(&c) {
@@ -285,11 +312,13 @@ fn run_copilot_watcher(
     session_id: SessionId,
     otel_path: PathBuf,
     emit: MetricsCb,
+    discover: AiSessionDiscoveryCb,
     running: Arc<AtomicBool>,
 ) {
     let mut state = CopilotState::default();
     let mut cursor: u64 = 0;
     let mut last_emitted: Option<SessionMetricsEvent> = None;
+    let mut last_announced_conversation: Option<String> = None;
 
     while running.load(Ordering::SeqCst) {
         if let Ok(meta) = std::fs::metadata(&otel_path) {
@@ -301,11 +330,25 @@ fn run_copilot_watcher(
                 cursor = 0;
                 state = CopilotState::default();
                 last_emitted = None;
+                last_announced_conversation = None;
             }
             if len > cursor {
                 cursor = tail_lines(&otel_path, cursor, len, |line| {
                     ingest_otel_line(line, &mut state);
                 });
+            }
+        }
+
+        // Surface the Copilot conversation id as soon as we see it. The
+        // OTel file is per-Arborist-session (controlled by `env_for_tool`
+        // via `COPILOT_OTEL_FILE_EXPORTER_PATH`), so this is unambiguous
+        // even when multiple Copilot sessions run concurrently — unlike
+        // a directory-scan of `~/.copilot/session-state/`. Fire only on
+        // change to keep the per-poll work cheap.
+        if let Some(conv) = state.conversation_id.as_ref() {
+            if last_announced_conversation.as_ref() != Some(conv) {
+                discover(session_id, conv.clone());
+                last_announced_conversation = Some(conv.clone());
             }
         }
 
@@ -668,6 +711,11 @@ pub(crate) struct CopilotState {
     /// the conversational context the agent had in front of it at the
     /// moment of the span. Drives the sidebar's "context % used".
     current_tokens: Option<u64>,
+    /// Copilot's conversation/session id (`gen_ai.conversation.id`),
+    /// matching the directory name under `~/.copilot/session-state/<id>/`
+    /// and accepted by `copilot --resume <id>`. Captured for AI-session
+    /// discovery; not part of the metrics snapshot.
+    pub(crate) conversation_id: Option<String>,
     /// True once at least one chat span has been ingested.
     seen: bool,
 }
@@ -764,6 +812,15 @@ pub(crate) fn ingest_otel_line(line: &[u8], state: &mut CopilotState) {
         })
     {
         state.last_model = Some(model.to_owned());
+    }
+
+    if let Some(conv) = attrs
+        .and_then(|a| a.get("gen_ai.conversation.id"))
+        .and_then(|v| v.as_str())
+    {
+        if !conv.is_empty() {
+            state.conversation_id = Some(conv.to_owned());
+        }
     }
 
     if let Some(events) = outer.events.as_ref() {
@@ -1006,6 +1063,7 @@ mod tests {
             PathBuf::from("/tmp"),
             SystemTime::now(),
             cb,
+            Arc::new(|_, _| {}),
         );
         assert!(started, "Copilot watcher must start");
         assert!(
@@ -1081,6 +1139,28 @@ mod tests {
         assert_eq!(state.last_model.as_deref(), Some("claude-opus-4.7"));
         assert_eq!(state.token_limit, Some(168_000));
         assert_eq!(state.current_tokens, Some(29_461));
+    }
+
+    #[test]
+    fn ingest_otel_chat_span_extracts_conversation_id() {
+        // The chat span carries `gen_ai.conversation.id` — that's the
+        // Copilot session id we feed back into `--resume`.
+        let chat_line = fixture_lines()
+            .into_iter()
+            .find(|l| {
+                std::str::from_utf8(l)
+                    .unwrap_or("")
+                    .contains(r#""name":"chat "#)
+            })
+            .expect("chat span in fixture");
+        let mut state = CopilotState::default();
+        ingest_otel_line(chat_line, &mut state);
+        assert!(
+            state.conversation_id.is_some(),
+            "chat span must populate conversation_id",
+        );
+        let id = state.conversation_id.as_deref().expect("present");
+        assert!(!id.is_empty(), "conversation id must be non-empty");
     }
 
     #[test]
@@ -1234,7 +1314,13 @@ mod tests {
         });
         let path_for_thread = path.clone();
         let handle = std::thread::spawn(move || {
-            run_copilot_watcher(session_id, path_for_thread, cb, running_for_thread);
+            run_copilot_watcher(
+                session_id,
+                path_for_thread,
+                cb,
+                Arc::new(|_, _| {}),
+                running_for_thread,
+            );
         });
 
         // Append the fixture (one chat span + invoke_agent + metrics) and
@@ -1271,7 +1357,13 @@ mod tests {
         });
         let path_for_thread = path.clone();
         let handle = std::thread::spawn(move || {
-            run_copilot_watcher(session_id, path_for_thread, cb, running_for_thread);
+            run_copilot_watcher(
+                session_id,
+                path_for_thread,
+                cb,
+                Arc::new(|_, _| {}),
+                running_for_thread,
+            );
         });
 
         // 1) Initial usage from the full fixture.
@@ -1476,6 +1568,7 @@ mod tests {
                 cwd_for_thread,
                 spawn_instant,
                 cb,
+                Arc::new(|_, _| {}),
                 running_for_thread,
             );
         });

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -97,11 +97,14 @@ pub type MetricsCb = Arc<dyn Fn(SessionMetricsEvent) + Send + Sync>;
 pub type AiSessionDiscoveryCb = Arc<dyn Fn(SessionId, String) + Send + Sync>;
 
 /// Per-session running watcher handle. Drop semantics: clearing the
-/// `running` flag stops the watcher thread on its next poll iteration; the
-/// thread's `JoinHandle` is detached so dropping the registry entry never
-/// blocks the caller.
+/// `running` flag stops the watcher thread on its next poll iteration. We
+/// also retain the `JoinHandle` so callers that need a quiescence
+/// guarantee (e.g. `session_restart_impl`, which clears
+/// `Session.ai_session_id` and must ensure no late discovery callback
+/// can persist the stale id back) can use [`MetricsRegistry::stop_and_join`].
 struct WatcherHandle {
     running: Arc<AtomicBool>,
+    join: Option<thread::JoinHandle<()>>,
 }
 
 /// Registry of active per-session watchers. Stored on `AppContext`. Calls
@@ -178,11 +181,14 @@ impl MetricsRegistry {
             }
         };
         match join {
-            Ok(_handle) => {
-                self.inner
-                    .lock()
-                    .expect("metrics registry lock")
-                    .insert(session_id, WatcherHandle { running });
+            Ok(handle) => {
+                self.inner.lock().expect("metrics registry lock").insert(
+                    session_id,
+                    WatcherHandle {
+                        running,
+                        join: Some(handle),
+                    },
+                );
                 true
             }
             Err(e) => {
@@ -193,6 +199,10 @@ impl MetricsRegistry {
     }
 
     /// Stop the watcher for `session_id` if any. Idempotent.
+    ///
+    /// Returns immediately after flipping the `running` flag — the worker
+    /// thread observes it on its next poll. Use [`Self::stop_and_join`]
+    /// when you need a guarantee that no further callbacks will fire.
     pub fn stop(&self, session_id: &SessionId) {
         let removed = self
             .inner
@@ -201,6 +211,31 @@ impl MetricsRegistry {
             .remove(session_id);
         if let Some(h) = removed {
             h.running.store(false, Ordering::SeqCst);
+        }
+    }
+
+    /// Stop the watcher and block until its worker thread has fully
+    /// exited. Idempotent. Use this when you need a quiescence guarantee
+    /// — i.e., when subsequent code mutates state (like
+    /// `Session.ai_session_id`) that the worker's discovery callback
+    /// could otherwise overwrite from a final in-flight poll iteration.
+    ///
+    /// Worst-case wait is one `POLL_INTERVAL` (~200ms) since the worker
+    /// only re-checks `running` at the top of its loop. Errors from the
+    /// underlying thread `join()` are swallowed — there is nothing
+    /// meaningful the caller can do, and the registry entry has already
+    /// been removed.
+    pub fn stop_and_join(&self, session_id: &SessionId) {
+        let removed = self
+            .inner
+            .lock()
+            .expect("metrics registry lock")
+            .remove(session_id);
+        if let Some(mut h) = removed {
+            h.running.store(false, Ordering::SeqCst);
+            if let Some(handle) = h.join.take() {
+                let _ = handle.join();
+            }
         }
     }
 

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -147,6 +147,14 @@ pub struct Session {
     /// [`SessionView`].
     #[serde(default)]
     pub temp_files: Vec<TempFileSpec>,
+    /// Most recently observed AI-side session id (Claude transcript file
+    /// stem; Copilot OTel `gen_ai.conversation.id` / session-state dir
+    /// name). When set, `restore_all_sessions` augments the spawn command
+    /// with `--resume <id>` so the conversation continues across an app
+    /// restart. Backend-only — omitted from [`SessionView`]; not surfaced
+    /// to the frontend today.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ai_session_id: Option<String>,
 }
 
 /// Frontend-facing projection of [`Session`]. Intentionally drops
@@ -749,6 +757,7 @@ mod tests {
                 path: PathBuf::from("/tmp/arborist/abc/sp.md"),
                 contents: "context".to_owned(),
             }],
+            ai_session_id: None,
         }
     }
 

--- a/src-tauri/tests/pty_pool.rs
+++ b/src-tauri/tests/pty_pool.rs
@@ -51,6 +51,7 @@ fn make_session(workdir: &Path) -> Session {
         created_at: 0,
         tab_index: 0,
         temp_files: Vec::new(),
+        ai_session_id: None,
     }
 }
 
@@ -339,6 +340,7 @@ fn make_copilot_session(workdir: &Path) -> Session {
         created_at: 0,
         tab_index: 0,
         temp_files: Vec::new(),
+        ai_session_id: None,
     }
 }
 

--- a/src-tauri/tests/workspace_command.rs
+++ b/src-tauri/tests/workspace_command.rs
@@ -85,6 +85,7 @@ fn build_ctx(git: Arc<dyn GitRunner>, store_dir: &TempDir) -> Arc<AppContext> {
         null_sink(),
         git,
         Arc::new(|_| {}),
+        Arc::new(|_, _| {}),
     ))
 }
 

--- a/src-tauri/tests/worktrees_command.rs
+++ b/src-tauri/tests/worktrees_command.rs
@@ -68,6 +68,7 @@ fn build_ctx(git: Arc<dyn GitRunner>, store_dir: &TempDir) -> Arc<AppContext> {
         null_sink(),
         git,
         Arc::new(|_| {}),
+        Arc::new(|_, _| {}),
     ))
 }
 

--- a/src/types/arborist.test.ts
+++ b/src/types/arborist.test.ts
@@ -95,7 +95,7 @@ describe('arborist type mirrors', () => {
         'tabIndex',
         'tempFiles',
       ],
-      ['pid', 'instructionSetId'],
+      ['pid', 'instructionSetId', 'aiSessionId'],
       'Session',
     );
   });

--- a/src/types/arborist.ts
+++ b/src/types/arborist.ts
@@ -42,6 +42,13 @@ export interface Session {
   createdAt: number;
   tabIndex: number;
   tempFiles: TempFileSpec[];
+  /**
+   * Most recently observed AI-side session id. When set, the backend
+   * augments the spawn command with `--resume <id>` on app-restart
+   * restore so the conversation continues. Backend-only — currently
+   * not exposed on `SessionView`.
+   */
+  aiSessionId?: string;
 }
 
 // MIRROR: src-tauri/src/types.rs::SessionView


### PR DESCRIPTION
Closes the gap where reopening Arborist re-spawns persisted sessions but the underlying Claude/Copilot CLI starts a brand-new conversation.

## What changes

- New `Session.ai_session_id: Option<String>` (Rust + TS mirror), discovered post-spawn by the existing metrics watchers:
  - **Claude** — file stem of the JSONL the watcher already tracks
  - **Copilot** — `gen_ai.conversation.id` from the OTel JSONL we already tail (per-Arborist-session, so unambiguous)
- Discovery callback (`AiSessionDiscoveryCb`) plumbed through `AppContext` to both watchers, persisted via new mutex-guarded `ConfigStore::update_session_ai_session_id` (idempotent — returns early on no-change to avoid disk-write churn).
- `compose::with_resume` augments `composed_command` at restore time **only** (not on user-initiated `session_restart`, which intentionally starts fresh). The persisted `composed_command` is **never** mutated — DESIGN §5.4's no-recompose rule still holds for the stored record.
- Preflight existence check skips `--resume` (and clears the stale id) if the underlying transcript was deleted between launches.
- `ConfigStore` now serializes all writers through a process-wide mutex, fixing a real intra-process race between the PTY wait thread (`update_session_status`) and the metrics watcher thread (`update_session_ai_session_id`).

## Tests

12 new unit tests:
- `compose::with_resume` — bare command, with `--system-prompt`, with prelaunch chains, with shell-metachar ids
- `ConfigStore::update_session_ai_session_id` — persists, idempotent, NotFound, can clear
- `ingest_otel_line` — chat span populates `conversation_id`

Quality gate (all green): `cargo fmt`, `cargo clippy -D warnings`, 218 lib + integration tests, `npm run lint`, 205 vitest tests.

## Docs

- `DESIGN.md` §3 documents the new field; §5.4 calls out that user-restart is fresh by design; §5.5 documents augment-not-recompose at restore.

## Known limitation

For Claude, the AI-session id is discovered heuristically from the newest JSONL in the project dir post-spawn. Two Arborist sessions sharing the same worktree can converge on the same file and persist the same id. The fix is a hook-driven id source (tracked in #4 / ROADMAP §4.5). The single-session-per-worktree case (the common one) is unaffected. Documented inline in `restore_all_sessions`.

## Out of scope (cross-process)

The `ConfigStore` mutex covers intra-process races only. Concurrent access from a second Arborist instance is unsupported by design (would need OS advisory locking or a single-writer daemon). Documented on `ConfigStore`'s doc-comment.