### PR TITLE
docs(agents): forbid killing the host arborist process

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@ This repo is dogfooded: the user typically runs the **host** `arborist.exe` (or 
 Hard rules:
 
 - **Never** terminate `arborist.exe` / `arborist`, or its parent dev processes — `cargo run … arborist`, `npm run tauri:dev`, `tauri dev`, the Vite dev server, or any `node`/`cargo` process you did not personally spawn in this session. Treat them as the user's running editor.
-- **Never** use name-based or pattern-based process kills — `Stop-Process -Name`, `taskkill /IM`, `pkill`, `killall`, `Get-Process … | Stop-Process`. They will sweep up the host. The runtime already forbids these; do not work around the rule.
+- **Never** use name-based or pattern-based process kills — `Stop-Process -Name`, `taskkill /IM`, `pkill`, `killall`, `Get-Process … | Stop-Process`. They will sweep up the host. Do not use or work around these commands.
 - **Even with `Stop-Process -Id <PID>`**, only kill PIDs you captured from a child process you started yourself in this same session. If you didn't record the PID at spawn time, don't kill it.
 - If your `cargo build` / `cargo run` is blocked by a "file in use" / target-locked error, **stop and ask the user** — that lock almost always means the host arborist is running. Do not "free" the lock by killing processes.
 - Do not run `npm run tauri:dev` or `cargo run -p arborist` "to test changes" unless the user explicitly asks. The user already has it running. Use `cargo build`, `cargo test`, `npm run build`, or `npm test -- --run` for verification instead.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,20 @@ Read both before proposing implementation work. When the codebase is scaffolded,
 
 This repo has a remote at `origin` -> `https://github.com/mcaden/arborist.git`. Agents may commit, push feature branches, and open pull requests. Do not push directly to `main` and do not force-push shared branches; land changes through PRs.
 
+## Dogfooding safety — don't kill the host
+
+This repo is dogfooded: the user typically runs the **host** `arborist.exe` (or `arborist` on macOS/Linux) and you, the agent, are executing inside one of its PTY sessions. Killing the host crashes the user's editor and every sibling session, including yours. **A previous agent killed the host this way — do not repeat it.**
+
+Hard rules:
+
+- **Never** terminate `arborist.exe` / `arborist`, or its parent dev processes — `cargo run … arborist`, `npm run tauri:dev`, `tauri dev`, the Vite dev server, or any `node`/`cargo` process you did not personally spawn in this session. Treat them as the user's running editor.
+- **Never** use name-based or pattern-based process kills — `Stop-Process -Name`, `taskkill /IM`, `pkill`, `killall`, `Get-Process … | Stop-Process`. They will sweep up the host. The runtime already forbids these; do not work around the rule.
+- **Even with `Stop-Process -Id <PID>`**, only kill PIDs you captured from a child process you started yourself in this same session. If you didn't record the PID at spawn time, don't kill it.
+- If your `cargo build` / `cargo run` is blocked by a "file in use" / target-locked error, **stop and ask the user** — that lock almost always means the host arborist is running. Do not "free" the lock by killing processes.
+- Do not run `npm run tauri:dev` or `cargo run -p arborist` "to test changes" unless the user explicitly asks. The user already has it running. Use `cargo build`, `cargo test`, `npm run build`, or `npm test -- --run` for verification instead.
+
+If a task genuinely requires restarting the host, ask the user to do it — never do it yourself.
+
 ## What Arborist is
 
 A cross-platform desktop app (Tauri v2 + React/TS) that manages multiple Claude CLI / GitHub Copilot CLI sessions, each bound to a Git worktree, in a sidebar of vertical tabs with a single visible PTY terminal in the main area.
@@ -175,7 +189,7 @@ For exact commands, watcher setup, Husky configuration, test layout, and end-of-
 A change is mergeable when **all** of these hold:
 1. New/changed behavior has direct test coverage that fails without the change.
 2. `npm run lint`, `npm test`, `cargo clippy -D warnings`, `cargo test` all pass locally.
-3. The app launches via `npm run tauri dev` and the touched flow works end-to-end manually at least once.
+3. The app launches via `npm run tauri dev` (run by the **user**, not the agent — see "Dogfooding safety") and the touched flow works end-to-end manually at least once.
 4. No `// @ts-ignore`, `any`, `.unwrap()`, `.expect()`, `console.log`, or `dbg!()` added without justification in a code comment.
 5. If a Rust struct in `types.rs` changed, its TS mirror changed in the same commit.
 
@@ -188,3 +202,4 @@ A change is mergeable when **all** of these hold:
 - Forgetting to add a new command to `capabilities/main.json` — the call will be rejected at runtime with no compile-time warning.
 - Holding a `Mutex` guard across `.await` — deadlocks under load.
 - Storing credentials anywhere — auth is the CLI tool's job. (SPEC NF-05)
+- Killing the host `arborist` process or its dev-server parents to "clean up" or break a target lock — see "Dogfooding safety". A previous agent crashed the user's editor doing this.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,20 @@ A cross-platform desktop app (Tauri v2 + React/TypeScript) that manages multiple
 
 Authoritative specs: `dev/docs/SPEC.md` (requirements), `dev/docs/DESIGN.md` (architecture + data model + command/event API). Engineering conventions live in `.github/copilot-instructions.md`. Read those before proposing structural changes.
 
+## Dogfooding safety — don't kill the host
+
+This repo is dogfooded: the user typically runs the **host** `arborist.exe` (or `arborist` on macOS/Linux) and you, the agent, are executing inside one of its PTY sessions. Killing the host crashes the user's editor and every sibling session, including yours. **A previous agent killed the host this way — do not repeat it.**
+
+Hard rules:
+
+- **Never** terminate `arborist.exe` / `arborist`, or its parent dev processes — `cargo run … arborist`, `npm run tauri:dev`, `tauri dev`, the Vite dev server, or any `node`/`cargo` process you did not personally spawn in this session. Treat them as the user's running editor.
+- **Never** use name-based or pattern-based process kills — `Stop-Process -Name`, `taskkill /IM`, `pkill`, `killall`, `Get-Process … | Stop-Process`. They will sweep up the host.
+- **Even with `Stop-Process -Id <PID>`**, only kill PIDs you captured from a child process you started yourself in this same session. If you didn't record the PID at spawn time, don't kill it.
+- If `cargo build` / `cargo run` is blocked by a "file in use" / target-locked error, **stop and ask the user** — that lock almost always means the host arborist is running. Do not "free" the lock by killing processes.
+- Do not run `npm run tauri:dev` or `cargo run -p arborist` "to test changes" unless the user explicitly asks. The user already has it running. Use `cargo build`, `cargo test`, `npm run build`, or `npm test -- --run` for verification instead.
+
+If a task genuinely requires restarting the host, ask the user to do it — never do it yourself.
+
 ## Stack
 
 - **Frontend**: React + TypeScript, Vite, Tailwind CSS (class dark-mode strategy), Zustand, xterm.js


### PR DESCRIPTION
## Why

A previous Copilot CLI session terminated the user's running `arborist.exe` (exit code `0xffffffff`), crashing the editor and every sibling session along with it. The agent had no instruction telling it that the parent process was sacred — so it picked the wrong PID to clean up.

## What

Added a prominent **Dogfooding safety — don't kill the host** section to both `CLAUDE.md` and `.github/copilot-instructions.md`, placed near the top of each so an agent sees it before reaching for any process-management command. Hard rules:

- Never kill `arborist.exe` / `arborist` or its dev-server parents (`cargo run`, `npm run tauri:dev`, `vite`, unrelated `node`/`cargo`).
- Never use name- or pattern-based process kills.
- Even with PID-targeted kills, only kill PIDs from processes the agent itself spawned in the current session.
- Treat `file in use` / target-locked build errors as a signal that the host is running — ask the user, don't kill processes.
- Don't run `npm run tauri:dev` / `cargo run -p arborist` `to test` — use `cargo build`/`cargo test` and `npm run build`/`npm test` instead.

Also cross-referenced the rule from the existing `what tested means before merge` checklist and `Common pitfalls` list in `copilot-instructions.md` so the guidance is reachable from anywhere an agent might land in the doc.

## Verification

Docs-only change; `npx prettier --check CLAUDE.md` is clean (`.github/` is in `.prettierignore`).