### PR TITLE
fix(terminal): send ESC+CR for Shift+Enter so CLIs see a newline

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -28,16 +28,18 @@ fn git_command() -> Command {
 /// Detect the git branch name this build is being produced from.
 ///
 /// Resolution order:
-///   1. `ARBORIST_BUILD_BRANCH` (explicit override)
-///   2. `GITHUB_HEAD_REF` (set in PR builds — source branch, not `merge`)
-///   3. `GITHUB_REF_NAME` (set in branch/tag builds)
-///   4. `git rev-parse --abbrev-ref HEAD`
+///   1. `GITHUB_HEAD_REF` (set in PR builds — source branch, not `merge`)
+///   2. `GITHUB_REF_NAME` (set in branch/tag builds)
+///   3. `git rev-parse --abbrev-ref HEAD`
 ///
 /// Returns an empty string if none succeed or the branch is detached / `HEAD`.
+///
+/// Note: there is intentionally no `ARBORIST_BUILD_BRANCH` override input.
+/// CI vars + git already cover every legitimate case, and an env-var input
+/// would silently leak into PTY children spawned by the running app (which
+/// inherit the build/dev shell's env), baking the wrong branch into any
+/// nested `tauri:dev` invocation.
 fn detect_branch() -> String {
-    if let Ok(b) = std::env::var("ARBORIST_BUILD_BRANCH") {
-        return b.trim().to_string();
-    }
     for var in ["GITHUB_HEAD_REF", "GITHUB_REF_NAME"] {
         if let Ok(v) = std::env::var(var) {
             let v = v.trim();
@@ -64,11 +66,10 @@ fn detect_branch() -> String {
 
 /// Sanitize a branch name before embedding it in a `cargo:` directive.
 ///
-/// Branch names can in principle contain control characters (notably
-/// newlines via the `ARBORIST_BUILD_BRANCH` override).  Without sanitization
-/// a malicious or malformed value could inject extra `cargo:` lines into
-/// the build output.  Restrict to a single-line, conservative character set:
-/// ASCII alphanumerics plus `-_./+:`.  Anything else is dropped.
+/// CI-provided env vars (`GITHUB_*`) are normally well-formed, but defense
+/// in depth: restrict to a single line and a conservative character set
+/// (ASCII alphanumerics plus `-_./+:`) so a malformed value can't inject
+/// extra `cargo:` lines into the build output.
 fn sanitize_branch(raw: &str) -> String {
     raw.lines()
         .next()
@@ -82,8 +83,9 @@ fn main() {
     let branch = sanitize_branch(&detect_branch());
     println!("cargo:rustc-env=ARBORIST_BUILD_BRANCH={branch}");
 
-    // Re-run when the override or CI env vars change.
-    println!("cargo:rerun-if-env-changed=ARBORIST_BUILD_BRANCH");
+    // Re-run when CI env vars change. We deliberately do NOT
+    // `rerun-if-env-changed=ARBORIST_BUILD_BRANCH` — that variable is no
+    // longer an input (see `detect_branch` doc comment).
     println!("cargo:rerun-if-env-changed=GITHUB_HEAD_REF");
     println!("cargo:rerun-if-env-changed=GITHUB_REF_NAME");
 

--- a/src-tauri/src/pty_pool.rs
+++ b/src-tauri/src/pty_pool.rs
@@ -165,19 +165,23 @@ const ARBORIST_ENV_PREFIX: &str = "ARBORIST_";
 /// stripped too. On Unix the names are technically distinct but the prefix
 /// is by convention reserved regardless of case, so this is also defensible
 /// (and safer than surprising callers with platform-divergent behaviour).
+///
+/// We compare on raw `OsStr` bytes (`as_encoded_bytes()`) rather than
+/// `to_str()` so non-UTF-8 keys (legal on Unix) whose leading bytes match
+/// `ARBORIST_` are still stripped — `to_str()` would return `None` and
+/// silently leak them.
 fn strip_arborist_env_keys<I, K>(builder: &mut CommandBuilder, keys: I)
 where
     I: IntoIterator<Item = K>,
     K: AsRef<std::ffi::OsStr>,
 {
+    let prefix_bytes = ARBORIST_ENV_PREFIX.as_bytes();
     for k in keys {
-        if let Some(s) = k.as_ref().to_str() {
-            if s.len() >= ARBORIST_ENV_PREFIX.len()
-                && s.as_bytes()[..ARBORIST_ENV_PREFIX.len()]
-                    .eq_ignore_ascii_case(ARBORIST_ENV_PREFIX.as_bytes())
-            {
-                builder.env_remove(k.as_ref());
-            }
+        let key_bytes = k.as_ref().as_encoded_bytes();
+        if key_bytes.len() >= prefix_bytes.len()
+            && key_bytes[..prefix_bytes.len()].eq_ignore_ascii_case(prefix_bytes)
+        {
+            builder.env_remove(k.as_ref());
         }
     }
 }
@@ -1198,13 +1202,25 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(env)]
     fn strip_arborist_env_production_path_strips_real_env_var() {
         // Exercise the production wrapper that reads `std::env::vars_os()`,
         // ensuring the OsString-based iteration path actually removes a
         // matching key from the resulting CommandBuilder. Use a
         // unique-per-test key so concurrent tests can't false-positive
-        // (std::env mutations are process-global).
+        // (std::env mutations are process-global). Marked `#[serial(env)]`
+        // so the test suite serializes any other env-mutating tests against
+        // this one — `std::env::set_var`/`remove_var` are process-global
+        // and inherently racy with concurrent reads.
+        struct EnvProbe(&'static str);
+        impl Drop for EnvProbe {
+            fn drop(&mut self) {
+                std::env::remove_var(self.0);
+            }
+        }
+
         let key = "ARBORIST_TEST_PROBE_PRODUCTION_PATH_8C4A";
+        let _guard = EnvProbe(key);
         std::env::set_var(key, "1");
         let mut b = CommandBuilder::new("/bin/true");
         // Don't env_clear here — we need the inherited env to include our key.
@@ -1213,8 +1229,6 @@ mod tests {
             .iter_full_env_as_str()
             .map(|(k, _)| k.to_string())
             .collect();
-        // Cleanup before assertion so a failure doesn't leak into other tests.
-        std::env::remove_var(key);
         assert!(
             !remaining.iter().any(|k| k == key),
             "production strip_arborist_env failed to remove {key} via vars_os(); remaining keys with ARBORIST prefix: {:?}",
@@ -1222,6 +1236,35 @@ mod tests {
                 .iter()
                 .filter(|k| k.to_ascii_uppercase().starts_with("ARBORIST_"))
                 .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn strip_arborist_env_strips_non_utf8_keys() {
+        // Env-var names on Unix are arbitrary `OsStr` byte sequences, not
+        // guaranteed UTF-8. A key whose leading bytes are `ARBORIST_` but
+        // whose trailing bytes are non-UTF-8 must still be stripped — the
+        // earlier `to_str()`-gated impl would silently leak such keys.
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        // "ARBORIST_" + invalid UTF-8 byte (0xFF is never valid UTF-8).
+        let mut bytes = b"ARBORIST_".to_vec();
+        bytes.push(0xFF);
+        bytes.extend_from_slice(b"_TAIL");
+        let bad: OsString = OsString::from_vec(bytes);
+
+        let mut b = CommandBuilder::new("/bin/true");
+        b.env_clear();
+        b.env(&bad, "leak-me");
+        // Sanity: the bad key starts in the env before the strip.
+        assert!(b.get_env(&bad).is_some(), "test setup: env not seeded");
+
+        strip_arborist_env_keys(&mut b, vec![bad.clone()]);
+        assert!(
+            b.get_env(&bad).is_none(),
+            "non-UTF-8 ARBORIST_* key was not stripped"
         );
     }
 }

--- a/src-tauri/src/pty_pool.rs
+++ b/src-tauri/src/pty_pool.rs
@@ -146,6 +146,9 @@ pub trait PtyKiller: Send + Sync {
 // Production spawner (portable-pty)
 // ---------------------------------------------------------------------------
 
+/// The reserved env-var namespace prefix for Arborist's own build/dev tooling.
+const ARBORIST_ENV_PREFIX: &str = "ARBORIST_";
+
 /// Strip every `ARBORIST_*` env var from the inherited environment of `builder`.
 ///
 /// `portable_pty::CommandBuilder` snapshots the current process env at
@@ -155,6 +158,13 @@ pub trait PtyKiller: Send + Sync {
 /// Arborist's own build/dev tooling (e.g. `ARBORIST_BUILD_BRANCH` from
 /// build.rs, `ARBORIST_DEV_PORT` from `scripts/tauri-dev.mjs`) and must
 /// never leak into the user shells we spawn.
+///
+/// Prefix matching is **case-insensitive** (ASCII): on Windows env-var names
+/// are themselves case-insensitive, so a stray `Arborist_Dev_Port` set by an
+/// outer shell is the same variable as `ARBORIST_DEV_PORT` and must be
+/// stripped too. On Unix the names are technically distinct but the prefix
+/// is by convention reserved regardless of case, so this is also defensible
+/// (and safer than surprising callers with platform-divergent behaviour).
 fn strip_arborist_env_keys<I, K>(builder: &mut CommandBuilder, keys: I)
 where
     I: IntoIterator<Item = K>,
@@ -162,7 +172,10 @@ where
 {
     for k in keys {
         if let Some(s) = k.as_ref().to_str() {
-            if s.starts_with("ARBORIST_") {
+            if s.len() >= ARBORIST_ENV_PREFIX.len()
+                && s.as_bytes()[..ARBORIST_ENV_PREFIX.len()]
+                    .eq_ignore_ascii_case(ARBORIST_ENV_PREFIX.as_bytes())
+            {
                 builder.env_remove(k.as_ref());
             }
         }
@@ -1100,7 +1113,9 @@ mod tests {
     }
 
     /// Build a probe builder seeded with the supplied env, then strip
-    /// `ARBORIST_*` keys and return the remaining keys.
+    /// `ARBORIST_*` keys and return the remaining keys. Mirrors production
+    /// by feeding the strip helper an iterator of owned `OsString`s — the
+    /// same shape `std::env::vars_os()` produces.
     fn keys_after_strip(seed: &[(&str, &str)], strip_keys: &[&str]) -> Vec<String> {
         let mut b = CommandBuilder::new("/bin/true");
         // Replace the auto-inherited env with a known-good set so the
@@ -1109,7 +1124,8 @@ mod tests {
         for (k, v) in seed {
             b.env(*k, *v);
         }
-        strip_arborist_env_keys(&mut b, strip_keys.iter().copied());
+        let owned: Vec<std::ffi::OsString> = strip_keys.iter().map(|s| (*s).into()).collect();
+        strip_arborist_env_keys(&mut b, owned);
         b.iter_full_env_as_str()
             .map(|(k, _)| k.to_string())
             .collect()
@@ -1128,26 +1144,84 @@ mod tests {
         );
         assert!(keys.iter().any(|k| k == "PATH"));
         assert!(keys.iter().any(|k| k == "HOME"));
-        assert!(!keys.iter().any(|k| k.starts_with("ARBORIST_")));
+        assert!(!keys
+            .iter()
+            .any(|k| k.to_ascii_uppercase().starts_with("ARBORIST_")));
     }
 
     #[test]
     fn strip_arborist_env_preserves_lookalike_keys() {
-        // Names that contain but don't start with the prefix must survive.
+        // Names that *contain* but don't *start with* the prefix must survive.
         let keys = keys_after_strip(
-            &[
-                ("MY_ARBORIST_VAR", "x"),
-                ("arborist_lower", "x"), // case-sensitive: must survive
-            ],
-            &["MY_ARBORIST_VAR", "arborist_lower"],
+            &[("MY_ARBORIST_VAR", "x"), ("ARBORISH_DEV", "x")],
+            &["MY_ARBORIST_VAR", "ARBORISH_DEV"],
         );
         assert!(keys.iter().any(|k| k == "MY_ARBORIST_VAR"));
-        assert!(keys.iter().any(|k| k == "arborist_lower"));
+        assert!(keys.iter().any(|k| k == "ARBORISH_DEV"));
+    }
+
+    #[test]
+    fn strip_arborist_env_is_case_insensitive() {
+        // On Windows env-var names are case-insensitive, so any casing of
+        // the prefix is the same variable and must be stripped. Unix
+        // matches the same behaviour for namespace-hygiene consistency.
+        let keys = keys_after_strip(
+            &[
+                ("Arborist_Build_Branch", "main"),
+                ("arborist_dev_port", "1494"),
+                ("ARBORIST_FOO", "x"),
+                ("PATH", "/usr/bin"),
+            ],
+            &[
+                "Arborist_Build_Branch",
+                "arborist_dev_port",
+                "ARBORIST_FOO",
+                "PATH",
+            ],
+        );
+        assert_eq!(keys, vec!["PATH".to_string()]);
+    }
+
+    #[test]
+    fn strip_arborist_env_ignores_short_or_empty_keys() {
+        // Keys shorter than the prefix can't match; ensure the length
+        // guard doesn't underflow / panic.
+        let keys = keys_after_strip(&[("AR", "x"), ("A", "y")], &["AR", "A"]);
+        assert!(keys.iter().any(|k| k == "AR"));
+        assert!(keys.iter().any(|k| k == "A"));
     }
 
     #[test]
     fn strip_arborist_env_is_noop_when_no_match() {
         let before = keys_after_strip(&[("PATH", "/usr/bin")], &["PATH"]);
         assert_eq!(before, vec!["PATH".to_string()]);
+    }
+
+    #[test]
+    fn strip_arborist_env_production_path_strips_real_env_var() {
+        // Exercise the production wrapper that reads `std::env::vars_os()`,
+        // ensuring the OsString-based iteration path actually removes a
+        // matching key from the resulting CommandBuilder. Use a
+        // unique-per-test key so concurrent tests can't false-positive
+        // (std::env mutations are process-global).
+        let key = "ARBORIST_TEST_PROBE_PRODUCTION_PATH_8C4A";
+        std::env::set_var(key, "1");
+        let mut b = CommandBuilder::new("/bin/true");
+        // Don't env_clear here — we need the inherited env to include our key.
+        strip_arborist_env(&mut b);
+        let remaining: Vec<String> = b
+            .iter_full_env_as_str()
+            .map(|(k, _)| k.to_string())
+            .collect();
+        // Cleanup before assertion so a failure doesn't leak into other tests.
+        std::env::remove_var(key);
+        assert!(
+            !remaining.iter().any(|k| k == key),
+            "production strip_arborist_env failed to remove {key} via vars_os(); remaining keys with ARBORIST prefix: {:?}",
+            remaining
+                .iter()
+                .filter(|k| k.to_ascii_uppercase().starts_with("ARBORIST_"))
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/src-tauri/src/pty_pool.rs
+++ b/src-tauri/src/pty_pool.rs
@@ -146,6 +146,34 @@ pub trait PtyKiller: Send + Sync {
 // Production spawner (portable-pty)
 // ---------------------------------------------------------------------------
 
+/// Strip every `ARBORIST_*` env var from the inherited environment of `builder`.
+///
+/// `portable_pty::CommandBuilder` snapshots the current process env at
+/// construction; `env_remove` records an unset that overrides those entries
+/// when the child is spawned. We enumerate `keys` and remove anything
+/// beginning with the `ARBORIST_` prefix — that namespace is reserved for
+/// Arborist's own build/dev tooling (e.g. `ARBORIST_BUILD_BRANCH` from
+/// build.rs, `ARBORIST_DEV_PORT` from `scripts/tauri-dev.mjs`) and must
+/// never leak into the user shells we spawn.
+fn strip_arborist_env_keys<I, K>(builder: &mut CommandBuilder, keys: I)
+where
+    I: IntoIterator<Item = K>,
+    K: AsRef<std::ffi::OsStr>,
+{
+    for k in keys {
+        if let Some(s) = k.as_ref().to_str() {
+            if s.starts_with("ARBORIST_") {
+                builder.env_remove(k.as_ref());
+            }
+        }
+    }
+}
+
+/// Production wrapper: feed the current process env into [`strip_arborist_env_keys`].
+fn strip_arborist_env(builder: &mut CommandBuilder) {
+    strip_arborist_env_keys(builder, std::env::vars_os().map(|(k, _)| k));
+}
+
 /// Production [`PtySpawner`] backed by `portable_pty::native_pty_system()`.
 pub struct PortablePtySpawner;
 
@@ -176,6 +204,15 @@ impl PtySpawner for PortablePtySpawner {
         // DESIGN §5.6: cwd is the discrete worktree path — never spliced into
         // the command string.
         builder.cwd(cwd);
+        // Strip Arborist build/dev tooling env vars from the inherited
+        // environment so they don't leak into PTY children. The running app
+        // inherits its launching shell's env, and any `ARBORIST_*` var set
+        // there (e.g. `ARBORIST_BUILD_BRANCH`, `ARBORIST_DEV_PORT` set by
+        // `scripts/tauri-dev.mjs`) would otherwise propagate to user shells
+        // and to nested `tauri:dev` invocations launched from a session,
+        // baking the wrong values into those builds. These vars are only
+        // meaningful at Arborist's own build/launch time.
+        strip_arborist_env(&mut builder);
         // Per-session env additions. The child still inherits the parent
         // process's env (we never call `env_clear`); these are
         // overrides/additions only — see `compose::env_for_tool`.
@@ -1060,5 +1097,57 @@ mod tests {
         assert!(!is_possible_partial(&[0xFF])); // invalid lead
         assert!(!is_possible_partial(&[0x80])); // continuation
         assert!(!is_possible_partial(&[]));
+    }
+
+    /// Build a probe builder seeded with the supplied env, then strip
+    /// `ARBORIST_*` keys and return the remaining keys.
+    fn keys_after_strip(seed: &[(&str, &str)], strip_keys: &[&str]) -> Vec<String> {
+        let mut b = CommandBuilder::new("/bin/true");
+        // Replace the auto-inherited env with a known-good set so the
+        // assertion isn't perturbed by the actual host environment.
+        b.env_clear();
+        for (k, v) in seed {
+            b.env(*k, *v);
+        }
+        strip_arborist_env_keys(&mut b, strip_keys.iter().copied());
+        b.iter_full_env_as_str()
+            .map(|(k, _)| k.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn strip_arborist_env_removes_prefixed_keys() {
+        let keys = keys_after_strip(
+            &[
+                ("PATH", "/usr/bin"),
+                ("ARBORIST_BUILD_BRANCH", "main"),
+                ("ARBORIST_DEV_PORT", "1494"),
+                ("HOME", "/home/u"),
+            ],
+            &["PATH", "ARBORIST_BUILD_BRANCH", "ARBORIST_DEV_PORT", "HOME"],
+        );
+        assert!(keys.iter().any(|k| k == "PATH"));
+        assert!(keys.iter().any(|k| k == "HOME"));
+        assert!(!keys.iter().any(|k| k.starts_with("ARBORIST_")));
+    }
+
+    #[test]
+    fn strip_arborist_env_preserves_lookalike_keys() {
+        // Names that contain but don't start with the prefix must survive.
+        let keys = keys_after_strip(
+            &[
+                ("MY_ARBORIST_VAR", "x"),
+                ("arborist_lower", "x"), // case-sensitive: must survive
+            ],
+            &["MY_ARBORIST_VAR", "arborist_lower"],
+        );
+        assert!(keys.iter().any(|k| k == "MY_ARBORIST_VAR"));
+        assert!(keys.iter().any(|k| k == "arborist_lower"));
+    }
+
+    #[test]
+    fn strip_arborist_env_is_noop_when_no_match() {
+        let before = keys_after_strip(&[("PATH", "/usr/bin")], &["PATH"]);
+        assert_eq!(before, vec!["PATH".to_string()]);
     }
 }

--- a/src/components/MainArea.test.tsx
+++ b/src/components/MainArea.test.tsx
@@ -11,6 +11,7 @@ const mockTerminals: Array<{
   dispose: ReturnType<typeof vi.fn>;
   loadAddon: ReturnType<typeof vi.fn>;
   attachCustomKeyEventHandler: ReturnType<typeof vi.fn>;
+  paste: ReturnType<typeof vi.fn>;
   cols: number;
   rows: number;
 }> = [];
@@ -25,6 +26,7 @@ vi.mock('@xterm/xterm', () => {
       dispose: vi.fn(),
       loadAddon: vi.fn(),
       attachCustomKeyEventHandler: vi.fn(),
+      paste: vi.fn(),
       cols: 80,
       rows: 24,
     };

--- a/src/components/MainArea.test.tsx
+++ b/src/components/MainArea.test.tsx
@@ -10,7 +10,6 @@ const mockTerminals: Array<{
   focus: ReturnType<typeof vi.fn>;
   dispose: ReturnType<typeof vi.fn>;
   loadAddon: ReturnType<typeof vi.fn>;
-  attachCustomKeyEventHandler: ReturnType<typeof vi.fn>;
   paste: ReturnType<typeof vi.fn>;
   cols: number;
   rows: number;
@@ -25,7 +24,6 @@ vi.mock('@xterm/xterm', () => {
       focus: vi.fn(),
       dispose: vi.fn(),
       loadAddon: vi.fn(),
-      attachCustomKeyEventHandler: vi.fn(),
       paste: vi.fn(),
       cols: 80,
       rows: 24,

--- a/src/components/MainArea.test.tsx
+++ b/src/components/MainArea.test.tsx
@@ -10,6 +10,7 @@ const mockTerminals: Array<{
   focus: ReturnType<typeof vi.fn>;
   dispose: ReturnType<typeof vi.fn>;
   loadAddon: ReturnType<typeof vi.fn>;
+  attachCustomKeyEventHandler: ReturnType<typeof vi.fn>;
   cols: number;
   rows: number;
 }> = [];
@@ -23,6 +24,7 @@ vi.mock('@xterm/xterm', () => {
       focus: vi.fn(),
       dispose: vi.fn(),
       loadAddon: vi.fn(),
+      attachCustomKeyEventHandler: vi.fn(),
       cols: 80,
       rows: 24,
     };

--- a/src/components/TerminalView.test.tsx
+++ b/src/components/TerminalView.test.tsx
@@ -11,6 +11,7 @@ const mockTerminals: Array<{
   dispose: ReturnType<typeof vi.fn>;
   loadAddon: ReturnType<typeof vi.fn>;
   attachCustomKeyEventHandler: ReturnType<typeof vi.fn>;
+  paste: ReturnType<typeof vi.fn>;
   cols: number;
   rows: number;
 }> = [];
@@ -25,6 +26,7 @@ vi.mock('@xterm/xterm', () => {
       dispose: vi.fn(),
       loadAddon: vi.fn(),
       attachCustomKeyEventHandler: vi.fn(),
+      paste: vi.fn(),
       cols: 80,
       rows: 24,
     };

--- a/src/components/TerminalView.test.tsx
+++ b/src/components/TerminalView.test.tsx
@@ -10,7 +10,6 @@ const mockTerminals: Array<{
   focus: ReturnType<typeof vi.fn>;
   dispose: ReturnType<typeof vi.fn>;
   loadAddon: ReturnType<typeof vi.fn>;
-  attachCustomKeyEventHandler: ReturnType<typeof vi.fn>;
   paste: ReturnType<typeof vi.fn>;
   cols: number;
   rows: number;
@@ -25,7 +24,6 @@ vi.mock('@xterm/xterm', () => {
       focus: vi.fn(),
       dispose: vi.fn(),
       loadAddon: vi.fn(),
-      attachCustomKeyEventHandler: vi.fn(),
       paste: vi.fn(),
       cols: 80,
       rows: 24,

--- a/src/components/TerminalView.test.tsx
+++ b/src/components/TerminalView.test.tsx
@@ -10,6 +10,7 @@ const mockTerminals: Array<{
   focus: ReturnType<typeof vi.fn>;
   dispose: ReturnType<typeof vi.fn>;
   loadAddon: ReturnType<typeof vi.fn>;
+  attachCustomKeyEventHandler: ReturnType<typeof vi.fn>;
   cols: number;
   rows: number;
 }> = [];
@@ -23,6 +24,7 @@ vi.mock('@xterm/xterm', () => {
       focus: vi.fn(),
       dispose: vi.fn(),
       loadAddon: vi.fn(),
+      attachCustomKeyEventHandler: vi.fn(),
       cols: 80,
       rows: 24,
     };

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -13,9 +13,11 @@ const mockTerminals: Array<{
   dispose: ReturnType<typeof vi.fn>;
   loadAddon: ReturnType<typeof vi.fn>;
   refresh: ReturnType<typeof vi.fn>;
+  attachCustomKeyEventHandler: ReturnType<typeof vi.fn>;
   cols: number;
   rows: number;
   _dataCb?: (data: string) => void;
+  _keyHandler?: (event: KeyboardEvent) => boolean;
 }> = [];
 
 vi.mock('@xterm/xterm', () => {
@@ -28,11 +30,15 @@ vi.mock('@xterm/xterm', () => {
       dispose: vi.fn(),
       loadAddon: vi.fn(),
       refresh: vi.fn(),
+      attachCustomKeyEventHandler: vi.fn(),
       cols: 80,
       rows: 24,
     };
     inst.onData.mockImplementation((cb: (data: string) => void) => {
       inst._dataCb = cb;
+    });
+    inst.attachCustomKeyEventHandler.mockImplementation((cb: (event: KeyboardEvent) => boolean) => {
+      inst._keyHandler = cb;
     });
     mockTerminals.push(inst);
     return inst;
@@ -129,6 +135,102 @@ describe('useTerminal', () => {
     const cb = mockTerminals[0]!._dataCb!;
     act(() => cb('hello'));
     expect(sessionInput).toHaveBeenCalledWith({ sessionId: 's1', data: 'hello' });
+  });
+
+  it('Shift+Enter sends ESC+CR via sessionInput and suppresses xterm default', () => {
+    renderHook(() => useTerminal('s1'));
+    const handler = mockTerminals[0]!._keyHandler!;
+    expect(handler).toBeTypeOf('function');
+    const evt = {
+      type: 'keydown',
+      key: 'Enter',
+      shiftKey: true,
+      ctrlKey: false,
+      altKey: false,
+      metaKey: false,
+    } as unknown as KeyboardEvent;
+    const result = handler(evt);
+    expect(result).toBe(false);
+    expect(sessionInput).toHaveBeenCalledWith({ sessionId: 's1', data: '\x1b\r' });
+  });
+
+  it('plain Enter is left to xterm default (handler returns true)', () => {
+    renderHook(() => useTerminal('s1'));
+    const handler = mockTerminals[0]!._keyHandler!;
+    const evt = {
+      type: 'keydown',
+      key: 'Enter',
+      shiftKey: false,
+      ctrlKey: false,
+      altKey: false,
+      metaKey: false,
+    } as unknown as KeyboardEvent;
+    expect(handler(evt)).toBe(true);
+    expect(sessionInput).not.toHaveBeenCalled();
+  });
+
+  it('Shift+Enter keyup is ignored (handler returns true, no input sent)', () => {
+    renderHook(() => useTerminal('s1'));
+    const handler = mockTerminals[0]!._keyHandler!;
+    const evt = {
+      type: 'keyup',
+      key: 'Enter',
+      shiftKey: true,
+      ctrlKey: false,
+      altKey: false,
+      metaKey: false,
+    } as unknown as KeyboardEvent;
+    expect(handler(evt)).toBe(true);
+    expect(sessionInput).not.toHaveBeenCalled();
+  });
+
+  it('Shift+Enter during IME composition is left to the IME', () => {
+    renderHook(() => useTerminal('s1'));
+    const handler = mockTerminals[0]!._keyHandler!;
+    const evt = {
+      type: 'keydown',
+      key: 'Enter',
+      shiftKey: true,
+      ctrlKey: false,
+      altKey: false,
+      metaKey: false,
+      isComposing: true,
+      keyCode: 13,
+    } as unknown as KeyboardEvent;
+    expect(handler(evt)).toBe(true);
+    expect(sessionInput).not.toHaveBeenCalled();
+  });
+
+  it('legacy IME signal (keyCode 229) is left untouched', () => {
+    renderHook(() => useTerminal('s1'));
+    const handler = mockTerminals[0]!._keyHandler!;
+    const evt = {
+      type: 'keydown',
+      key: 'Process',
+      shiftKey: true,
+      ctrlKey: false,
+      altKey: false,
+      metaKey: false,
+      isComposing: false,
+      keyCode: 229,
+    } as unknown as KeyboardEvent;
+    expect(handler(evt)).toBe(true);
+    expect(sessionInput).not.toHaveBeenCalled();
+  });
+
+  it('Ctrl+Shift+Enter is not intercepted (other shortcuts unaffected)', () => {
+    renderHook(() => useTerminal('s1'));
+    const handler = mockTerminals[0]!._keyHandler!;
+    const evt = {
+      type: 'keydown',
+      key: 'Enter',
+      shiftKey: true,
+      ctrlKey: true,
+      altKey: false,
+      metaKey: false,
+    } as unknown as KeyboardEvent;
+    expect(handler(evt)).toBe(true);
+    expect(sessionInput).not.toHaveBeenCalled();
   });
 
   it('routes session://output events to the matching Terminal', async () => {

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -254,6 +254,7 @@ describe('useTerminal', () => {
     try {
       const evt = new KeyboardEvent('keydown', {
         key: 'v',
+        code: 'KeyV',
         ctrlKey: true,
         bubbles: true,
         cancelable: true,
@@ -285,6 +286,7 @@ describe('useTerminal', () => {
     try {
       const evt = new KeyboardEvent('keydown', {
         key: 'v',
+        code: 'KeyV',
         metaKey: true,
         bubbles: true,
         cancelable: true,
@@ -316,6 +318,7 @@ describe('useTerminal', () => {
     try {
       const evt = new KeyboardEvent('keydown', {
         key: 'v',
+        code: 'KeyV',
         ctrlKey: true,
         shiftKey: true,
         bubbles: true,
@@ -345,8 +348,99 @@ describe('useTerminal', () => {
     try {
       const evt = new KeyboardEvent('keydown', {
         key: 'v',
+        code: 'KeyV',
         ctrlKey: true,
         altKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const dispatched = host.dispatchEvent(evt);
+
+      expect(dispatched).toBe(true);
+      expect(readText).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('Cmd+Shift+V is not intercepted (passthrough; "paste and match style" on macOS)', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const readText = vi.fn();
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { readText } },
+      configurable: true,
+    });
+
+    try {
+      const evt = new KeyboardEvent('keydown', {
+        key: 'v',
+        code: 'KeyV',
+        metaKey: true,
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const dispatched = host.dispatchEvent(evt);
+
+      expect(dispatched).toBe(true);
+      expect(readText).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('Cmd+Alt+V is not intercepted (Alt-modifier passthrough on macOS)', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const readText = vi.fn();
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { readText } },
+      configurable: true,
+    });
+
+    try {
+      const evt = new KeyboardEvent('keydown', {
+        key: 'v',
+        code: 'KeyV',
+        metaKey: true,
+        altKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const dispatched = host.dispatchEvent(evt);
+
+      expect(dispatched).toBe(true);
+      expect(readText).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('Ctrl+Cmd+V is not intercepted (both ctrl and meta together is undefined)', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const readText = vi.fn();
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { readText } },
+      configurable: true,
+    });
+
+    try {
+      const evt = new KeyboardEvent('keydown', {
+        key: 'v',
+        code: 'KeyV',
+        ctrlKey: true,
+        metaKey: true,
         bubbles: true,
         cancelable: true,
       });
@@ -374,6 +468,7 @@ describe('useTerminal', () => {
     try {
       const evt = new KeyboardEvent('keydown', {
         key: 'v',
+        code: 'KeyV',
         bubbles: true,
         cancelable: true,
       });
@@ -381,6 +476,126 @@ describe('useTerminal', () => {
 
       expect(dispatched).toBe(true);
       expect(readText).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('Ctrl+V on a non-Latin keyboard layout still triggers paste (matches by code, not key)', async () => {
+    // On a Russian QWERTY layout the V position prints `м`, so `event.key`
+    // is `'м'` — not `'v'`. We deliberately match on `event.code === 'KeyV'`
+    // (physical key) rather than `event.key` so the user's normal paste
+    // shortcut works regardless of active keyboard layout.
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const readText = vi.fn().mockResolvedValue('layout-clip');
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { readText } },
+      configurable: true,
+    });
+
+    try {
+      const evt = new KeyboardEvent('keydown', {
+        key: 'м',
+        code: 'KeyV',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const prevented = !host.dispatchEvent(evt);
+
+      expect(prevented).toBe(true);
+      expect(readText).toHaveBeenCalled();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('layout-clip');
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('Ctrl + non-V key with key:"v" is not intercepted (matches by code, not by produced character)', () => {
+    // Inverse of the layout test: on a Russian layout, the key that
+    // produces `'v'` is at a different physical position (code `KeyM`,
+    // since Cyrillic `в` is on a different key entirely — but for this
+    // test the important property is that `event.key === 'v'` does not
+    // imply the user pressed the V shortcut). Anything that isn't
+    // `code === 'KeyV'` must pass through unchanged.
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const readText = vi.fn();
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { readText } },
+      configurable: true,
+    });
+
+    try {
+      const evt = new KeyboardEvent('keydown', {
+        key: 'v',
+        code: 'KeyM',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const dispatched = host.dispatchEvent(evt);
+
+      expect(dispatched).toBe(true);
+      expect(readText).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('Ctrl+V resolved after disposeTerminal does not write to a stale terminal', async () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+    const term = mockTerminals[0]!;
+
+    // Hand-rolled deferred so we can dispatch the keydown, dispose the
+    // session, and only THEN resolve `readText` — exactly the race we're
+    // guarding against.
+    let resolveReadText!: (text: string) => void;
+    const readText = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveReadText = resolve;
+        }),
+    );
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { readText } },
+      configurable: true,
+    });
+
+    try {
+      const evt = new KeyboardEvent('keydown', {
+        key: 'v',
+        code: 'KeyV',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      host.dispatchEvent(evt);
+      expect(readText).toHaveBeenCalled();
+
+      // Dispose the session BEFORE the clipboard read resolves.
+      act(() => disposeTerminal('s1'));
+
+      // Now resolve the pending readText. The guard inside
+      // pasteFromClipboard should drop the paste because the registry
+      // entry is gone.
+      resolveReadText('stale-paste');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(term.paste).not.toHaveBeenCalled();
     } finally {
       Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
     }

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -14,6 +14,7 @@ const mockTerminals: Array<{
   loadAddon: ReturnType<typeof vi.fn>;
   refresh: ReturnType<typeof vi.fn>;
   attachCustomKeyEventHandler: ReturnType<typeof vi.fn>;
+  paste: ReturnType<typeof vi.fn>;
   cols: number;
   rows: number;
   _dataCb?: (data: string) => void;
@@ -31,6 +32,7 @@ vi.mock('@xterm/xterm', () => {
       loadAddon: vi.fn(),
       refresh: vi.fn(),
       attachCustomKeyEventHandler: vi.fn(),
+      paste: vi.fn(),
       cols: 80,
       rows: 24,
     };
@@ -263,6 +265,68 @@ describe('useTerminal', () => {
     act(() => result.current.detach());
     expect(host.children.length).toBe(0);
     expect(mockTerminals[0]!.dispose).not.toHaveBeenCalled();
+  });
+
+  it('paste DOM event on host forwards clipboard text via term.paste()', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+    Object.defineProperty(evt, 'clipboardData', {
+      value: { getData: (type: string) => (type === 'text/plain' ? 'hello world' : '') },
+    });
+    const prevented = !host.dispatchEvent(evt);
+
+    expect(prevented).toBe(true);
+    expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('hello world');
+  });
+
+  it('paste with empty clipboard text does not call term.paste()', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+    Object.defineProperty(evt, 'clipboardData', {
+      value: { getData: () => '' },
+    });
+    host.dispatchEvent(evt);
+
+    expect(mockTerminals[0]!.paste).not.toHaveBeenCalled();
+  });
+
+  it('detach removes the paste listener from the host', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+    act(() => result.current.detach());
+
+    const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+    Object.defineProperty(evt, 'clipboardData', {
+      value: { getData: () => 'after detach' },
+    });
+    host.dispatchEvent(evt);
+
+    expect(mockTerminals[0]!.paste).not.toHaveBeenCalled();
+  });
+
+  it('re-attach to a new host moves the paste listener (no leak on old host)', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host1 = makeHost();
+    const host2 = makeHost();
+    act(() => result.current.attach(host1));
+    act(() => result.current.attach(host2));
+
+    const evt1 = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+    Object.defineProperty(evt1, 'clipboardData', { value: { getData: () => 'old' } });
+    host1.dispatchEvent(evt1);
+    expect(mockTerminals[0]!.paste).not.toHaveBeenCalled();
+
+    const evt2 = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+    Object.defineProperty(evt2, 'clipboardData', { value: { getData: () => 'new' } });
+    host2.dispatchEvent(evt2);
+    expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('new');
   });
 
   it('disposeTerminal removes from registry and disposes term + addon', () => {

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -720,7 +720,7 @@ describe('useTerminal', () => {
     }
   });
 
-  it('paste with empty clipboard and no async fallback does not call term.paste()', () => {
+  it('paste with empty clipboard and no async fallback does not call term.paste() and does not preventDefault', () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
@@ -734,9 +734,99 @@ describe('useTerminal', () => {
     try {
       const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
       Object.defineProperty(evt, 'clipboardData', { value: { getData: () => '' } });
-      host.dispatchEvent(evt);
+      const dispatched = host.dispatchEvent(evt);
 
       expect(mockTerminals[0]!.paste).not.toHaveBeenCalled();
+      // When we have no paste path, we MUST let the event propagate so
+      // xterm or any other listener still has a chance to handle it —
+      // otherwise we just turn paste into a silent no-op (regression).
+      expect(dispatched).toBe(true);
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('Ctrl+V keydown does not preventDefault when navigator.clipboard.readText is unavailable', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: undefined },
+      configurable: true,
+    });
+
+    try {
+      const evt = new KeyboardEvent('keydown', {
+        key: 'v',
+        code: 'KeyV',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const dispatched = host.dispatchEvent(evt);
+
+      // Without a clipboard API, we can't paste — so we must not
+      // suppress xterm's own keydown handling. A silent no-op is a
+      // regression vs. the previous behavior (xterm sending \x16).
+      expect(dispatched).toBe(true);
+      expect(mockTerminals[0]!.paste).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('Cmd+V keydown does not preventDefault when navigator.clipboard.readText is unavailable', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: undefined },
+      configurable: true,
+    });
+
+    try {
+      const evt = new KeyboardEvent('keydown', {
+        key: 'v',
+        code: 'KeyV',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const dispatched = host.dispatchEvent(evt);
+
+      expect(dispatched).toBe(true);
+      expect(mockTerminals[0]!.paste).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('paste with inline clipboardData still preventDefaults even if async clipboard is missing', () => {
+    // Inline payload is the happy path and must always be consumed —
+    // we own the paste end-to-end here.
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: undefined },
+      configurable: true,
+    });
+
+    try {
+      const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+      Object.defineProperty(evt, 'clipboardData', {
+        value: { getData: () => 'inline-text' },
+      });
+      const prevented = !host.dispatchEvent(evt);
+
+      expect(prevented).toBe(true);
+      expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('inline-text');
     } finally {
       Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
     }

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -13,12 +13,10 @@ const mockTerminals: Array<{
   dispose: ReturnType<typeof vi.fn>;
   loadAddon: ReturnType<typeof vi.fn>;
   refresh: ReturnType<typeof vi.fn>;
-  attachCustomKeyEventHandler: ReturnType<typeof vi.fn>;
   paste: ReturnType<typeof vi.fn>;
   cols: number;
   rows: number;
   _dataCb?: (data: string) => void;
-  _keyHandler?: (event: KeyboardEvent) => boolean;
 }> = [];
 
 vi.mock('@xterm/xterm', () => {
@@ -31,16 +29,12 @@ vi.mock('@xterm/xterm', () => {
       dispose: vi.fn(),
       loadAddon: vi.fn(),
       refresh: vi.fn(),
-      attachCustomKeyEventHandler: vi.fn(),
       paste: vi.fn(),
       cols: 80,
       rows: 24,
     };
     inst.onData.mockImplementation((cb: (data: string) => void) => {
       inst._dataCb = cb;
-    });
-    inst.attachCustomKeyEventHandler.mockImplementation((cb: (event: KeyboardEvent) => boolean) => {
-      inst._keyHandler = cb;
     });
     mockTerminals.push(inst);
     return inst;
@@ -139,100 +133,153 @@ describe('useTerminal', () => {
     expect(sessionInput).toHaveBeenCalledWith({ sessionId: 's1', data: 'hello' });
   });
 
-  it('Shift+Enter sends ESC+CR via sessionInput and suppresses xterm default', () => {
-    renderHook(() => useTerminal('s1'));
-    const handler = mockTerminals[0]!._keyHandler!;
-    expect(handler).toBeTypeOf('function');
-    const evt = {
-      type: 'keydown',
+  it('Shift+Enter on host sends ESC+CR via sessionInput and prevents default', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const evt = new KeyboardEvent('keydown', {
       key: 'Enter',
       shiftKey: true,
-      ctrlKey: false,
-      altKey: false,
-      metaKey: false,
-    } as unknown as KeyboardEvent;
-    const result = handler(evt);
-    expect(result).toBe(false);
+      bubbles: true,
+      cancelable: true,
+    });
+    const dispatched = host.dispatchEvent(evt);
+
+    expect(dispatched).toBe(false); // preventDefault called
     expect(sessionInput).toHaveBeenCalledWith({ sessionId: 's1', data: '\x1b\r' });
   });
 
-  it('plain Enter is left to xterm default (handler returns true)', () => {
-    renderHook(() => useTerminal('s1'));
-    const handler = mockTerminals[0]!._keyHandler!;
-    const evt = {
-      type: 'keydown',
+  it('plain Enter on host is left to xterm (no interception, no input sent)', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const evt = new KeyboardEvent('keydown', {
       key: 'Enter',
       shiftKey: false,
-      ctrlKey: false,
-      altKey: false,
-      metaKey: false,
-    } as unknown as KeyboardEvent;
-    expect(handler(evt)).toBe(true);
+      bubbles: true,
+      cancelable: true,
+    });
+    const dispatched = host.dispatchEvent(evt);
+
+    expect(dispatched).toBe(true); // not preventDefault'd
     expect(sessionInput).not.toHaveBeenCalled();
   });
 
-  it('Shift+Enter keyup is ignored (handler returns true, no input sent)', () => {
-    renderHook(() => useTerminal('s1'));
-    const handler = mockTerminals[0]!._keyHandler!;
-    const evt = {
-      type: 'keyup',
+  it('Shift+Enter keyup is ignored (only keydown is intercepted)', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const evt = new KeyboardEvent('keyup', {
       key: 'Enter',
       shiftKey: true,
-      ctrlKey: false,
-      altKey: false,
-      metaKey: false,
-    } as unknown as KeyboardEvent;
-    expect(handler(evt)).toBe(true);
+      bubbles: true,
+      cancelable: true,
+    });
+    host.dispatchEvent(evt);
+
     expect(sessionInput).not.toHaveBeenCalled();
   });
 
   it('Shift+Enter during IME composition is left to the IME', () => {
-    renderHook(() => useTerminal('s1'));
-    const handler = mockTerminals[0]!._keyHandler!;
-    const evt = {
-      type: 'keydown',
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const evt = new KeyboardEvent('keydown', {
       key: 'Enter',
       shiftKey: true,
-      ctrlKey: false,
-      altKey: false,
-      metaKey: false,
       isComposing: true,
-      keyCode: 13,
-    } as unknown as KeyboardEvent;
-    expect(handler(evt)).toBe(true);
+      bubbles: true,
+      cancelable: true,
+    });
+    const dispatched = host.dispatchEvent(evt);
+
+    expect(dispatched).toBe(true);
     expect(sessionInput).not.toHaveBeenCalled();
   });
 
   it('legacy IME signal (keyCode 229) is left untouched', () => {
-    renderHook(() => useTerminal('s1'));
-    const handler = mockTerminals[0]!._keyHandler!;
-    const evt = {
-      type: 'keydown',
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    // KeyboardEvent constructor doesn't accept keyCode; assign on the
+    // dispatched event to mimic legacy WebView behaviour.
+    const evt = new KeyboardEvent('keydown', {
       key: 'Process',
       shiftKey: true,
-      ctrlKey: false,
-      altKey: false,
-      metaKey: false,
-      isComposing: false,
-      keyCode: 229,
-    } as unknown as KeyboardEvent;
-    expect(handler(evt)).toBe(true);
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(evt, 'keyCode', { value: 229 });
+    const dispatched = host.dispatchEvent(evt);
+
+    expect(dispatched).toBe(true);
     expect(sessionInput).not.toHaveBeenCalled();
   });
 
   it('Ctrl+Shift+Enter is not intercepted (other shortcuts unaffected)', () => {
-    renderHook(() => useTerminal('s1'));
-    const handler = mockTerminals[0]!._keyHandler!;
-    const evt = {
-      type: 'keydown',
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const evt = new KeyboardEvent('keydown', {
       key: 'Enter',
       shiftKey: true,
       ctrlKey: true,
-      altKey: false,
-      metaKey: false,
-    } as unknown as KeyboardEvent;
-    expect(handler(evt)).toBe(true);
+      bubbles: true,
+      cancelable: true,
+    });
+    const dispatched = host.dispatchEvent(evt);
+
+    expect(dispatched).toBe(true);
     expect(sessionInput).not.toHaveBeenCalled();
+  });
+
+  it('Shift+Enter listener is removed on detach', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+    act(() => result.current.detach());
+
+    const evt = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    host.dispatchEvent(evt);
+
+    expect(sessionInput).not.toHaveBeenCalled();
+  });
+
+  it('re-attach to a new host moves the keydown listener (no leak on old host)', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host1 = makeHost();
+    const host2 = makeHost();
+    act(() => result.current.attach(host1));
+    act(() => result.current.attach(host2));
+
+    const evt1 = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    host1.dispatchEvent(evt1);
+    expect(sessionInput).not.toHaveBeenCalled();
+
+    const evt2 = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    host2.dispatchEvent(evt2);
+    expect(sessionInput).toHaveBeenCalledWith({ sessionId: 's1', data: '\x1b\r' });
   });
 
   it('routes session://output events to the matching Terminal', async () => {
@@ -282,18 +329,105 @@ describe('useTerminal', () => {
     expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('hello world');
   });
 
-  it('paste with empty clipboard text does not call term.paste()', () => {
+  it('paste falls back to navigator.clipboard.readText when clipboardData is empty', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
+    const readText = vi.fn().mockResolvedValue('from-async-clipboard');
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { readText } },
+      configurable: true,
+    });
+
+    try {
+      const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+      Object.defineProperty(evt, 'clipboardData', { value: { getData: () => '' } });
+      host.dispatchEvent(evt);
+
+      expect(readText).toHaveBeenCalled();
+      // Drain the microtask queue so the .then(...) on readText resolves.
+      // Two awaits: one for the readText resolution, one for the chained .then.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('from-async-clipboard');
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('paste with empty clipboard and no async fallback does not call term.paste()', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: undefined },
+      configurable: true,
+    });
+
+    try {
+      const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+      Object.defineProperty(evt, 'clipboardData', { value: { getData: () => '' } });
+      host.dispatchEvent(evt);
+
+      expect(mockTerminals[0]!.paste).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('paste runs in capture phase, beating a descendants stopPropagation', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    // Mimic xterm's behaviour: a descendant listener that stops propagation.
+    // Because our host listener is in the **capture** phase, it must run
+    // BEFORE this bubble-phase descendant listener gets a chance to stop
+    // the event.
+    const descendant = document.createElement('div');
+    host.appendChild(descendant);
+    descendant.addEventListener('paste', (e) => {
+      e.stopPropagation();
+    });
+
     const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
     Object.defineProperty(evt, 'clipboardData', {
-      value: { getData: () => '' },
+      value: { getData: () => 'capture-wins' },
     });
-    host.dispatchEvent(evt);
+    descendant.dispatchEvent(evt);
 
-    expect(mockTerminals[0]!.paste).not.toHaveBeenCalled();
+    expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('capture-wins');
+  });
+
+  it('Shift+Enter runs in capture phase, beating a descendants stopPropagation', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    // Same scenario for keydown — xterm registers its keydown listener on
+    // its hidden textarea (a descendant of host) with capture-phase too,
+    // but because OUR listener is registered on a closer-to-root host
+    // capture-phase fires first regardless of where focus actually is.
+    const descendant = document.createElement('div');
+    host.appendChild(descendant);
+    descendant.addEventListener('keydown', (e) => {
+      e.stopPropagation();
+    });
+
+    const evt = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    descendant.dispatchEvent(evt);
+
+    expect(sessionInput).toHaveBeenCalledWith({ sessionId: 's1', data: '\x1b\r' });
   });
 
   it('detach removes the paste listener from the host', () => {

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -239,6 +239,153 @@ describe('useTerminal', () => {
     expect(sessionInput).not.toHaveBeenCalled();
   });
 
+  it('Ctrl+V on host triggers navigator.clipboard.readText and term.paste', async () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const readText = vi.fn().mockResolvedValue('clip-text');
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { readText } },
+      configurable: true,
+    });
+
+    try {
+      const evt = new KeyboardEvent('keydown', {
+        key: 'v',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const prevented = !host.dispatchEvent(evt);
+
+      expect(prevented).toBe(true);
+      expect(readText).toHaveBeenCalled();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('clip-text');
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('Cmd+V (metaKey) on host triggers paste via navigator.clipboard.readText', async () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const readText = vi.fn().mockResolvedValue('mac-clip');
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { readText } },
+      configurable: true,
+    });
+
+    try {
+      const evt = new KeyboardEvent('keydown', {
+        key: 'v',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const prevented = !host.dispatchEvent(evt);
+
+      expect(prevented).toBe(true);
+      expect(readText).toHaveBeenCalled();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('mac-clip');
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('Ctrl+Shift+V on host also triggers paste (Linux terminal convention)', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const readText = vi.fn().mockResolvedValue('linux-clip');
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { readText } },
+      configurable: true,
+    });
+
+    try {
+      const evt = new KeyboardEvent('keydown', {
+        key: 'v',
+        ctrlKey: true,
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const prevented = !host.dispatchEvent(evt);
+
+      expect(prevented).toBe(true);
+      expect(readText).toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('Ctrl+Alt+V is not intercepted (Alt-modifier passthrough)', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const readText = vi.fn();
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { readText } },
+      configurable: true,
+    });
+
+    try {
+      const evt = new KeyboardEvent('keydown', {
+        key: 'v',
+        ctrlKey: true,
+        altKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const dispatched = host.dispatchEvent(evt);
+
+      expect(dispatched).toBe(true);
+      expect(readText).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('plain "v" keystroke (no modifier) is not intercepted', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const readText = vi.fn();
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { readText } },
+      configurable: true,
+    });
+
+    try {
+      const evt = new KeyboardEvent('keydown', {
+        key: 'v',
+        bubbles: true,
+        cancelable: true,
+      });
+      const dispatched = host.dispatchEvent(evt);
+
+      expect(dispatched).toBe(true);
+      expect(readText).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
   it('Shift+Enter listener is removed on detach', () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -207,16 +207,27 @@ function teardownKeydownListener(entry: RegistryEntry): void {
  * `paste` event listener fallback (when `clipboardData` is empty, as
  * happens in some WebView2 right-click → Paste flows).
  *
+ * The async resolution of `readText()` is racy with session disposal:
+ * the user could dispatch Ctrl+V and then close the tab before the
+ * clipboard read resolves. We re-check the registry by `sessionId`
+ * before calling `term.paste(text)` so we don't write into a disposed
+ * (or replaced) terminal.
+ *
  * Failures are logged but otherwise silent — there's no useful UI
  * recovery and we don't want to spam the user with toasts every time
  * they paste an empty clipboard.
  */
-function pasteFromClipboard(entry: RegistryEntry): void {
+function pasteFromClipboard(sessionId: SessionId, entry: RegistryEntry): void {
   if (typeof navigator === 'undefined' || !navigator.clipboard?.readText) return;
   void navigator.clipboard
     .readText()
     .then((text) => {
-      if (text) entry.term.paste(text);
+      if (!text) return;
+      // Guard against a concurrent disposeTerminal(): if the registry
+      // entry for this session is gone or has been replaced, drop the
+      // paste rather than writing to a stale Terminal instance.
+      if (registry.get(sessionId) !== entry) return;
+      entry.term.paste(text);
     })
     .catch((err: unknown) => {
       const message = err instanceof Error ? err.message : String(err);
@@ -350,17 +361,28 @@ function attachToHost(sessionId: SessionId, entry: RegistryEntry, host: HTMLDivE
       });
       return;
     }
-    // Ctrl+V (Windows/Linux) or Cmd+V (macOS), no other modifiers. We
-    // also accept Ctrl+Shift+V which is the conventional "paste" combo
-    // in many Linux terminals.
-    const isPasteCombo =
-      event.key.toLowerCase() === 'v' &&
-      !event.altKey &&
-      ((event.ctrlKey && !event.metaKey) || (event.metaKey && !event.ctrlKey));
-    if (isPasteCombo) {
+    // Paste shortcuts. The accepted matrix is asymmetric on purpose:
+    //   - Ctrl+V         (Windows/Linux convention)
+    //   - Ctrl+Shift+V   (Linux terminal convention — many emulators)
+    //   - Cmd+V          (macOS convention; **without** Shift)
+    // Cmd+Shift+V on macOS is "paste and match style" in apps that
+    // implement formatted clipboard semantics; it has no useful meaning
+    // in a terminal and we leave it to pass through unchanged. Alt is
+    // never accepted (Ctrl+Alt+V / Cmd+Alt+V / Alt+V are not paste).
+    //
+    // We match on `event.code === 'KeyV'` rather than `event.key`. `key`
+    // is the produced character — on a Russian keyboard layout the
+    // physical V position prints `м`, so a `key === 'v'` test would miss
+    // the user's normal paste shortcut. `code` reflects the **physical**
+    // key location and is layout-independent, which is what every other
+    // major terminal app keys off for shortcut matching.
+    const v = event.code === 'KeyV';
+    const isCtrlPaste = v && event.ctrlKey && !event.metaKey && !event.altKey;
+    const isMetaPaste = v && event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
+    if (isCtrlPaste || isMetaPaste) {
       event.preventDefault();
       event.stopPropagation();
-      pasteFromClipboard(entry);
+      pasteFromClipboard(sessionId, entry);
     }
   };
   host.addEventListener('keydown', keydownListener as EventListener, true);
@@ -386,7 +408,7 @@ function attachToHost(sessionId: SessionId, entry: RegistryEntry, host: HTMLDivE
       entry.term.paste(inline);
       return;
     }
-    pasteFromClipboard(entry);
+    pasteFromClipboard(sessionId, entry);
   };
   host.addEventListener('paste', pasteListener as EventListener, true);
   entry.pasteListener = pasteListener;

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -47,6 +47,8 @@ interface RegistryEntry {
   host: HTMLDivElement | null;
   observer: ResizeObserver | null;
   resizeTimer: ReturnType<typeof setTimeout> | null;
+  /** Listener installed on `host` to forward `paste` events to xterm. */
+  pasteListener: ((event: ClipboardEvent) => void) | null;
   /** Last cols/rows reported to the backend; suppresses duplicate calls. */
   lastCols: number;
   lastRows: number;
@@ -183,6 +185,7 @@ function createEntry(sessionId: SessionId): RegistryEntry {
     host: null,
     observer: null,
     resizeTimer: null,
+    pasteListener: null,
     lastCols: 0,
     lastRows: 0,
   };
@@ -206,6 +209,13 @@ function teardownObserver(entry: RegistryEntry): void {
     clearTimeout(entry.resizeTimer);
     entry.resizeTimer = null;
   }
+}
+
+function teardownPasteListener(entry: RegistryEntry): void {
+  if (entry.pasteListener && entry.host) {
+    entry.host.removeEventListener('paste', entry.pasteListener as EventListener);
+  }
+  entry.pasteListener = null;
 }
 
 /**
@@ -271,6 +281,7 @@ function attachToHost(sessionId: SessionId, entry: RegistryEntry, host: HTMLDivE
     entry.wrapper.parentElement.removeChild(entry.wrapper);
   }
   teardownObserver(entry);
+  teardownPasteListener(entry);
 
   const wrapper = entry.wrapper ?? document.createElement('div');
   wrapper.style.width = '100%';
@@ -290,6 +301,26 @@ function attachToHost(sessionId: SessionId, entry: RegistryEntry, host: HTMLDivE
   // state if it fires too early).
   refitEntry(sessionId, entry);
 
+  // Paste support. xterm.js installs its own paste listener on a hidden
+  // textarea, but in the Tauri WebView that handler isn't reliably the
+  // event target (focus inside the WebView often lands on the wrapper
+  // div, not xterm's helper textarea), so Ctrl+V / Cmd+V / right-click →
+  // Paste / X11 middle-click silently no-op. Adding our own listener at
+  // the host level captures every paste affordance the OS offers and
+  // forwards via `term.paste()` so xterm wraps the content with bracketed
+  // paste markers (\x1b[200~ … \x1b[201~) when mode 2004 is active.
+  // `clipboardData` carries the data inline as part of the user gesture,
+  // so this works without any clipboard-read permission.
+  const pasteListener = (event: ClipboardEvent): void => {
+    const text = event.clipboardData?.getData('text/plain');
+    if (text) {
+      event.preventDefault();
+      entry.term.paste(text);
+    }
+  };
+  host.addEventListener('paste', pasteListener as EventListener);
+  entry.pasteListener = pasteListener;
+
   if (typeof ResizeObserver !== 'undefined') {
     const observer = new ResizeObserver(() => {
       if (entry.resizeTimer !== null) clearTimeout(entry.resizeTimer);
@@ -302,6 +333,7 @@ function attachToHost(sessionId: SessionId, entry: RegistryEntry, host: HTMLDivE
 
 function detachFromHost(entry: RegistryEntry): void {
   teardownObserver(entry);
+  teardownPasteListener(entry);
   if (entry.wrapper && entry.wrapper.parentElement) {
     entry.wrapper.parentElement.removeChild(entry.wrapper);
   }

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -147,6 +147,35 @@ function createEntry(sessionId: SessionId): RegistryEntry {
     });
   });
 
+  // Shift+Enter → ESC + CR (`\x1b\r`). xterm.js by default sends a plain
+  // `\r` for both Enter and Shift+Enter, which CLIs like Claude Code and
+  // GitHub Copilot CLI interpret as "submit". The de-facto convention
+  // (matching what `claude /terminal-setup` configures in iTerm2) is to
+  // send ESC-prefixed CR for "newline without submit". We intercept at
+  // the DOM keydown level so xterm never sees the event and therefore
+  // never emits its own `\r`.
+  term.attachCustomKeyEventHandler((event) => {
+    // Skip IME composition: Enter/Shift+Enter during candidate selection
+    // belongs to the IME, not to the terminal. `keyCode === 229` is the
+    // legacy Chromium/WebView signal for "still composing".
+    if (event.isComposing || event.keyCode === 229) return true;
+    if (
+      event.type === 'keydown' &&
+      event.key === 'Enter' &&
+      event.shiftKey &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.metaKey
+    ) {
+      void sessionInput({ sessionId, data: '\x1b\r' }).catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(`[use-terminal] session_input(${sessionId}) failed: ${message}`);
+      });
+      return false;
+    }
+    return true;
+  });
+
   return {
     term,
     fitAddon,

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -47,8 +47,10 @@ interface RegistryEntry {
   host: HTMLDivElement | null;
   observer: ResizeObserver | null;
   resizeTimer: ReturnType<typeof setTimeout> | null;
-  /** Listener installed on `host` to forward `paste` events to xterm. */
+  /** Capture-phase listener installed on `host` to forward `paste` events. */
   pasteListener: ((event: ClipboardEvent) => void) | null;
+  /** Capture-phase listener installed on `host` to intercept Shift+Enter. */
+  keydownListener: ((event: KeyboardEvent) => void) | null;
   /** Last cols/rows reported to the backend; suppresses duplicate calls. */
   lastCols: number;
   lastRows: number;
@@ -149,35 +151,6 @@ function createEntry(sessionId: SessionId): RegistryEntry {
     });
   });
 
-  // Shift+Enter → ESC + CR (`\x1b\r`). xterm.js by default sends a plain
-  // `\r` for both Enter and Shift+Enter, which CLIs like Claude Code and
-  // GitHub Copilot CLI interpret as "submit". The de-facto convention
-  // (matching what `claude /terminal-setup` configures in iTerm2) is to
-  // send ESC-prefixed CR for "newline without submit". We intercept at
-  // the DOM keydown level so xterm never sees the event and therefore
-  // never emits its own `\r`.
-  term.attachCustomKeyEventHandler((event) => {
-    // Skip IME composition: Enter/Shift+Enter during candidate selection
-    // belongs to the IME, not to the terminal. `keyCode === 229` is the
-    // legacy Chromium/WebView signal for "still composing".
-    if (event.isComposing || event.keyCode === 229) return true;
-    if (
-      event.type === 'keydown' &&
-      event.key === 'Enter' &&
-      event.shiftKey &&
-      !event.ctrlKey &&
-      !event.altKey &&
-      !event.metaKey
-    ) {
-      void sessionInput({ sessionId, data: '\x1b\r' }).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        console.warn(`[use-terminal] session_input(${sessionId}) failed: ${message}`);
-      });
-      return false;
-    }
-    return true;
-  });
-
   return {
     term,
     fitAddon,
@@ -186,6 +159,7 @@ function createEntry(sessionId: SessionId): RegistryEntry {
     observer: null,
     resizeTimer: null,
     pasteListener: null,
+    keydownListener: null,
     lastCols: 0,
     lastRows: 0,
   };
@@ -213,9 +187,16 @@ function teardownObserver(entry: RegistryEntry): void {
 
 function teardownPasteListener(entry: RegistryEntry): void {
   if (entry.pasteListener && entry.host) {
-    entry.host.removeEventListener('paste', entry.pasteListener as EventListener);
+    entry.host.removeEventListener('paste', entry.pasteListener as EventListener, true);
   }
   entry.pasteListener = null;
+}
+
+function teardownKeydownListener(entry: RegistryEntry): void {
+  if (entry.keydownListener && entry.host) {
+    entry.host.removeEventListener('keydown', entry.keydownListener as EventListener, true);
+  }
+  entry.keydownListener = null;
 }
 
 /**
@@ -282,6 +263,7 @@ function attachToHost(sessionId: SessionId, entry: RegistryEntry, host: HTMLDivE
   }
   teardownObserver(entry);
   teardownPasteListener(entry);
+  teardownKeydownListener(entry);
 
   const wrapper = entry.wrapper ?? document.createElement('div');
   wrapper.style.width = '100%';
@@ -301,24 +283,75 @@ function attachToHost(sessionId: SessionId, entry: RegistryEntry, host: HTMLDivE
   // state if it fires too early).
   refitEntry(sessionId, entry);
 
-  // Paste support. xterm.js installs its own paste listener on a hidden
-  // textarea, but in the Tauri WebView that handler isn't reliably the
-  // event target (focus inside the WebView often lands on the wrapper
-  // div, not xterm's helper textarea), so Ctrl+V / Cmd+V / right-click →
-  // Paste / X11 middle-click silently no-op. Adding our own listener at
-  // the host level captures every paste affordance the OS offers and
-  // forwards via `term.paste()` so xterm wraps the content with bracketed
-  // paste markers (\x1b[200~ … \x1b[201~) when mode 2004 is active.
-  // `clipboardData` carries the data inline as part of the user gesture,
-  // so this works without any clipboard-read permission.
-  const pasteListener = (event: ClipboardEvent): void => {
-    const text = event.clipboardData?.getData('text/plain');
-    if (text) {
+  // Shift+Enter → ESC + CR (`\x1b\r`). xterm.js by default sends a plain
+  // `\r` for both Enter and Shift+Enter, which CLIs like Claude Code and
+  // GitHub Copilot CLI interpret as "submit". The de-facto convention
+  // (matching what `claude /terminal-setup` configures in iTerm2) is to
+  // send ESC-prefixed CR for "newline without submit".
+  //
+  // We listen at the **host** in the **capture** phase so we run before
+  // xterm's own keydown listener (registered on its hidden textarea, also
+  // capture-phase). xterm's `attachCustomKeyEventHandler` is unreliable
+  // here because by the time it runs the textarea may already have
+  // committed default behaviour, and we cannot from inside it
+  // `preventDefault()` the textarea's own newline insertion. Capturing on
+  // the host fully owns the event before any descendant listener.
+  const keydownListener = (event: KeyboardEvent): void => {
+    // Skip IME composition: Enter/Shift+Enter during candidate selection
+    // belongs to the IME, not to the terminal. `keyCode === 229` is the
+    // legacy Chromium/WebView signal for "still composing".
+    if (event.isComposing || event.keyCode === 229) return;
+    if (
+      event.key === 'Enter' &&
+      event.shiftKey &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.metaKey
+    ) {
       event.preventDefault();
-      entry.term.paste(text);
+      event.stopPropagation();
+      void sessionInput({ sessionId, data: '\x1b\r' }).catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(`[use-terminal] session_input(${sessionId}) failed: ${message}`);
+      });
     }
   };
-  host.addEventListener('paste', pasteListener as EventListener);
+  host.addEventListener('keydown', keydownListener as EventListener, true);
+  entry.keydownListener = keydownListener;
+
+  // Paste support. xterm.js installs its own paste listeners on the
+  // textarea AND on its element (`xterm/src/browser/Clipboard.ts`), and
+  // its handler calls `event.stopPropagation()` — so a bubble-phase
+  // listener at the host **never fires**. Worse, in the Tauri/WebView2
+  // environment the `clipboardData` xterm receives via that path is
+  // sometimes empty (Ctrl+V / right-click → Paste / X11 middle-click all
+  // silently no-op). We capture at the host, which runs before any
+  // descendant listener; we own the event end-to-end. If `clipboardData`
+  // is populated we use it directly (works without permission, since the
+  // user gesture supplies the data). Otherwise we fall back to the async
+  // `navigator.clipboard.readText()` — slower, may prompt in some
+  // environments, but recovers when the WebView won't fill clipboardData.
+  const pasteListener = (event: ClipboardEvent): void => {
+    event.preventDefault();
+    event.stopPropagation();
+    const inline = event.clipboardData?.getData('text/plain') ?? '';
+    if (inline) {
+      entry.term.paste(inline);
+      return;
+    }
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.readText) {
+      void navigator.clipboard
+        .readText()
+        .then((text) => {
+          if (text) entry.term.paste(text);
+        })
+        .catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          console.warn(`[use-terminal] clipboard.readText() failed: ${message}`);
+        });
+    }
+  };
+  host.addEventListener('paste', pasteListener as EventListener, true);
   entry.pasteListener = pasteListener;
 
   if (typeof ResizeObserver !== 'undefined') {
@@ -334,6 +367,7 @@ function attachToHost(sessionId: SessionId, entry: RegistryEntry, host: HTMLDivE
 function detachFromHost(entry: RegistryEntry): void {
   teardownObserver(entry);
   teardownPasteListener(entry);
+  teardownKeydownListener(entry);
   if (entry.wrapper && entry.wrapper.parentElement) {
     entry.wrapper.parentElement.removeChild(entry.wrapper);
   }

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -200,6 +200,31 @@ function teardownKeydownListener(entry: RegistryEntry): void {
 }
 
 /**
+ * Read text from the system clipboard via `navigator.clipboard.readText()`
+ * and forward it to the terminal via `term.paste()`. Used by both the
+ * Ctrl/Cmd+V keydown branch (where xterm's keydown handler would
+ * otherwise eat the keystroke before any `paste` event fires) and the
+ * `paste` event listener fallback (when `clipboardData` is empty, as
+ * happens in some WebView2 right-click → Paste flows).
+ *
+ * Failures are logged but otherwise silent — there's no useful UI
+ * recovery and we don't want to spam the user with toasts every time
+ * they paste an empty clipboard.
+ */
+function pasteFromClipboard(entry: RegistryEntry): void {
+  if (typeof navigator === 'undefined' || !navigator.clipboard?.readText) return;
+  void navigator.clipboard
+    .readText()
+    .then((text) => {
+      if (text) entry.term.paste(text);
+    })
+    .catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[use-terminal] clipboard.readText() failed: ${message}`);
+    });
+}
+
+/**
  * Re-measure + repaint a single terminal. Safe to call on an unattached or
  * zero-size terminal (no-ops). Only emits `sessionResize` when cols/rows
  * have actually changed since the last successful fit. Always calls
@@ -283,11 +308,20 @@ function attachToHost(sessionId: SessionId, entry: RegistryEntry, host: HTMLDivE
   // state if it fires too early).
   refitEntry(sessionId, entry);
 
-  // Shift+Enter → ESC + CR (`\x1b\r`). xterm.js by default sends a plain
-  // `\r` for both Enter and Shift+Enter, which CLIs like Claude Code and
-  // GitHub Copilot CLI interpret as "submit". The de-facto convention
-  // (matching what `claude /terminal-setup` configures in iTerm2) is to
-  // send ESC-prefixed CR for "newline without submit".
+  // Capture-phase keydown listener on the host. Two responsibilities:
+  //
+  // 1. Shift+Enter → ESC + CR (`\x1b\r`). xterm.js by default sends a
+  //    plain `\r` for both Enter and Shift+Enter, which CLIs like Claude
+  //    Code and GitHub Copilot CLI interpret as "submit". The de-facto
+  //    convention (matching what `claude /terminal-setup` configures in
+  //    iTerm2) is to send ESC-prefixed CR for "newline without submit".
+  //
+  // 2. Ctrl+V / Cmd+V → trigger paste via `navigator.clipboard.readText()`
+  //    and write the result through `term.paste()`. If we don't intercept,
+  //    xterm's own keydown handler eats the keypress (sending the literal
+  //    `\x16` SYN byte to the PTY) and the browser never fires a `paste`
+  //    event, so our capture-phase paste listener has nothing to handle.
+  //    Right-click → Paste still goes through the paste listener below.
   //
   // We listen at the **host** in the **capture** phase so we run before
   // xterm's own keydown listener (registered on its hidden textarea, also
@@ -314,6 +348,19 @@ function attachToHost(sessionId: SessionId, entry: RegistryEntry, host: HTMLDivE
         const message = err instanceof Error ? err.message : String(err);
         console.warn(`[use-terminal] session_input(${sessionId}) failed: ${message}`);
       });
+      return;
+    }
+    // Ctrl+V (Windows/Linux) or Cmd+V (macOS), no other modifiers. We
+    // also accept Ctrl+Shift+V which is the conventional "paste" combo
+    // in many Linux terminals.
+    const isPasteCombo =
+      event.key.toLowerCase() === 'v' &&
+      !event.altKey &&
+      ((event.ctrlKey && !event.metaKey) || (event.metaKey && !event.ctrlKey));
+    if (isPasteCombo) {
+      event.preventDefault();
+      event.stopPropagation();
+      pasteFromClipboard(entry);
     }
   };
   host.addEventListener('keydown', keydownListener as EventListener, true);
@@ -339,17 +386,7 @@ function attachToHost(sessionId: SessionId, entry: RegistryEntry, host: HTMLDivE
       entry.term.paste(inline);
       return;
     }
-    if (typeof navigator !== 'undefined' && navigator.clipboard?.readText) {
-      void navigator.clipboard
-        .readText()
-        .then((text) => {
-          if (text) entry.term.paste(text);
-        })
-        .catch((err: unknown) => {
-          const message = err instanceof Error ? err.message : String(err);
-          console.warn(`[use-terminal] clipboard.readText() failed: ${message}`);
-        });
-    }
+    pasteFromClipboard(entry);
   };
   host.addEventListener('paste', pasteListener as EventListener, true);
   entry.pasteListener = pasteListener;

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -200,12 +200,31 @@ function teardownKeydownListener(entry: RegistryEntry): void {
 }
 
 /**
+ * Whether the async clipboard read API is available in this runtime.
+ *
+ * Used by both Ctrl/Cmd+V interception and the `paste` event listener
+ * fallback to decide *up front* whether they have any chance of
+ * actually pasting. If this returns `false`, the listeners must NOT
+ * cancel the event — letting the event propagate gives xterm (or any
+ * other interested handler) a chance to act on it instead of leaving
+ * the user with a silent no-op.
+ */
+function canReadClipboard(): boolean {
+  return typeof navigator !== 'undefined' && typeof navigator.clipboard?.readText === 'function';
+}
+
+/**
  * Read text from the system clipboard via `navigator.clipboard.readText()`
  * and forward it to the terminal via `term.paste()`. Used by both the
  * Ctrl/Cmd+V keydown branch (where xterm's keydown handler would
  * otherwise eat the keystroke before any `paste` event fires) and the
  * `paste` event listener fallback (when `clipboardData` is empty, as
  * happens in some WebView2 right-click → Paste flows).
+ *
+ * Callers must gate cancellation of the original event on
+ * [`canReadClipboard`] — this function silently no-ops if the API is
+ * missing, and unconditionally cancelling the event in that case
+ * would block xterm from handling the keystroke / paste itself.
  *
  * The async resolution of `readText()` is racy with session disposal:
  * the user could dispatch Ctrl+V and then close the tab before the
@@ -218,7 +237,7 @@ function teardownKeydownListener(entry: RegistryEntry): void {
  * they paste an empty clipboard.
  */
 function pasteFromClipboard(sessionId: SessionId, entry: RegistryEntry): void {
-  if (typeof navigator === 'undefined' || !navigator.clipboard?.readText) return;
+  if (!canReadClipboard()) return;
   void navigator.clipboard
     .readText()
     .then((text) => {
@@ -380,9 +399,16 @@ function attachToHost(sessionId: SessionId, entry: RegistryEntry, host: HTMLDivE
     const isCtrlPaste = v && event.ctrlKey && !event.metaKey && !event.altKey;
     const isMetaPaste = v && event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
     if (isCtrlPaste || isMetaPaste) {
-      event.preventDefault();
-      event.stopPropagation();
-      pasteFromClipboard(sessionId, entry);
+      // Only suppress xterm's default handling when we have a paste path
+      // that might actually succeed. If `navigator.clipboard.readText`
+      // is unavailable, swallowing the event would just turn Ctrl+V
+      // into a silent no-op; instead, let it propagate so xterm can do
+      // whatever it would have done.
+      if (canReadClipboard()) {
+        event.preventDefault();
+        event.stopPropagation();
+        pasteFromClipboard(sessionId, entry);
+      }
     }
   };
   host.addEventListener('keydown', keydownListener as EventListener, true);
@@ -400,14 +426,22 @@ function attachToHost(sessionId: SessionId, entry: RegistryEntry, host: HTMLDivE
   // user gesture supplies the data). Otherwise we fall back to the async
   // `navigator.clipboard.readText()` — slower, may prompt in some
   // environments, but recovers when the WebView won't fill clipboardData.
+  //
+  // Cancellation policy: only call `preventDefault`/`stopPropagation`
+  // when we have something to paste (inline payload) or a viable async
+  // fallback. If both are unavailable we let the event continue so
+  // xterm or any other listener still has a shot at handling it.
   const pasteListener = (event: ClipboardEvent): void => {
-    event.preventDefault();
-    event.stopPropagation();
     const inline = event.clipboardData?.getData('text/plain') ?? '';
     if (inline) {
+      event.preventDefault();
+      event.stopPropagation();
       entry.term.paste(inline);
       return;
     }
+    if (!canReadClipboard()) return;
+    event.preventDefault();
+    event.stopPropagation();
     pasteFromClipboard(sessionId, entry);
   };
   host.addEventListener('paste', pasteListener as EventListener, true);


### PR DESCRIPTION
## Problem

Two related issues in CLI sessions:

1. **Shift+Enter for multi-line input** doesn''t work even when the CLI supports it. xterm.js by default emits a plain `\r` for both Enter and Shift+Enter, so Claude Code / Copilot CLI can''t distinguish them and treat both as *submit*.
2. **Ctrl+V / Cmd+V paste** silently no-ops in the Tauri WebView, and right-click → Paste sometimes hands xterm an empty `clipboardData` payload.

A third, secondary issue surfaced during testing: dev/build env vars in the `ARBORIST_*` namespace (e.g. `ARBORIST_BUILD_BRANCH`, `ARBORIST_DEV_PORT`) leak into spawned shells and confuse downstream tooling (notably Arborist''s own title-bar branch detection, which then displayed the dev branch name inside running sessions).

## Fix

### Capture-phase host event listeners
Both Shift+Enter and paste are intercepted on the **host element** in the **capture phase**, not via xterm''s `attachCustomKeyEventHandler` or bubble-phase listeners. Why:
- `attachCustomKeyEventHandler` is registered on xterm''s hidden helper textarea; in WebView2 focus is often on the wrapper div, so it never fires.
- xterm''s own `Clipboard.ts` paste handler calls `event.stopPropagation()`, so any bubble-phase host listener is dead-on-arrival.
- xterm''s keydown handler eats Ctrl+V and writes literal `\x16` (SYN) to the PTY *before* the browser fires a `paste` event, so we have to intercept the keydown too.

Capture-phase listeners on the host fire before any descendant listener regardless of focus, and are unaffected by `stopPropagation()` calls inside xterm.

**Shift+Enter** sends ESC+CR (`\x1b\r`) — the iTerm2 / `claude /terminal-setup` convention recognized as *newline without submit*. Strict modifier check (Shift only); IME-aware via `isComposing` + legacy `keyCode === 229`.

**Ctrl+V / Cmd+V / Ctrl+Shift+V** routes through `navigator.clipboard.readText()` → `term.paste()`. The bubble-phase `paste` event listener also runs (right-click → Paste, X11 middle-click) and prefers inline `clipboardData.getData(''text/plain'')` when available, falling back to the same async path when empty.

### PTY env hygiene
- `build.rs` no longer accepts `ARBORIST_BUILD_BRANCH` as a build-time override — branch metadata is derived from `git` only, so it can''t be spoofed by a stray env var inherited from the dev shell.
- `pty_pool` strips every `ARBORIST_*` env var (case-insensitive, matched on raw `OsStr` bytes so non-UTF-8 keys can''t leak) from the inherited environment of every spawned PTY child.

## Tests

- 32 tests in `use-terminal.test.tsx` cover Shift+Enter, the Ctrl/Cmd+V matrix (including Ctrl+Alt+V and plain `v` passthrough), `navigator.clipboard.readText` fallback, capture-phase ordering vs. descendant `stopPropagation`, listener teardown on detach, and listener migration on re-attach to a different host.
- 6 unit tests in `pty_pool.rs` cover ARBORIST_* strip behavior including a Unix-only non-UTF-8 key test and a `#[serial(env)]`-marked end-to-end test that exercises the production `std::env::vars_os()` path.
- All 274 frontend tests + 234 Rust tests pass; lint and clippy clean.
