### PR TITLE
fix(pty): plumb host-measured cols/rows through every spawn path so the CLI's first paint matches the terminal width

### DIFF
--- a/dev/docs/DESIGN.md
+++ b/dev/docs/DESIGN.md
@@ -178,7 +178,7 @@ User clicks [+]
           list, so the manual "Browse…" button (powered by
           `tauri-plugin-dialog`) is always available.
   → User optionally selects instruction set (default pre-selected)
-  → Frontend invokes Tauri command: session_create { tool, worktreePath } (instructionSetId is optional and currently never sent by the new-session wizard)
+  → Frontend invokes Tauri command: session_create { tool, worktreePath, cols, rows } (instructionSetId is optional and currently never sent by the new-session wizard; cols/rows are measured from the host before invocation, see §5.5b)
   → Rust backend:
       1. Creates Session record; assigns label — appends " N" suffix if a session
          with the same tool + worktreePath already exists (e.g., "my-feature 2")
@@ -243,7 +243,7 @@ PTY process exits with non-zero code
       2. Displays error overlay in terminal area with a "Restart" button
 
 User clicks "Restart"
-  → Frontend invokes Tauri command: session_restart { sessionId }
+  → Frontend invokes Tauri command: session_restart { sessionId, cols, rows }
   → Rust backend:
       1. Re-spawns PTY using stored Session.composedCommand and Session.worktreePath
       2. Records new pid on Session; sets status → 'starting'
@@ -275,39 +275,82 @@ App.tsx mounts (frontend)
                                      below)
   → initTerminalRouter()            (attaches global session://output)
   → subscribeToStatus()             (attaches global session://status)
-  → frontendReady()                 (one-shot CAS on the backend)
-       └─ backend kicks off restore_all_sessions on a blocking thread:
+  → frontendReady()                 (one-shot CAS on the backend; awaits restore registration before resolving)
+       └─ backend dispatches restore_all_sessions to a blocking thread
+          and *awaits* its completion before frontend_ready returns:
            for each persisted Session in tabOrder order it
              1. (re-)materialises any persisted temp_files,
              2. flips the persisted status to Starting and emits
                 session://status,
-             3. calls pty_pool::respawn_existing using the stored
-                composedCommand and worktreePath; if Session.aiSessionId
-                is set and the underlying transcript still exists on disk
+             3. registers the (possibly AI-resume-augmented) Session
+                in the backend's `pending_spawn` claim map. The actual
+                PTY spawn is deferred until the frontend issues its
+                first `session_resize` for that session id (see §5.5b).
+                If Session.aiSessionId is set and the underlying
+                transcript still exists on disk
                 (`~/.claude/projects/<encoded-cwd>/<id>.jsonl` for Claude,
-                `~/.copilot/session-state/<id>/` for Copilot), the spawn
-                command is *augmented* (not recomposed) by appending
-                `--resume <quoted-id>` to the trailing CLI invocation so
-                the AI conversation continues across the restart. The
-                persisted Session.composedCommand is never mutated by
-                this augmentation. The wait thread later flips the
-                status to Running / Exited / Error as the child reports.
-           Spawn or temp-file failures map per-session to Error and
-           never abort the loop.
+                `~/.copilot/session-state/<id>/` for Copilot), the
+                stored composedCommand is *augmented* (not recomposed)
+                with `--resume <quoted-id>` on the spawn-time copy only.
+                The persisted Session.composedCommand is never mutated.
+           Temp-file or status-update failures map per-session to Error
+           and never abort the loop. Awaiting restore creates the
+           happens-before edge that the frontend's first
+           `session_resize` (issued synchronously by `attachToHost`
+           → `refitEntry` once `setStatus('ready')` triggers MainArea
+           to mount) needs in order to find the pending entry.
   → first session in tabOrder remains the active session
 ```
 
 This ordering guarantees:
 
-- The window is interactive within the SPEC NF-03 startup budget,
-  regardless of how slow individual sessions are to start (restore is
-  fire-and-forget from the frontend's perspective).
+- The window is interactive within the SPEC NF-03 startup budget. Restore
+  registration is bounded — disk IO + HashMap inserts only — so awaiting
+  it does not blow the budget.
 - `session://output` and `session://status` listeners are attached
   *before* any spawn happens, so early output and status events cannot
   be lost.
 - Restore is driven by the Rust backend (`restore_all_sessions`), not by
   re-invoking `session_create` from the frontend — the frontend never
   has to reconstruct a `composedCommand`.
+- The PTY child's first paint (splash, prompt) sees the actual host
+  cols/rows the user will see, not the historical 80×24 default — see
+  §5.5b for the deferred-spawn rationale.
+
+
+### 5.5b Deferred-spawn-on-first-resize (avoiding the splash-too-narrow bug)
+
+A pre-fix bug: every PTY was opened at a hardcoded 80×24 default, even
+on hosts that ended up rendering at e.g. 114 cols. The CLI's first paint
+(splash, first prompt) was drawn at 80 cols and sat permanently in
+xterm's scrollback at the wrong layout — Copilot's splash logo broke
+visibly, prompt input columns drifted, etc.
+
+The fix plumbs the host's actual cols/rows into the spawn at every
+entrypoint:
+
+- **`session_create`** and **`session_restart`**: the frontend measures
+  its host *before* invoking the command (`measureInitialPtyDimensions`
+  in `src/hooks/use-terminal.ts`) and passes `cols`/`rows` in the args.
+  The backend forwards the same `PtySize` straight to
+  `PtySpawner::spawn` — no default fallback in the live spawn path.
+- **`restore_all_sessions`**: the host doesn't yet exist when restore
+  runs (the frontend hasn't laid out MainArea), so the spawn is
+  *deferred*. Restore registers the prepared `Session` (already
+  AI-resume-augmented if applicable) in `pending_spawn`. The first
+  `session_resize` for that session id atomically `remove()`s the entry,
+  spawns at the resize's `PtySize`, and starts the metrics watcher. A
+  later resize hits the regular `pool.resize` path.
+
+Race notes:
+- `frontend_ready` awaits restore completion before resolving, so the
+  frontend's first synchronous `session_resize` (from `attachToHost` →
+  `refitEntry`) cannot lose the pending entry.
+- A second resize that lands while the deferred spawn is still in flight
+  may transiently get `NotFound` from `pool.resize`. The frontend logs
+  and continues; the next ResizeObserver tick (debounced 50 ms) corrects.
+  The window is short enough that we accept it rather than complicate
+  the synchronisation further.
 
 
 ### 5.6 CLI Launch Commands
@@ -421,14 +464,14 @@ All commands are gated by Tauri capability declarations in `capabilities/main.js
 
 | Command | Payload | Return | Description |
 |---------|---------|--------|-------------|
-| `session_create` | `{ tool, worktreePath, instructionSetId? }` | `SessionView` | Compose and spawn a new session. `instructionSetId` is optional; when omitted, Claude is launched without `--system-prompt` and the CLI relies on `cwd`-based discovery for repo instructions. |
+| `session_create` | `{ tool, worktreePath, instructionSetId?, cols, rows }` | `SessionView` | Compose and spawn a new session. `instructionSetId` is optional; when omitted, Claude is launched without `--system-prompt` and the CLI relies on `cwd`-based discovery for repo instructions. `cols`/`rows` are the frontend-measured initial PTY dimensions — required so the CLI's first paint matches the actual host width (see §5.5b). |
 | `session_list` | — | `SessionView[]` | Return all current sessions (without composedCommand/tempFiles) |
 | `session_close` | `{ sessionId, deleteWorktree? }` | `SessionCloseResult` | Terminate a session (after UI confirmation). When `deleteWorktree` is `true`, the backend additionally runs `git worktree remove --force <worktreePath>` after killing the PTY. Refuses to remove the configured `workspaceRoot` (main worktree), any path outside the workspace root, or a path still referenced by another live session. The session record + PTY are always torn down on success; if the worktree-remove step fails, the message is reported via `worktreeDeleteError` rather than as a hard error. |
 | `session_focus` | `{ sessionId }` | — | Mark session as active |
 | `session_resize` | `{ sessionId, cols, rows }` | — | Resize PTY |
 | `session_input` | `{ sessionId, data }` | — | Send keystrokes to PTY |
-| `session_restart` | `{ sessionId }` | — | Re-spawn a session using its stored `composedCommand` verbatim (DESIGN §5.4) |
-| `frontend_ready` | — | — | One-shot signal from the frontend after first paint; triggers restore-on-launch (re-spawns every session in `lastOpenSessions` via `respawn_existing`). Idempotent — subsequent calls are no-ops. |
+| `session_restart` | `{ sessionId, cols, rows }` | — | Re-spawn a session using its stored `composedCommand` verbatim (DESIGN §5.4). `cols`/`rows` are the frontend-measured current PTY dimensions so the new child paints at the right size from the first byte (see §5.5b). |
+| `frontend_ready` | — | — | One-shot signal from the frontend after first paint; **awaits** restore-on-launch completion so the frontend's first `session_resize` is guaranteed to find the pending session entry registered (see §5.5/§5.5b). Idempotent — subsequent calls are no-ops. |
 | `config_get` | — | `AppConfig` | Retrieve AppConfig |
 | `config_set` | `Partial<AppConfig>` | — | Update AppConfig (`activeSessionId` is tri-state: omit to leave alone, `null` to clear, value to set) |
 | `instructions_list` | — | `InstructionSet[]` | List available instruction sets from `instructionSetsDir` |

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -28,8 +28,8 @@ use crate::config_store::{list_instructions_for, ConfigStore};
 use crate::types::{
     AppConfig, AppError, InstructionSet, PartialAppConfig, SessionCloseArgs, SessionCloseResult,
     SessionCreateArgs, SessionId, SessionIdArg, SessionInputArgs, SessionOutputEvent,
-    SessionResizeArgs, SessionStatus, SessionStatusEvent, SessionView, WorkspaceValidateArgs,
-    WorkspaceValidateResult, WorktreeCreateArgs, WorktreeCreateResult,
+    SessionResizeArgs, SessionRestartArgs, SessionStatus, SessionStatusEvent, SessionView,
+    WorkspaceValidateArgs, WorkspaceValidateResult, WorktreeCreateArgs, WorktreeCreateResult,
 };
 
 pub use session::AppContext;
@@ -139,26 +139,46 @@ pub async fn session_input(app: tauri::AppHandle, args: SessionInputArgs) -> Res
 }
 
 #[tauri::command]
-pub async fn session_restart(app: tauri::AppHandle, args: SessionIdArg) -> Result<(), AppError> {
+pub async fn session_restart(
+    app: tauri::AppHandle,
+    args: SessionRestartArgs,
+) -> Result<(), AppError> {
     let ctx = ctx_of(&app)?;
-    session::session_restart_impl(&ctx, args.session_id)
+    session::session_restart_impl(&ctx, args)
 }
 
 /// Frontend signals that it has subscribed to `session://output` and
 /// `session://status`. The first call triggers restore-on-launch (DESIGN
 /// §5.5); subsequent calls are no-ops.
+///
+/// **Awaits restore registration** before resolving so the frontend can
+/// safely fire its first `session_resize` (issued synchronously by
+/// `attachToHost` → `refitEntry`) and trust that any restored session id
+/// is already registered in `pending_spawn`. Without this, the
+/// resize-arrives-before-restore race would silently drop the deferred
+/// spawn (`pool.resize` → `NotFound`), leaving the session stuck in
+/// `Starting` with no PTY child.
 #[tauri::command]
 pub async fn frontend_ready(app: tauri::AppHandle) -> Result<(), AppError> {
     let ctx = ctx_of(&app)?;
     if session::frontend_ready_impl(&ctx) {
         let ctx_for_task = Arc::clone(&ctx);
-        // `restore_all_sessions` does blocking IO and PTY spawn — run it
-        // on a blocking thread so we don't hold the executor. We
-        // intentionally don't await the JoinHandle: restore is fire-and-
-        // forget from the frontend's perspective.
-        std::mem::drop(tauri::async_runtime::spawn_blocking(move || {
+        // `restore_all_sessions` no longer spawns PTYs (it only does
+        // disk IO + HashMap inserts), so the work is bounded — but we
+        // still run it on a blocking thread because materialise_temp_files
+        // / cleanup_orphans / store IO can block. We *await* completion
+        // here so the resolution of `frontend_ready` becomes a
+        // happens-before edge for the frontend's first `session_resize`.
+        tauri::async_runtime::spawn_blocking(move || {
             session::restore_all_sessions(&ctx_for_task);
-        }));
+        })
+        .await
+        .map_err(|join_err| {
+            AppError::new(
+                "Internal",
+                format!("restore_all_sessions task panicked: {join_err}"),
+            )
+        })?;
     }
     Ok(())
 }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -138,6 +138,28 @@ impl AppContext {
 // session_create
 // ---------------------------------------------------------------------------
 
+/// Reject zero-sized PTY dimensions at the command boundary. Raw `u16`
+/// allows `0`; passing `PtySize { cols: 0, rows: 0, ... }` to
+/// `portable_pty::openpty` fails with an opaque OS error on the spawn
+/// thread. We catch it here so the frontend gets a stable, branchable
+/// error code (`InvalidArgs`) it can surface as a real diagnostic
+/// instead of a generic "PTY spawn failed".
+///
+/// In normal use, [`crate::types::SessionCreateArgs`]/`SessionResizeArgs`
+/// are populated by the frontend's `measureInitialPtyDimensions` /
+/// `getTerminalDimensions`, which clamp upward. This guard is purely
+/// defensive against a future refactor that bypasses those helpers, or
+/// a buggy direct caller.
+fn validate_pty_dims(cols: u16, rows: u16) -> Result<(), AppError> {
+    if cols == 0 || rows == 0 {
+        return Err(AppError::new(
+            "InvalidArgs",
+            format!("pty dimensions must be > 0 (got cols={cols}, rows={rows})"),
+        ));
+    }
+    Ok(())
+}
+
 /// Create a new session, materialise its temp files, persist it, and spawn
 /// the PTY child. Returns the [`SessionView`] the frontend can stash in its
 /// store.
@@ -145,6 +167,8 @@ pub fn session_create_impl(
     ctx: &AppContext,
     args: SessionCreateArgs,
 ) -> Result<SessionView, AppError> {
+    validate_pty_dims(args.cols, args.rows)?;
+
     // 1. Validate worktree (canonicalises; rejects relative/missing).
     let worktree = compose::validate_worktree(&args.worktree_path).map_err(AppError::from)?;
 
@@ -553,6 +577,12 @@ pub fn session_resize_impl(ctx: &AppContext, args: SessionResizeArgs) -> Result<
         rows,
     } = args;
 
+    // Reject 0×0 up front. Without this, the deferred-spawn branch below
+    // would forward zeros into `pool.spawn` and the live-resize branch
+    // into `pool.resize`, both of which surface OS-level openpty/ioctl
+    // errors. See [`validate_pty_dims`].
+    validate_pty_dims(cols, rows)?;
+
     // Atomically claim a pending-spawn entry for this session, if any.
     // `restore_all_sessions` registers restored sessions here without
     // spawning, deferring the actual `pool.spawn` until the frontend
@@ -630,6 +660,8 @@ pub fn session_input_impl(ctx: &AppContext, args: SessionInputArgs) -> Result<()
 // ---------------------------------------------------------------------------
 
 pub fn session_restart_impl(ctx: &AppContext, args: SessionRestartArgs) -> Result<(), AppError> {
+    validate_pty_dims(args.cols, args.rows)?;
+
     let id = args.session_id;
     let sessions = ctx.store.load_sessions();
     let session = sessions

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -20,11 +20,13 @@
 //! the on-disk session record converges automatically when the production
 //! sink is wired (see [`crate::lib::run`]).
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use portable_pty::PtySize;
 use tracing::{debug, info, warn};
 
 use crate::compose::{self, ComposeInputs};
@@ -36,8 +38,8 @@ use crate::pty_pool::{cleanup_orphans, PtyPool, PtySink};
 use crate::session_metrics::{AiSessionDiscoveryCb, MetricsCb, MetricsRegistry, TurnCb};
 use crate::types::{
     AppError, Error, InstructionSet, PartialAppConfig, Session, SessionCloseResult,
-    SessionCreateArgs, SessionId, SessionInputArgs, SessionResizeArgs, SessionStatus, SessionView,
-    Tool,
+    SessionCreateArgs, SessionId, SessionInputArgs, SessionResizeArgs, SessionRestartArgs,
+    SessionStatus, SessionView, Tool,
 };
 
 /// Wiring shared by every Phase 7 session command. Built once at startup
@@ -74,6 +76,19 @@ pub struct AppContext {
     /// `session://activity` channel as a `TurnEnd` variant; tests
     /// substitute a capturing closure.
     pub turn_emit: TurnCb,
+    /// Sessions that have been persisted but not yet PTY-spawned. Used by
+    /// `restore_all_sessions` to defer the actual `pool.spawn` until the
+    /// frontend reports the real terminal dimensions via `session_resize`.
+    /// The first `session_resize` for a pending id atomically claims it
+    /// (removing it from the map) and triggers the spawn at the right
+    /// size — so the CLI's first paint never happens at the wrong width.
+    /// The map value is the spawn-ready `Session` (already augmented with
+    /// `--resume <ai-session-id>` if applicable) so the claim path doesn't
+    /// have to re-derive it. `Mutex<HashMap>` (not `RwLock`) because the
+    /// only access pattern is a single-step claim (`remove`) under the same
+    /// lock as the membership check, which a `RwLock` cannot give us
+    /// atomically.
+    pub pending_spawn: Arc<Mutex<HashMap<SessionId, Session>>>,
 }
 
 impl AppContext {
@@ -97,6 +112,7 @@ impl AppContext {
             metrics_emit,
             ai_session_discover,
             turn_emit,
+            pending_spawn: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -234,7 +250,16 @@ pub fn session_create_impl(
     // 11. Spawn. The pool emits Running with PID through the same sink.
     let pid = ctx
         .pool
-        .spawn(&session, ctx.sink.clone())
+        .spawn(
+            &session,
+            ctx.sink.clone(),
+            PtySize {
+                cols: args.cols,
+                rows: args.rows,
+                pixel_width: 0,
+                pixel_height: 0,
+            },
+        )
         .map_err(AppError::from)?;
 
     // 12. Start the per-session metrics watcher (Issue #3). No-op for tools
@@ -279,6 +304,14 @@ pub async fn session_close_impl(
     // 0. Stop the metrics watcher (Issue #3) before tearing the rest down
     //    so it never observes a half-cleaned session.
     ctx.metrics.stop(&id);
+
+    // 0b. Drop any deferred-spawn registration so a session closed before
+    //     the frontend ever measured it doesn't leak — and so a later
+    //     `session_resize` for a stale id can't trigger a phantom spawn
+    //     of an already-removed record.
+    if let Ok(mut g) = ctx.pending_spawn.lock() {
+        g.remove(&id);
+    }
 
     // Capture the worktree path *before* we drop the persisted record —
     // we need it for the optional `git worktree remove` step at the end.
@@ -514,8 +547,75 @@ pub fn session_focus_impl(ctx: &AppContext, id: SessionId) -> Result<(), AppErro
 // ---------------------------------------------------------------------------
 
 pub fn session_resize_impl(ctx: &AppContext, args: SessionResizeArgs) -> Result<(), AppError> {
+    let SessionResizeArgs {
+        session_id,
+        cols,
+        rows,
+    } = args;
+
+    // Atomically claim a pending-spawn entry for this session, if any.
+    // `restore_all_sessions` registers restored sessions here without
+    // spawning, deferring the actual `pool.spawn` until the frontend
+    // measures its host and fires the first `session_resize`. That way
+    // the CLI's first paint sees the correct PTY width rather than the
+    // OS-default 80×24 — see DESIGN §5.5 (restore-on-launch) and the
+    // PR notes for the long-standing splash-screen-too-narrow bug.
+    let pending = {
+        let mut guard = ctx
+            .pending_spawn
+            .lock()
+            .map_err(|_| AppError::new("Internal", "pending_spawn mutex poisoned"))?;
+        guard.remove(&session_id)
+    };
+
+    if let Some(session) = pending {
+        let size = PtySize {
+            cols,
+            rows,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        match ctx.pool.spawn(&session, ctx.sink.clone(), size) {
+            Ok(pid) => {
+                info!(
+                    session_id = %session.id,
+                    pid,
+                    cols,
+                    rows,
+                    "deferred spawn fired by first session_resize",
+                );
+                // Start the metrics watcher (Issue #3) — mirrors what
+                // `restore_all_sessions` used to do immediately after
+                // the inline spawn.
+                ctx.metrics.start(
+                    session.id,
+                    session.tool,
+                    session.worktree_path.clone(),
+                    SystemTime::now(),
+                    Arc::clone(&ctx.metrics_emit),
+                    Arc::clone(&ctx.turn_emit),
+                    Arc::clone(&ctx.ai_session_discover),
+                );
+                return Ok(());
+            }
+            Err(e) => {
+                // The deferred spawn failed (e.g. PTY allocation OS error).
+                // Surface as Error status so the UI shows the overlay
+                // with a Restart button — same shape as a restart-time
+                // failure (the user can retry once they've fixed
+                // whatever caused the spawn to fail).
+                let msg = format!("Failed to start restored session: {e}");
+                let _ = ctx
+                    .store
+                    .update_session_status(&session.id, SessionStatus::Error, None);
+                (ctx.sink.status)(&session.id, SessionStatus::Error, None, Some(msg));
+                return Err(AppError::from(e));
+            }
+        }
+    }
+
     ctx.pool
-        .resize(&args.session_id, args.cols, args.rows)
+        .resize(&session_id, cols, rows)
         .map_err(AppError::from)
 }
 
@@ -529,7 +629,8 @@ pub fn session_input_impl(ctx: &AppContext, args: SessionInputArgs) -> Result<()
 // session_restart
 // ---------------------------------------------------------------------------
 
-pub fn session_restart_impl(ctx: &AppContext, id: SessionId) -> Result<(), AppError> {
+pub fn session_restart_impl(ctx: &AppContext, args: SessionRestartArgs) -> Result<(), AppError> {
+    let id = args.session_id;
     let sessions = ctx.store.load_sessions();
     let session = sessions
         .get(&id)
@@ -589,7 +690,16 @@ pub fn session_restart_impl(ctx: &AppContext, id: SessionId) -> Result<(), AppEr
         warn!(session_id = %id, error = ?e, "restart: failed to clear ai_session_id");
     }
 
-    if let Err(e) = ctx.pool.respawn_existing(&session, ctx.sink.clone()) {
+    if let Err(e) = ctx.pool.respawn_existing(
+        &session,
+        ctx.sink.clone(),
+        PtySize {
+            cols: args.cols,
+            rows: args.rows,
+            pixel_width: 0,
+            pixel_height: 0,
+        },
+    ) {
         let msg = format!("Failed to restart session: {e}");
         let _ = ctx
             .store
@@ -756,32 +866,27 @@ pub fn restore_all_sessions(ctx: &AppContext) {
         }
 
         match ctx
-            .pool
-            .respawn_existing(&session_to_spawn, ctx.sink.clone())
+            .pending_spawn
+            .lock()
+            .map(|mut g| g.insert(id, session_to_spawn))
         {
-            Ok(pid) => {
-                info!(session_id = %id, pid, "restored session");
-                // Issue #3: spin up the metrics watcher for restored sessions
-                // too, otherwise a user who never recreates a session would
-                // never see the indicator.
-                ctx.metrics.start(
-                    id,
-                    session.tool,
-                    session.worktree_path.clone(),
-                    SystemTime::now(),
-                    Arc::clone(&ctx.metrics_emit),
-                    Arc::clone(&ctx.turn_emit),
-                    Arc::clone(&ctx.ai_session_discover),
+            Ok(_) => {
+                info!(
+                    session_id = %id,
+                    "restore: registered for deferred spawn (will fire on first session_resize)",
                 );
             }
-            Err(e) => {
-                warn!(session_id = %id, error = ?e, "restore: respawn failed");
-                let msg = format!("Failed to restart session: {e}");
-                // Best-effort: surface as Error status so the UI can show it.
+            Err(_) => {
+                warn!(session_id = %id, "restore: pending_spawn mutex poisoned; skipping deferred registration");
                 let _ = ctx
                     .store
                     .update_session_status(&id, SessionStatus::Error, None);
-                (ctx.sink.status)(&id, SessionStatus::Error, None, Some(msg));
+                (ctx.sink.status)(
+                    &id,
+                    SessionStatus::Error,
+                    None,
+                    Some("Internal error: could not register session for restore".to_owned()),
+                );
             }
         }
     }

--- a/src-tauri/src/pty_pool.rs
+++ b/src-tauri/src/pty_pool.rs
@@ -519,9 +519,14 @@ impl PtyPool {
     /// invocation `[shell, flag, session.composed_command]` and passes the
     /// session's worktree as the discrete `cwd`.
     ///
+    /// The `size` is the initial PTY dimensions the child sees at startup.
+    /// Callers must measure the host terminal first — passing the wrong size
+    /// here is the exact race that caused the long-standing "splash screen
+    /// rendered at 80 cols then never re-laid-out" bug.
+    ///
     /// Returns the assigned PID.
-    pub fn spawn(&self, session: &Session, sink: PtySink) -> Result<u32, Error> {
-        self.spawn_internal(session, sink)
+    pub fn spawn(&self, session: &Session, sink: PtySink, size: PtySize) -> Result<u32, Error> {
+        self.spawn_internal(session, sink, size)
     }
 
     /// Re-spawn a session from its **already-stored** `composed_command`.
@@ -530,17 +535,27 @@ impl PtyPool {
     /// "do not recompose at restart time" rule from DESIGN §5.4.
     ///
     /// [`spawn`]: Self::spawn
-    pub fn respawn_existing(&self, session: &Session, sink: PtySink) -> Result<u32, Error> {
+    pub fn respawn_existing(
+        &self,
+        session: &Session,
+        sink: PtySink,
+        size: PtySize,
+    ) -> Result<u32, Error> {
         // If a previous runtime entry exists (e.g. from a prior spawn that
         // hasn't exited yet), tear it down first.
         if self.contains(&session.id) {
             // Best-effort kill; if the child is already dead this is a no-op.
             let _ = self.kill_blocking(&session.id);
         }
-        self.spawn_internal(session, sink)
+        self.spawn_internal(session, sink, size)
     }
 
-    fn spawn_internal(&self, session: &Session, sink: PtySink) -> Result<u32, Error> {
+    fn spawn_internal(
+        &self,
+        session: &Session,
+        sink: PtySink,
+        size: PtySize,
+    ) -> Result<u32, Error> {
         // ------- 1. Per-session spawn prep (telemetry env, temp dir).
         //
         // We do this here — not in `commands/session.rs` — so every spawn
@@ -590,9 +605,7 @@ impl PtyPool {
         };
 
         // ------- 3. Spawn via injected spawner; cwd is discrete (DESIGN §5.6)
-        let spawned = self
-            .spawner
-            .spawn(cmd, &session.worktree_path, DEFAULT_PTY_SIZE)?;
+        let spawned = self.spawner.spawn(cmd, &session.worktree_path, size)?;
         let SpawnedChild {
             pid,
             reader,

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -559,6 +559,15 @@ pub struct SessionCreateArgs {
     /// See [`Session::instruction_set_id`].
     #[serde(default)]
     pub instruction_set_id: Option<InstructionSetId>,
+    /// Initial PTY width (columns) the child process will see at startup.
+    /// The frontend measures the terminal host before calling `session_create`
+    /// so the CLI's first paint (e.g., a Copilot/Claude splash screen)
+    /// renders at the right width — without this, the child reads 80 cols
+    /// from the OS, draws its splash narrow, and never re-paints when the
+    /// later `session_resize` arrives.
+    pub cols: u16,
+    /// Initial PTY height (rows). See [`Self::cols`].
+    pub rows: u16,
 }
 
 /// Arguments for any command keyed only by session id
@@ -612,6 +621,21 @@ pub struct SessionCloseResult {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionResizeArgs {
+    pub session_id: SessionId,
+    pub cols: u16,
+    pub rows: u16,
+}
+
+/// Arguments for `session_restart`. Carries the current PTY dimensions so
+/// the freshly-spawned child process sees the right size from its very
+/// first `ioctl(TIOCGWINSZ)` / ConPTY query, instead of starting at the
+/// OS-default 80×24 and rendering its initial output (splash screen,
+/// shell prompt, …) at the wrong width.
+///
+/// MIRROR: `src/lib/tauri-bridge.ts::SessionRestartArgs`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRestartArgs {
     pub session_id: SessionId,
     pub cols: u16,
     pub rows: u16,

--- a/src-tauri/tests/pty_pool.rs
+++ b/src-tauri/tests/pty_pool.rs
@@ -17,7 +17,8 @@ use std::time::{Duration, Instant};
 use arborist_lib::compose::{copilot_otel_path, session_temp_dir};
 use arborist_lib::pty_pool::{
     cleanup_orphans, ChildCommand, PortablePtySpawner, PtyKiller, PtyPool, PtyResize, PtySink,
-    PtySpawner, PtyWaiter, SpawnedChild, ANSI_FULL_RESET, OUTPUT_CHANNEL_CAPACITY,
+    PtySpawner, PtyWaiter, SpawnedChild, ANSI_FULL_RESET, DEFAULT_PTY_SIZE,
+    OUTPUT_CHANNEL_CAPACITY,
 };
 use arborist_lib::types::{
     InstructionSetId, Session, SessionId, SessionStatus, TempFileSpec, Tool,
@@ -164,7 +165,7 @@ fn spawn_banner_then_quit_yields_exited_status() {
 
     let rt = rt();
     let _g = rt.enter();
-    let pid = pool.spawn(&session, sink).expect("spawn");
+    let pid = pool.spawn(&session, sink, DEFAULT_PTY_SIZE).expect("spawn");
     assert!(pid > 0);
 
     assert!(
@@ -206,7 +207,7 @@ fn echoes_input_back_through_sink() {
 
     let _rt = rt();
     let _g = _rt.enter();
-    pool.spawn(&session, sink).expect("spawn");
+    pool.spawn(&session, sink, DEFAULT_PTY_SIZE).expect("spawn");
     wait_for(&outs, |s| s.contains("READY"), Duration::from_secs(5)).expect("ready");
     pool.write(&session.id, b"hello\r\n").expect("write");
     assert!(
@@ -227,7 +228,7 @@ fn resize_calls_do_not_disrupt_io() {
 
     let _rt = rt();
     let _g = _rt.enter();
-    pool.spawn(&session, sink).expect("spawn");
+    pool.spawn(&session, sink, DEFAULT_PTY_SIZE).expect("spawn");
     wait_for(&outs, |s| s.contains("READY"), Duration::from_secs(5)).expect("ready");
     pool.resize(&session.id, 100, 30).expect("resize");
     pool.resize(&session.id, 80, 24).expect("resize");
@@ -251,7 +252,7 @@ fn nonzero_exit_yields_error_status() {
 
     let _rt = rt();
     let _g = _rt.enter();
-    pool.spawn(&session, sink).expect("spawn");
+    pool.spawn(&session, sink, DEFAULT_PTY_SIZE).expect("spawn");
     wait_for(&outs, |s| s.contains("READY"), Duration::from_secs(5)).expect("ready");
     pool.write(&session.id, b"exit 7\r\n").expect("write");
     assert!(
@@ -283,7 +284,7 @@ fn kill_terminates_child_and_removes_entry_and_temp_dir() {
 
     let rt = rt();
     let _g = rt.enter();
-    pool.spawn(&session, sink).expect("spawn");
+    pool.spawn(&session, sink, DEFAULT_PTY_SIZE).expect("spawn");
     wait_for(&outs, |s| s.contains("READY"), Duration::from_secs(5)).expect("ready");
 
     rt.block_on(async {
@@ -304,12 +305,16 @@ fn respawn_existing_yields_a_new_pid() {
 
     let rt = rt();
     let _g = rt.enter();
-    let pid1 = pool.spawn(&session, sink.clone()).expect("spawn 1");
+    let pid1 = pool
+        .spawn(&session, sink.clone(), DEFAULT_PTY_SIZE)
+        .expect("spawn 1");
     wait_for(&outs, |s| s.contains("READY"), Duration::from_secs(5)).expect("ready 1");
     rt.block_on(async { pool.kill(&session.id).await.expect("kill") });
 
     let (sink2, outs2, _stats2) = recording_sink();
-    let pid2 = pool.respawn_existing(&session, sink2).expect("respawn");
+    let pid2 = pool
+        .respawn_existing(&session, sink2, DEFAULT_PTY_SIZE)
+        .expect("respawn");
     assert_ne!(pid1, pid2, "respawn should yield a new pid");
     assert!(
         wait_for(&outs2, |s| s.contains("READY"), Duration::from_secs(5)).is_some(),
@@ -365,7 +370,7 @@ fn pool_spawn_prep_injects_otel_env_and_clears_stale_file_for_copilot() {
 
     let rt = rt();
     let _g = rt.enter();
-    pool.spawn(&session, sink).expect("spawn");
+    pool.spawn(&session, sink, DEFAULT_PTY_SIZE).expect("spawn");
 
     // Assert: the spawner saw a ChildCommand with the three OTel env keys.
     let cmd = spawner_for_assert
@@ -429,7 +434,7 @@ fn pool_spawn_prep_is_noop_for_claude_session() {
 
     let rt = rt();
     let _g = rt.enter();
-    pool.spawn(&session, sink).expect("spawn");
+    pool.spawn(&session, sink, DEFAULT_PTY_SIZE).expect("spawn");
 
     let cmd = spawner_for_assert
         .last_cmd
@@ -662,7 +667,7 @@ fn backpressure_drops_chunks_and_inserts_reset_after_drain() {
 
     let rt = rt();
     let _g = rt.enter();
-    pool.spawn(&session, sink).expect("spawn");
+    pool.spawn(&session, sink, DEFAULT_PTY_SIZE).expect("spawn");
 
     // Wait for the read thread to finish producing AND for the channel to
     // fill up. The channel cap is 512; 2000 chunks > 512 so drops must occur.
@@ -731,7 +736,7 @@ fn no_output_delivered_after_kill_returns() {
 
     let rt = rt();
     let _g = rt.enter();
-    pool.spawn(&session, sink).expect("spawn");
+    pool.spawn(&session, sink, DEFAULT_PTY_SIZE).expect("spawn");
     rt.block_on(async {
         pool.kill(&session.id).await.expect("kill");
     });
@@ -766,7 +771,7 @@ fn utf8_character_split_across_reads_emerges_intact() {
 
     let rt = rt();
     let _g = rt.enter();
-    pool.spawn(&session, sink).expect("spawn");
+    pool.spawn(&session, sink, DEFAULT_PTY_SIZE).expect("spawn");
 
     assert!(
         wait_for(&outs, |s| s.contains("a世b"), Duration::from_secs(3)).is_some(),
@@ -801,7 +806,7 @@ fn wait_thread_emits_status_with_cleared_pid_on_natural_exit() {
     let (sink, _outs, stats) = recording_sink();
     let rt = rt();
     let _g = rt.enter();
-    pool.spawn(&session, sink).expect("spawn");
+    pool.spawn(&session, sink, DEFAULT_PTY_SIZE).expect("spawn");
     assert!(
         wait_for_status(
             &stats,

--- a/src-tauri/tests/session_lifecycle_fake.rs
+++ b/src-tauri/tests/session_lifecycle_fake.rs
@@ -426,6 +426,72 @@ async fn restart_passes_dims_to_respawn() {
 }
 
 #[tokio::test]
+async fn create_rejects_zero_dimensions() {
+    // PR #28 review: raw u16 lets `0` slip through, which then fails
+    // deep inside `portable_pty::openpty` with an opaque OS error. The
+    // command boundary now rejects it with a stable, branchable code so
+    // the frontend can surface a real diagnostic (or a future refactor
+    // that bypasses `measureInitialPtyDimensions` is caught at the
+    // boundary instead of as a cryptic "PTY spawn failed").
+    let h = build_harness();
+    for (cols, rows) in [(0u16, 24u16), (80, 0), (0, 0)] {
+        let args = SessionCreateArgs {
+            tool: Tool::Claude,
+            worktree_path: h.worktree.path().to_path_buf(),
+            instruction_set_id: Some(h.instruction_id.clone()),
+            cols,
+            rows,
+        };
+        let err = session_create_impl(&h.ctx, args)
+            .expect_err(&format!("create({cols}x{rows}) should have failed"));
+        assert_eq!(err.code, "InvalidArgs", "unexpected code for {cols}x{rows}");
+        assert!(
+            err.message.contains("pty dimensions"),
+            "unexpected message: {}",
+            err.message
+        );
+    }
+    // Sanity: the spawner must NOT have been touched.
+    let st = h.spawner.state.lock().unwrap();
+    assert!(
+        st.last_size.is_none(),
+        "spawner.spawn should not run when dims are 0"
+    );
+}
+
+#[tokio::test]
+async fn restart_rejects_zero_dimensions() {
+    let h = build_harness();
+    let view = session_create_impl(&h.ctx, create_args(&h)).unwrap();
+    let err = session_restart_impl(
+        &h.ctx,
+        SessionRestartArgs {
+            session_id: view.id,
+            cols: 0,
+            rows: 24,
+        },
+    )
+    .expect_err("restart with cols=0 should fail");
+    assert_eq!(err.code, "InvalidArgs");
+}
+
+#[tokio::test]
+async fn resize_rejects_zero_dimensions() {
+    let h = build_harness();
+    let view = session_create_impl(&h.ctx, create_args(&h)).unwrap();
+    let err = session_resize_impl(
+        &h.ctx,
+        SessionResizeArgs {
+            session_id: view.id,
+            cols: 0,
+            rows: 0,
+        },
+    )
+    .expect_err("resize with 0×0 should fail");
+    assert_eq!(err.code, "InvalidArgs");
+}
+
+#[tokio::test]
 async fn create_with_unknown_instruction_set_returns_notfound() {
     let h = build_harness();
     let args = SessionCreateArgs {

--- a/src-tauri/tests/session_lifecycle_fake.rs
+++ b/src-tauri/tests/session_lifecycle_fake.rs
@@ -32,7 +32,8 @@ use arborist_lib::pty_pool::{
 };
 use arborist_lib::types::{
     InstructionSetId, PartialAppConfig, PartialDefaultInstructionSets, SessionCreateArgs,
-    SessionId, SessionInputArgs, SessionResizeArgs, SessionStatus, Tool, WorktreeInfo,
+    SessionId, SessionInputArgs, SessionResizeArgs, SessionRestartArgs, SessionStatus, Tool,
+    WorktreeInfo,
 };
 use portable_pty::{ExitStatus, PtySize};
 use tempfile::TempDir;
@@ -46,6 +47,13 @@ struct SpawnerState {
     spawn_count: usize,
     last_cwd: Option<PathBuf>,
     last_cmd: Option<ChildCommand>,
+    /// PtySize handed to the most recent `spawn` call. Used by regression
+    /// tests that pin the deferred-spawn path: `restore_all_sessions` no
+    /// longer spawns directly; the first `session_resize` from the
+    /// frontend triggers the spawn and *that* size — not
+    /// `DEFAULT_PTY_SIZE` — must reach the spawner so the CLI's first
+    /// paint matches the real terminal width.
+    last_size: Option<PtySize>,
     /// One entry per spawn so a test can keep killing/respawning.
     eofs: Vec<Arc<AtomicBool>>,
     next_pid: u32,
@@ -71,12 +79,13 @@ impl PtySpawner for FakeSpawner {
         &self,
         cmd: ChildCommand,
         cwd: &Path,
-        _size: PtySize,
+        size: PtySize,
     ) -> Result<SpawnedChild, arborist_lib::types::Error> {
         let mut s = self.state.lock().unwrap();
         s.spawn_count += 1;
         s.last_cwd = Some(cwd.to_path_buf());
         s.last_cmd = Some(cmd);
+        s.last_size = Some(size);
         let pid = s.next_pid;
         s.next_pid += 1;
         let eof = Arc::new(AtomicBool::new(false));
@@ -302,6 +311,8 @@ fn create_args(h: &Harness) -> SessionCreateArgs {
         tool: Tool::Claude,
         worktree_path: h.worktree.path().to_path_buf(),
         instruction_set_id: Some(h.instruction_id.clone()),
+        cols: 80,
+        rows: 24,
     }
 }
 
@@ -370,12 +381,59 @@ async fn create_emits_starting_then_running_and_persists_session() {
 }
 
 #[tokio::test]
+async fn create_passes_initial_size_to_spawner() {
+    // Regression: pre-fix, the PTY was always opened at DEFAULT_PTY_SIZE
+    // (80×24) regardless of what the frontend actually rendered, so the
+    // CLI's first paint (e.g. a Copilot/Claude splash) was always at 80
+    // cols. The frontend now measures its host first and passes the real
+    // dims through SessionCreateArgs; this test pins that they actually
+    // reach `PtySpawner::spawn`.
+    let h = build_harness();
+    let args = SessionCreateArgs {
+        tool: Tool::Claude,
+        worktree_path: h.worktree.path().to_path_buf(),
+        instruction_set_id: Some(h.instruction_id.clone()),
+        cols: 173,
+        rows: 47,
+    };
+    session_create_impl(&h.ctx, args).expect("create ok");
+    let st = h.spawner.state.lock().unwrap();
+    let size = st.last_size.expect("spawner should have recorded a size");
+    assert_eq!(size.cols, 173);
+    assert_eq!(size.rows, 47);
+}
+
+#[tokio::test]
+async fn restart_passes_dims_to_respawn() {
+    // Companion to `create_passes_initial_size_to_spawner` — restart goes
+    // through the same race and is fixed the same way (frontend reads
+    // term.cols/rows and passes them in `SessionRestartArgs`).
+    let h = build_harness();
+    let view = session_create_impl(&h.ctx, create_args(&h)).unwrap();
+    session_restart_impl(
+        &h.ctx,
+        SessionRestartArgs {
+            session_id: view.id,
+            cols: 200,
+            rows: 60,
+        },
+    )
+    .expect("restart ok");
+    let st = h.spawner.state.lock().unwrap();
+    let size = st.last_size.expect("respawn should have recorded a size");
+    assert_eq!(size.cols, 200);
+    assert_eq!(size.rows, 60);
+}
+
+#[tokio::test]
 async fn create_with_unknown_instruction_set_returns_notfound() {
     let h = build_harness();
     let args = SessionCreateArgs {
         tool: Tool::Claude,
         worktree_path: h.worktree.path().to_path_buf(),
         instruction_set_id: Some(InstructionSetId("does-not-exist".into())),
+        cols: 80,
+        rows: 24,
     };
     let err = session_create_impl(&h.ctx, args).expect_err("should fail");
     assert_eq!(err.code, "NotFound");
@@ -391,6 +449,8 @@ async fn create_with_tool_mismatch_returns_toolmismatch() {
         tool: Tool::Claude,
         worktree_path: h.worktree.path().to_path_buf(),
         instruction_set_id: Some(InstructionSetId("copilot-only".into())),
+        cols: 80,
+        rows: 24,
     };
     let err = session_create_impl(&h.ctx, args).expect_err("should fail");
     assert_eq!(err.code, "ToolMismatch");
@@ -681,7 +741,15 @@ async fn restart_reuses_composed_command_and_yields_new_pid() {
     let v1 = session_create_impl(&h.ctx, create_args(&h)).unwrap();
     let original_pid = v1.pid.unwrap();
 
-    session_restart_impl(&h.ctx, v1.id).unwrap();
+    session_restart_impl(
+        &h.ctx,
+        SessionRestartArgs {
+            session_id: v1.id,
+            cols: 80,
+            rows: 24,
+        },
+    )
+    .unwrap();
 
     // After restart, list reports a Running session with a new PID.
     let listed = session_list_impl(&h.ctx).unwrap();
@@ -705,7 +773,7 @@ async fn frontend_ready_is_one_shot() {
 }
 
 #[tokio::test]
-async fn restore_respawns_persisted_sessions_without_recomposing() {
+async fn restore_defers_spawn_until_first_session_resize() {
     // Bootstrap a harness, persist a session, then drop the pool and rebuild
     // a fresh ctx around the same store — simulating an app restart.
     let h = build_harness();
@@ -724,20 +792,48 @@ async fn restore_respawns_persisted_sessions_without_recomposing() {
     let pool2 = Arc::new(PtyPool::new(spawner2.clone() as Arc<dyn PtySpawner>));
     let events2 = Arc::new(CapturedEvents::default());
     let sink2 = capture_sink(Arc::clone(&events2), h.ctx.store.clone());
-    let ctx2 = AppContext::with_real_git(pool2, h.ctx.store.clone(), sink2);
+    let ctx2 = Arc::new(AppContext::with_real_git(pool2, h.ctx.store.clone(), sink2));
 
     restore_all_sessions(&ctx2);
 
-    // The restored session should still appear and now have a fresh PID
-    // (the new spawner starts at 9000).
-    let listed = session_list_impl(&Arc::new(ctx2)).unwrap();
+    // Restore *registers* the session for deferred spawn but doesn't spawn
+    // yet — so the spawner stays untouched and status is still Starting.
+    assert!(
+        spawner2.state.lock().unwrap().last_cmd.is_none(),
+        "restore_all_sessions must not invoke the spawner directly anymore"
+    );
+    let listed_pre = session_list_impl(&ctx2).unwrap();
+    assert_eq!(listed_pre.len(), 1);
+    assert_eq!(listed_pre[0].status, SessionStatus::Starting);
+    assert_eq!(listed_pre[0].pid, None);
+
+    // The first session_resize from the (now-mounted) frontend triggers
+    // the actual spawn — at the freshly-measured size, so the CLI's
+    // first paint sees the right cols/rows.
+    session_resize_impl(
+        &ctx2,
+        SessionResizeArgs {
+            session_id: original.id,
+            cols: 132,
+            rows: 50,
+        },
+    )
+    .expect("deferred spawn via resize ok");
+
+    let listed = session_list_impl(&ctx2).unwrap();
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].id, original.id);
     assert_eq!(listed[0].status, SessionStatus::Running);
     assert_eq!(listed[0].pid, Some(9000));
 
-    // Composed command was reused verbatim — never recomposed.
+    // The PtySize handed to the spawner reflects the frontend-measured
+    // dims, not DEFAULT_PTY_SIZE — this is the whole point of the fix.
     let st = spawner2.state.lock().unwrap();
+    let size = st.last_size.expect("spawner should have recorded a size");
+    assert_eq!(size.cols, 132);
+    assert_eq!(size.rows, 50);
+
+    // Composed command was reused verbatim — never recomposed.
     let cmd = st.last_cmd.as_ref().unwrap();
     let composed_in_args = cmd.args.iter().find(|a| a.contains("claude")).cloned();
     assert!(

--- a/src/components/FitDebugButton.test.tsx
+++ b/src/components/FitDebugButton.test.tsx
@@ -78,6 +78,26 @@ describe('FitDebugButton', () => {
     expect(screen.getByTestId('fit-debug-button')).toHaveTextContent('Fit');
   });
 
+  it('exposes the visible label as the accessible name (no static aria-label that would mask it)', () => {
+    // Regression for the original sidebar-debug PR: the button used a
+    // static aria-label, so screen readers always heard "Force-fit every
+    // terminal..." regardless of whether the visible text changed to
+    // "Copied ✓" / "Copy failed". The fix drops aria-label so the SR
+    // accessible name is the visible label, and the live region on the
+    // label span announces the transient state.
+    render(<FitDebugButton />);
+    const btn = screen.getByRole('button', { name: /^fit$/i });
+    expect(btn).toBe(screen.getByTestId('fit-debug-button'));
+    expect(btn.hasAttribute('aria-label')).toBe(false);
+    // Tooltip stays on `title`.
+    expect(btn.getAttribute('title')).toMatch(/force-fit/i);
+    // The label span itself is the live region so SRs announce updates.
+    const labelSpan = btn.querySelector<HTMLElement>('[aria-live="polite"]');
+    expect(labelSpan).not.toBeNull();
+    expect(labelSpan!.textContent).toBe('Fit');
+    expect(labelSpan!.getAttribute('aria-atomic')).toBe('true');
+  });
+
   it('captures snapshot, forces refit, and copies bundle to clipboard', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, 'clipboard', {

--- a/src/components/FitDebugButton.test.tsx
+++ b/src/components/FitDebugButton.test.tsx
@@ -1,0 +1,205 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/tauri-bridge', async () => await import('@/lib/tauri-bridge.mock'));
+
+vi.mock('@/hooks/use-terminal', () => ({
+  forceRefitAllTerminals: vi.fn(),
+  captureTerminalDebugSnapshot: vi.fn(() => ({
+    capturedAt: '2026-04-30T00:00:00.000Z',
+    windowInnerWidth: 1280,
+    windowInnerHeight: 800,
+    devicePixelRatio: 2,
+    documentVisibility: 'visible',
+    documentHasFocus: true,
+    fontsStatus: 'loaded',
+    darkMode: false,
+    registrySize: 1,
+    entries: [
+      {
+        sessionId: 's1',
+        isAttached: true,
+        hostConnected: true,
+        wrapperConnected: true,
+        termCols: 80,
+        termRows: 24,
+        lastReportedCols: 80,
+        lastReportedRows: 24,
+        fontFamily: 'monospace',
+        fontSize: undefined,
+        hostRect: { width: 600, height: 400, top: 0, left: 0 },
+        wrapperRect: { width: 600, height: 400, top: 0, left: 0 },
+        screenRect: { width: 600, height: 400, top: 0, left: 0 },
+        approxCellWidth: 7.5,
+        approxCellHeight: 16.67,
+        hostDisplay: 'block',
+        hostVisibility: 'visible',
+        ancestors: [],
+      },
+    ],
+  })),
+}));
+
+import { captureTerminalDebugSnapshot, forceRefitAllTerminals } from '@/hooks/use-terminal';
+import { useSessionStore } from '@/store/session-store';
+
+import { FitDebugButton } from './FitDebugButton';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  useSessionStore.setState({
+    sessions: [
+      {
+        id: 's1',
+        tool: 'claude',
+        worktreePath: '/wt',
+        worktreeName: 'wt',
+        label: 'wt',
+        instructionSetId: 'default',
+        status: 'running',
+        createdAt: 0,
+        tabIndex: 0,
+      },
+    ],
+    activeId: 's1',
+    isHydrated: true,
+  });
+  vi.mocked(captureTerminalDebugSnapshot).mockClear();
+  vi.mocked(forceRefitAllTerminals).mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('FitDebugButton', () => {
+  it('renders an idle "Fit" label by default', () => {
+    render(<FitDebugButton />);
+    expect(screen.getByTestId('fit-debug-button')).toHaveTextContent('Fit');
+  });
+
+  it('captures snapshot, forces refit, and copies bundle to clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(<FitDebugButton />);
+    const btn = screen.getByTestId('fit-debug-button');
+
+    await act(async () => {
+      btn.click();
+      // Drain microtasks for the clipboard promise to resolve.
+      await Promise.resolve();
+    });
+
+    // Two snapshots: before + after refit.
+    expect(captureTerminalDebugSnapshot).toHaveBeenCalledTimes(2);
+    expect(forceRefitAllTerminals).toHaveBeenCalledTimes(1);
+
+    // Refit happens between the two snapshots.
+    const captureOrder = vi.mocked(captureTerminalDebugSnapshot).mock.invocationCallOrder;
+    const refitOrder = vi.mocked(forceRefitAllTerminals).mock.invocationCallOrder;
+    expect(captureOrder[0]!).toBeLessThan(refitOrder[0]!);
+    expect(refitOrder[0]!).toBeLessThan(captureOrder[1]!);
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    const payload = writeText.mock.calls[0]![0] as string;
+    const parsed = JSON.parse(payload) as Record<string, unknown>;
+    expect(parsed).toHaveProperty('before');
+    expect(parsed).toHaveProperty('after');
+    expect(parsed).toHaveProperty('sessions');
+    expect((parsed.sessions as unknown[]).length).toBe(1);
+
+    expect(btn).toHaveTextContent('Copied ✓');
+    act(() => {
+      vi.advanceTimersByTime(2100);
+    });
+    expect(btn).toHaveTextContent('Fit');
+  });
+
+  it('shows "Copy failed" when clipboard rejects', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    render(<FitDebugButton />);
+    const btn = screen.getByTestId('fit-debug-button');
+    await act(async () => {
+      btn.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Refit still happened — that's the "keep working" promise.
+    expect(forceRefitAllTerminals).toHaveBeenCalledTimes(1);
+    expect(btn).toHaveTextContent('Copy failed');
+    warnSpy.mockRestore();
+  });
+
+  it('still copies an after-snapshot when forceRefitAllTerminals throws', async () => {
+    vi.mocked(forceRefitAllTerminals).mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    render(<FitDebugButton />);
+    await act(async () => {
+      screen.getByTestId('fit-debug-button').click();
+      await Promise.resolve();
+    });
+
+    expect(captureTerminalDebugSnapshot).toHaveBeenCalledTimes(2);
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('fit-debug-button')).toHaveTextContent('Copied ✓');
+    warnSpy.mockRestore();
+  });
+
+  it('does not setState after unmount when the clipboard resolves late', async () => {
+    let resolveWrite: () => void = () => {};
+    const writeText = vi.fn().mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveWrite = resolve;
+      }),
+    );
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { unmount } = render(<FitDebugButton />);
+    act(() => {
+      screen.getByTestId('fit-debug-button').click();
+    });
+    expect(writeText).toHaveBeenCalledTimes(1);
+
+    // Unmount BEFORE the clipboard promise resolves — simulates the user
+    // tearing the sidebar down (e.g. navigating, app hot-reloading) mid-flight.
+    unmount();
+
+    await act(async () => {
+      resolveWrite();
+      await Promise.resolve();
+    });
+
+    // No "setState on unmounted component" warnings should have fired.
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    // No leaked timers either: advancing past the 2s flash window must not
+    // throw or trigger any further work.
+    act(() => {
+      vi.advanceTimersByTime(2100);
+    });
+    errorSpy.mockRestore();
+  });
+});

--- a/src/components/FitDebugButton.tsx
+++ b/src/components/FitDebugButton.tsx
@@ -130,17 +130,24 @@ export function FitDebugButton(): JSX.Element {
   const title =
     'Force-fit every terminal and copy a debug snapshot of layout state to the clipboard.';
 
+  // Accessibility: the visible `<span>` text doubles as the button's
+  // accessible name (no `aria-label`, which would mask it). The label
+  // span is `aria-live="polite"` + `aria-atomic="true"` so screen
+  // readers announce the transient "Copied ✓" / "Copy failed" status
+  // without spamming on every paint. `title` provides the long
+  // hover/tooltip description without affecting the SR name.
   return (
     <button
       type="button"
       data-testid="fit-debug-button"
       title={title}
-      aria-label={title}
       onClick={onClick}
       className="flex items-center gap-1 rounded px-2 py-1.5 text-xs text-slate-600 hover:bg-slate-200 dark:text-slate-300 dark:hover:bg-slate-800"
     >
       <span aria-hidden="true">🔧</span>
-      <span>{label}</span>
+      <span aria-live="polite" aria-atomic="true">
+        {label}
+      </span>
     </button>
   );
 }

--- a/src/components/FitDebugButton.tsx
+++ b/src/components/FitDebugButton.tsx
@@ -1,0 +1,146 @@
+// Sidebar debug button that helps diagnose terminal-fit issues. On click:
+//
+//   1. Captures a `before` snapshot of every attached terminal — host /
+//      wrapper / .xterm-screen rects, term cols/rows, last cols/rows
+//      reported to the backend, computed cell size, host visibility and a
+//      few ancestors, plus environment context (DPR, fonts state,
+//      visibility, focus).
+//   2. Forces `fit()` + `refresh()` on every attached terminal via
+//      `forceRefitAllTerminals()` so the user can keep working without
+//      having to reload.
+//   3. Captures an `after` snapshot.
+//   4. Copies `{ before, after, sessions }` as pretty-printed JSON to the
+//      clipboard so it can be pasted into a debug session.
+//
+// Visual feedback is a transient state on the button label ("Copied ✓" or
+// "Copy failed"). No toast system in v1.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  captureTerminalDebugSnapshot,
+  forceRefitAllTerminals,
+  type TerminalDebugSnapshot,
+} from '@/hooks/use-terminal';
+import { useActiveSessionId, useSessions } from '@/store/session-store';
+
+type ButtonState = 'idle' | 'copied' | 'error';
+
+interface DebugBundle {
+  before: TerminalDebugSnapshot;
+  after: TerminalDebugSnapshot;
+  sessions: Array<{
+    id: string;
+    label: string;
+    status: string;
+    tabIndex: number;
+    isActive: boolean;
+  }>;
+  userAgent: string | null;
+}
+
+async function writeToClipboard(text: string): Promise<void> {
+  // Modern clipboard API first; fall back to a transient textarea selection
+  // for environments where navigator.clipboard isn't available (older
+  // WebView2 builds, jsdom).
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  if (typeof document === 'undefined') {
+    throw new Error('clipboard unavailable: no document');
+  }
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.style.position = 'fixed';
+  ta.style.opacity = '0';
+  document.body.appendChild(ta);
+  try {
+    ta.select();
+    const ok = document.execCommand?.('copy');
+    if (!ok) throw new Error('execCommand("copy") returned false');
+  } finally {
+    ta.remove();
+  }
+}
+
+export function FitDebugButton(): JSX.Element {
+  const sessions = useSessions();
+  const activeId = useActiveSessionId();
+  const [state, setState] = useState<ButtonState>('idle');
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef<boolean>(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (resetTimer.current !== null) {
+        clearTimeout(resetTimer.current);
+        resetTimer.current = null;
+      }
+    };
+  }, []);
+
+  // Guarded against a click → clipboard-resolve → component-unmount race:
+  // the clipboard promise is async, and if the user dismisses the sidebar
+  // (or the app navigates) before it settles, `setState` would fire on an
+  // unmounted component AND schedule a leaked timer.
+  const flash = useCallback((next: 'copied' | 'error') => {
+    if (!mountedRef.current) return;
+    setState(next);
+    if (resetTimer.current !== null) clearTimeout(resetTimer.current);
+    resetTimer.current = setTimeout(() => {
+      resetTimer.current = null;
+      if (mountedRef.current) setState('idle');
+    }, 2000);
+  }, []);
+
+  const onClick = useCallback(() => {
+    const before = captureTerminalDebugSnapshot();
+    try {
+      forceRefitAllTerminals();
+    } catch (err) {
+      // Swallow — refit is best-effort. Still capture the after-snapshot so
+      // we know fit() threw.
+      console.warn('[FitDebugButton] forceRefitAllTerminals threw:', err);
+    }
+    const after = captureTerminalDebugSnapshot();
+    const bundle: DebugBundle = {
+      before,
+      after,
+      sessions: sessions.map((s) => ({
+        id: s.id,
+        label: s.label,
+        status: s.status,
+        tabIndex: s.tabIndex,
+        isActive: s.id === activeId,
+      })),
+      userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : null,
+    };
+    void writeToClipboard(JSON.stringify(bundle, null, 2))
+      .then(() => flash('copied'))
+      .catch((err: unknown) => {
+        console.warn('[FitDebugButton] clipboard write failed:', err);
+        flash('error');
+      });
+  }, [sessions, activeId, flash]);
+
+  const label = state === 'copied' ? 'Copied ✓' : state === 'error' ? 'Copy failed' : 'Fit';
+  const title =
+    'Force-fit every terminal and copy a debug snapshot of layout state to the clipboard.';
+
+  return (
+    <button
+      type="button"
+      data-testid="fit-debug-button"
+      title={title}
+      aria-label={title}
+      onClick={onClick}
+      className="flex items-center gap-1 rounded px-2 py-1.5 text-xs text-slate-600 hover:bg-slate-200 dark:text-slate-300 dark:hover:bg-slate-800"
+    >
+      <span aria-hidden="true">🔧</span>
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/src/components/MainArea.tsx
+++ b/src/components/MainArea.tsx
@@ -1,7 +1,8 @@
 // MainArea — right-hand pane of the app shell.
 //
 // Renders **every** session's TerminalView simultaneously, hiding all but
-// the active one via inline `display: none`. The motivation is twofold:
+// the active one via inline `visibility: hidden`. The motivation is
+// twofold:
 //
 //   1. xterm Terminal instances live in the `use-terminal` module-level
 //      registry, so even if MainArea swapped TerminalViews on tab change

--- a/src/components/NewSessionDialog.test.tsx
+++ b/src/components/NewSessionDialog.test.tsx
@@ -199,10 +199,12 @@ describe('NewSessionDialog', () => {
     fireEvent.click(createBtn);
     await waitFor(() => expect(bridgeMock.worktreeCreate).toHaveBeenCalledWith('my-feature'));
     await waitFor(() =>
-      expect(bridgeMock.sessionCreate).toHaveBeenCalledWith({
-        tool: 'claude',
-        worktreePath: `${REPO_ROOT}/.worktrees/my-feature`,
-      }),
+      expect(bridgeMock.sessionCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tool: 'claude',
+          worktreePath: `${REPO_ROOT}/.worktrees/my-feature`,
+        }),
+      ),
     );
     await waitFor(() => expect(useNewSessionDialog.getState().isOpen).toBe(false));
   });
@@ -377,10 +379,12 @@ describe('NewSessionDialog', () => {
     fireEvent.click(createBtn);
     await waitFor(() => expect(bridgeMock.worktreeCreate).toHaveBeenCalledWith('my-feature'));
     await waitFor(() =>
-      expect(bridgeMock.sessionCreate).toHaveBeenCalledWith({
-        tool: 'claude',
-        worktreePath: `${REPO_ROOT}/.worktrees/my-feature`,
-      }),
+      expect(bridgeMock.sessionCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tool: 'claude',
+          worktreePath: `${REPO_ROOT}/.worktrees/my-feature`,
+        }),
+      ),
     );
     await waitFor(() => expect(useNewSessionDialog.getState().isOpen).toBe(false));
   });
@@ -640,10 +644,12 @@ describe('NewSessionDialog', () => {
     fireEvent.click(screen.getByRole('button', { name: /create session/i }));
 
     await waitFor(() =>
-      expect(bridgeMock.sessionCreate).toHaveBeenCalledWith({
-        tool: 'claude',
-        worktreePath: `${REPO_ROOT}/.worktrees/main`,
-      }),
+      expect(bridgeMock.sessionCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tool: 'claude',
+          worktreePath: `${REPO_ROOT}/.worktrees/main`,
+        }),
+      ),
     );
     // Defensive: assert the field was not silently included as undefined
     // either, so the contract change is unambiguous on the wire.

--- a/src/components/NewSessionDialog.tsx
+++ b/src/components/NewSessionDialog.tsx
@@ -26,6 +26,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { isInsideWorktreesDir } from '@/lib/worktree-paths';
 import { formatError, pickDirectory, worktreeCreate, worktreesList } from '@/lib/tauri-bridge';
 import { validateWorktreeName } from '@/lib/worktree-validation';
+import { measureInitialPtyDimensions } from '@/hooks/use-terminal';
 import { selectPrelaunchCommands, selectWorkspaceRoot, useConfigStore } from '@/store/config-store';
 import { useNewSessionDialog } from '@/store/new-session-dialog-store';
 import { useSessionActions } from '@/store/session-store';
@@ -250,7 +251,13 @@ export function NewSessionDialog(): JSX.Element | null {
       // We refresh the worktree list lazily only on the failure path — on
       // success the dialog closes and the listing is never shown.
       try {
-        await actions.create({ tool, worktreePath: result.path });
+        const initialDims = measureInitialPtyDimensions();
+        await actions.create({
+          tool,
+          worktreePath: result.path,
+          cols: initialDims.cols,
+          rows: initialDims.rows,
+        });
         close();
       } catch (sessionErr) {
         setSubmitError(formatError(sessionErr));
@@ -303,9 +310,12 @@ export function NewSessionDialog(): JSX.Element | null {
       // `.github/copilot-instructions.md`. Power users can attach an
       // additional instruction-set overlay through Settings; this wizard
       // keeps the per-session create flow opinionated.
+      const initialDims = measureInitialPtyDimensions();
       await actions.create({
         tool,
         worktreePath: worktree.path,
+        cols: initialDims.cols,
+        rows: initialDims.rows,
       });
       close();
     } catch (err) {

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -367,6 +367,32 @@ describe('Sidebar', () => {
     // handler.
     expect(screen.queryByText(/terminate session/i)).toBeNull();
   });
+
+  it('does not swallow Enter/Space activation on non-tab buttons in the bottom bar', () => {
+    // Regression for the "Settings/Fit buttons stop working with the
+    // keyboard" PR-review finding: the tablist `onKeyDown` used to fire
+    // `preventDefault()` on Enter/Space for ANY descendant, so focusing
+    // the Settings button and pressing Enter would no longer activate
+    // it. Buttons inside the sidebar that lack `role="tab"` must be
+    // skipped by the tablist key handler so the browser's default click
+    // synthesis fires normally.
+    seed([makeView('a')], 'a');
+    render(<Sidebar />);
+    expect(screen.queryByTestId('settings-dialog')).toBeNull();
+
+    const settingsBtn = screen.getByTestId('settings-button');
+    settingsBtn.focus();
+    // Mirror what a real keyboard activation would do: fire keydown
+    // with the focused button as the event target. The handler must
+    // bail out, leaving Enter free to trigger the click → onClick.
+    fireEvent.keyDown(settingsBtn, { key: 'Enter' });
+    expect(settingsBtn).not.toHaveAttribute('aria-disabled', 'true');
+    // Sanity: the close-confirm dialog (bound to Delete on tabs)
+    // should also remain closed if Delete is pressed on a non-tab
+    // button — proves the gate is wide enough.
+    fireEvent.keyDown(settingsBtn, { key: 'Delete' });
+    expect(screen.queryByText(/terminate session/i)).toBeNull();
+  });
 });
 
 describe('Sidebar unread accessibility', () => {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -23,6 +23,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
 
 import { CloseConfirmDialog } from './CloseConfirmDialog';
+import { FitDebugButton } from './FitDebugButton';
 import { NewSessionButton } from './NewSessionButton';
 import { SettingsDialog } from './SettingsDialog';
 import { SidebarTab } from './SidebarTab';
@@ -243,16 +244,17 @@ export function Sidebar(): JSX.Element {
           </ul>
         </SortableContext>
       </DndContext>
-      <div className="mt-auto border-t border-slate-200 px-2 py-2 dark:border-slate-800">
+      <div className="mt-auto flex items-center gap-1 border-t border-slate-200 px-2 py-2 dark:border-slate-800">
         <button
           type="button"
           data-testid="settings-button"
           onClick={() => setSettingsOpen(true)}
-          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs text-slate-600 hover:bg-slate-200 dark:text-slate-300 dark:hover:bg-slate-800"
+          className="flex flex-1 items-center gap-2 rounded px-2 py-1.5 text-xs text-slate-600 hover:bg-slate-200 dark:text-slate-300 dark:hover:bg-slate-800"
         >
           <span aria-hidden="true">⚙</span>
           <span>Settings</span>
         </button>
+        <FitDebugButton />
       </div>
       <CloseConfirmDialog />
       {settingsOpen ? <SettingsDialog onClose={() => setSettingsOpen(false)} /> : null}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -148,6 +148,11 @@ export function Sidebar(): JSX.Element {
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
       if (target.isContentEditable) return;
       if (target.closest('[role="dialog"]')) return;
+      // Skip non-tab buttons inside the sidebar (Settings, Fit-debug). They
+      // bubble keydown into this tablist handler, which then `preventDefault`s
+      // Enter/Space and breaks their normal activation. Tabs themselves carry
+      // role="tab", so a tab's button passes the gate.
+      if (tag === 'BUTTON' && !target.matches('[role="tab"]')) return;
     }
     if (ids.length === 0) return;
     const current = Math.min(focusedIndex, ids.length - 1);

--- a/src/components/TerminalView.test.tsx
+++ b/src/components/TerminalView.test.tsx
@@ -104,7 +104,11 @@ describe('TerminalView', () => {
     render(<TerminalView sessionId="s1" isActive={true} />);
     const restart = screen.getByRole('button', { name: /restart/i });
     act(() => restart.click());
-    expect(sessionRestart).toHaveBeenCalledWith({ sessionId: 's1' });
+    expect(sessionRestart).toHaveBeenCalledWith({
+      sessionId: 's1',
+      cols: 80,
+      rows: 24,
+    });
   });
 
   it('shows overlay when status === exited', () => {

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -9,7 +9,7 @@
 import { useEffect, useRef } from 'react';
 
 import { sessionRestart } from '@/lib/tauri-bridge';
-import { useTerminal } from '@/hooks/use-terminal';
+import { measureInitialPtyDimensions, useTerminal } from '@/hooks/use-terminal';
 import { useSessionById, useStatusMessage } from '@/store/session-store';
 import type { SessionId } from '@/types/arborist';
 
@@ -28,7 +28,7 @@ export function TerminalView({ sessionId, isActive }: TerminalViewProps): JSX.El
   const containerRef = useRef<HTMLDivElement | null>(null);
   const session = useSessionById(sessionId);
   const statusMessage = useStatusMessage(sessionId);
-  const { attach, detach, focus, refit } = useTerminal(sessionId);
+  const { attach, detach, focus, refit, getDimensions } = useTerminal(sessionId);
 
   useEffect(() => {
     const el = containerRef.current;
@@ -60,7 +60,12 @@ export function TerminalView({ sessionId, isActive }: TerminalViewProps): JSX.El
   const showOverlay = status === 'error' || status === 'exited';
 
   const handleRestart = (): void => {
-    void sessionRestart({ sessionId }).catch((err: unknown) => {
+    // Reuse the existing terminal's measured cols/rows so the new PTY
+    // child paints its splash at the size xterm currently shows. If
+    // somehow the terminal entry is gone (very rare — overlay hides
+    // before the entry is disposed), fall back to a fresh measurement.
+    const dims = getDimensions() ?? measureInitialPtyDimensions();
+    void sessionRestart({ sessionId, cols: dims.cols, rows: dims.rows }).catch((err: unknown) => {
       const message = err instanceof Error ? err.message : String(err);
       console.warn(`[TerminalView] session_restart(${sessionId}) failed: ${message}`);
     });

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -68,7 +68,10 @@ import {
   __resetTerminalRegistryForTests,
   __getTerminalRegistryForTests,
   disposeTerminal,
+  FALLBACK_PTY_DIMS,
+  getTerminalDimensions,
   initTerminalRouter,
+  measureInitialPtyDimensions,
   useTerminal,
 } from './use-terminal';
 import {
@@ -347,5 +350,65 @@ describe('useTerminal', () => {
     // Advance past the debounce window — the original pending fit fires.
     act(() => vi.advanceTimersByTime(60));
     expect(mockFitAddons[0]!.fit).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('initial PTY dimension helpers', () => {
+  it('getTerminalDimensions returns null for unknown sessions and {cols,rows} once an entry exists', () => {
+    expect(getTerminalDimensions('nope')).toBeNull();
+
+    renderHook(() => useTerminal('s1'));
+    // The xterm mock seeds cols=80 / rows=24.
+    expect(getTerminalDimensions('s1')).toEqual({ cols: 80, rows: 24 });
+  });
+
+  it('measureInitialPtyDimensions reuses an attached terminal when present', () => {
+    renderHook(() => useTerminal('s1'));
+    // Without an attach() the entry exists but `host` is null, so the
+    // helper falls through. Force-mark the terminal's measured cols/rows
+    // and attach a host so the registry-reuse branch is exercised.
+    const entry = __getTerminalRegistryForTests().get('s1')!;
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    (entry as unknown as { host: HTMLElement | null }).host = host;
+    mockTerminals[0]!.cols = 173;
+    mockTerminals[0]!.rows = 47;
+    expect(measureInitialPtyDimensions()).toEqual({ cols: 173, rows: 47 });
+  });
+
+  it('measureInitialPtyDimensions ignores stale registry entries whose host is not connected', () => {
+    // Reproduces the "session is mid-dispose" race: the registry entry
+    // still exists, its `host` ref is non-null, but the host has been
+    // removed from the DOM. We must NOT reuse those cols/rows — they
+    // reflect a previous layout and could mislead the new session's
+    // PTY size.
+    renderHook(() => useTerminal('s1'));
+    const entry = __getTerminalRegistryForTests().get('s1')!;
+    const detachedHost = document.createElement('div'); // never appended
+    (entry as unknown as { host: HTMLElement | null }).host = detachedHost;
+    mockTerminals[0]!.cols = 999;
+    mockTerminals[0]!.rows = 999;
+    // No <main>, so we expect the fallback rather than the stale dims.
+    expect(document.querySelector('main')).toBeNull();
+    expect(measureInitialPtyDimensions()).toEqual(FALLBACK_PTY_DIMS);
+  });
+
+  it('measureInitialPtyDimensions falls back to defaults when no <main> exists in the DOM', () => {
+    // No active terminals (registry empty) and no <main> element.
+    expect(document.querySelector('main')).toBeNull();
+    expect(measureInitialPtyDimensions()).toEqual(FALLBACK_PTY_DIMS);
+  });
+
+  it('measureInitialPtyDimensions falls back to defaults when <main> is laid out at 0×0', () => {
+    // jsdom doesn't compute layout, so getBoundingClientRect returns
+    // {width: 0, height: 0}. Without the explicit zero-rect bail, the
+    // helper would clamp 0/cellW up to the 20-col floor and silently
+    // hand back a tiny PTY — exactly the splash-too-narrow regression.
+    const main = document.createElement('main');
+    document.body.appendChild(main);
+    const rect = main.getBoundingClientRect();
+    expect(rect.width).toBe(0);
+    expect(rect.height).toBe(0);
+    expect(measureInitialPtyDimensions()).toEqual(FALLBACK_PTY_DIMS);
   });
 });

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -391,18 +391,67 @@ describe('initial PTY dimension helpers', () => {
     expect(getTerminalDimensions('s1')).toBeNull();
   });
 
-  it('measureInitialPtyDimensions reuses an attached terminal when present', () => {
+  it('measureInitialPtyDimensions reuses an attached, proven-fit terminal when present', () => {
     renderHook(() => useTerminal('s1'));
-    // Without an attach() the entry exists but `host` is null, so the
-    // helper falls through. Force-mark the terminal's measured cols/rows
-    // and attach a host so the registry-reuse branch is exercised.
+    // Force-mark the entry as both attached AND proven-fit (lastCols/Rows
+    // > 0 — the same gate getTerminalDimensions uses). Without
+    // lastCols/Rows the helper would correctly fall through to the DOM
+    // probe even though host is connected, since the terminal was never
+    // actually fit.
     const entry = __getTerminalRegistryForTests().get('s1')!;
     const host = document.createElement('div');
     document.body.appendChild(host);
-    (entry as unknown as { host: HTMLElement | null }).host = host;
-    mockTerminals[0]!.cols = 173;
-    mockTerminals[0]!.rows = 47;
+    type Mut = {
+      host: HTMLElement | null;
+      wrapper: HTMLElement | null;
+      lastCols: number;
+      lastRows: number;
+    };
+    const mut = entry as unknown as Mut;
+    mut.host = host;
+    // measureInitialPtyDimensions delegates to getTerminalDimensions,
+    // which checks `wrapper?.isConnected` not `host.isConnected`.
+    const wrapper = document.createElement('div');
+    host.appendChild(wrapper);
+    mut.wrapper = wrapper;
+    mut.lastCols = 173;
+    mut.lastRows = 47;
     expect(measureInitialPtyDimensions()).toEqual({ cols: 173, rows: 47 });
+  });
+
+  it('measureInitialPtyDimensions does NOT reuse a connected-but-unfitted entry (lastCols/Rows still 0)', () => {
+    // Regression for the "splash too narrow" risk that survived the
+    // first round of review fixes: an entry whose host is connected
+    // but whose first fitAddon.fit() threw (e.g. host was zero-size
+    // mid-transition) leaves lastCols/lastRows at 0 even though
+    // term.cols/rows still default to 80/24. Reusing those would feed
+    // 80x24 straight back into session_create — exactly the bug we're
+    // closing. The helper must skip the entry and fall through.
+    renderHook(() => useTerminal('s1'));
+    const entry = __getTerminalRegistryForTests().get('s1')!;
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const wrapper = document.createElement('div');
+    host.appendChild(wrapper);
+    type Mut = {
+      host: HTMLElement | null;
+      wrapper: HTMLElement | null;
+      lastCols: number;
+      lastRows: number;
+    };
+    const mut = entry as unknown as Mut;
+    mut.host = host;
+    mut.wrapper = wrapper;
+    // term.cols/rows still default to 80/24 from the xterm mock (the
+    // exact OS-default we want to avoid leaking). lastCols/lastRows
+    // remain 0 — the proven-fit signal. No <main> in the DOM ⇒ helper
+    // must reach the FALLBACK branch instead of returning {80,24}.
+    expect(mockTerminals[0]!.cols).toBe(80);
+    expect(mockTerminals[0]!.rows).toBe(24);
+    expect(mut.lastCols).toBe(0);
+    expect(mut.lastRows).toBe(0);
+    expect(document.querySelector('main')).toBeNull();
+    expect(measureInitialPtyDimensions()).toEqual(FALLBACK_PTY_DIMS);
   });
 
   it('measureInitialPtyDimensions ignores stale registry entries whose host is not connected', () => {

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -16,6 +16,12 @@ const mockTerminals: Array<{
   cols: number;
   rows: number;
   _dataCb?: (data: string) => void;
+  _core: {
+    _renderService: {
+      clear: ReturnType<typeof vi.fn>;
+      handleCharSizeChanged: ReturnType<typeof vi.fn>;
+    };
+  };
 }> = [];
 
 vi.mock('@xterm/xterm', () => {
@@ -30,6 +36,12 @@ vi.mock('@xterm/xterm', () => {
       refresh: vi.fn(),
       cols: 80,
       rows: 24,
+      _core: {
+        _renderService: {
+          clear: vi.fn(),
+          handleCharSizeChanged: vi.fn(),
+        },
+      },
     };
     inst.onData.mockImplementation((cb: (data: string) => void) => {
       inst._dataCb = cb;
@@ -258,6 +270,43 @@ describe('useTerminal', () => {
     expect(mockFitAddons[0]!.fit).not.toHaveBeenCalled();
     expect(mockTerminals[0]!.refresh).not.toHaveBeenCalled();
     expect(sessionResize).not.toHaveBeenCalled();
+  });
+
+  it('refit() forces a render-service repaint each call (recovers from fit() short-circuit when dims are unchanged)', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const handleCharSizeChanged = mockTerminals[0]!._core._renderService.handleCharSizeChanged;
+    const clear = mockTerminals[0]!._core._renderService.clear;
+
+    // Attach already ran one synchronous fit cycle, so each spy fired
+    // exactly once during attachment.
+    expect(handleCharSizeChanged).toHaveBeenCalledTimes(1);
+    expect(clear).toHaveBeenCalledTimes(1);
+
+    // A subsequent imperative refit fires both again — even though the
+    // mocked dims haven't changed (FitAddon.fit() would short-circuit
+    // its internal renderService.clear + term.resize). This is the exact
+    // case where a manual window resize "fixes it" but the old refit
+    // path did nothing visible: the renderer's inline sizes on
+    // .xterm-screen / row elements were never re-applied.
+    act(() => result.current.refit());
+    expect(handleCharSizeChanged).toHaveBeenCalledTimes(2);
+    expect(clear).toHaveBeenCalledTimes(2);
+  });
+
+  it('refit() tolerates xterm builds without _core / _renderService', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    // Simulate a future xterm major that drops or renames the private
+    // fields we poke at — refit should degrade to the old fit+refresh
+    // behaviour rather than throwing.
+    (mockTerminals[0] as unknown as { _core?: unknown })._core = undefined;
+    expect(() => act(() => result.current.attach(host))).not.toThrow();
+    expect(() => act(() => result.current.refit())).not.toThrow();
+    expect(mockFitAddons[0]!.fit).toHaveBeenCalled();
+    expect(mockTerminals[0]!.refresh).toHaveBeenCalled();
   });
 
   it('refit() does not cancel a pending debounced fit when fit() throws', () => {

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -67,6 +67,7 @@ import { renderHook } from '@testing-library/react';
 import {
   __resetTerminalRegistryForTests,
   __getTerminalRegistryForTests,
+  captureTerminalDebugSnapshot,
   disposeTerminal,
   FALLBACK_PTY_DIMS,
   getTerminalDimensions,
@@ -354,12 +355,40 @@ describe('useTerminal', () => {
 });
 
 describe('initial PTY dimension helpers', () => {
-  it('getTerminalDimensions returns null for unknown sessions and {cols,rows} once an entry exists', () => {
+  it('getTerminalDimensions returns null for unknown sessions', () => {
     expect(getTerminalDimensions('nope')).toBeNull();
+  });
 
+  it('getTerminalDimensions returns null for an entry that has not been attached/fitted yet', () => {
+    // Regression for the "80x24 leaks into session_restart" bug: a
+    // brand-new xterm Terminal defaults to cols=80/rows=24 even before
+    // open()/fit(). Returning those would feed the OS-default size
+    // straight back into the backend on a fast Restart click.
     renderHook(() => useTerminal('s1'));
-    // The xterm mock seeds cols=80 / rows=24.
+    expect(__getTerminalRegistryForTests().has('s1')).toBe(true);
+    expect(getTerminalDimensions('s1')).toBeNull();
+  });
+
+  it('getTerminalDimensions returns the measured dims after a successful attach/fit', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+    // attach() ran one synchronous refit; lastCols/lastRows now mirror
+    // the mock terminal's seeded 80×24.
     expect(getTerminalDimensions('s1')).toEqual({ cols: 80, rows: 24 });
+  });
+
+  it('getTerminalDimensions returns null after detach (wrapper no longer connected)', () => {
+    // Defensive: detach() leaves the registry entry in place (so the
+    // next attach can re-parent without re-running term.open) but
+    // disconnects the wrapper. We treat that as "no proven-fit dims"
+    // rather than handing back the last-known size, which may not match
+    // the new host's layout.
+    const { result } = renderHook(() => useTerminal('s1'));
+    act(() => result.current.attach(makeHost()));
+    expect(getTerminalDimensions('s1')).toEqual({ cols: 80, rows: 24 });
+    act(() => result.current.detach());
+    expect(getTerminalDimensions('s1')).toBeNull();
   });
 
   it('measureInitialPtyDimensions reuses an attached terminal when present', () => {
@@ -410,5 +439,35 @@ describe('initial PTY dimension helpers', () => {
     expect(rect.width).toBe(0);
     expect(rect.height).toBe(0);
     expect(measureInitialPtyDimensions()).toEqual(FALLBACK_PTY_DIMS);
+  });
+});
+
+describe('captureTerminalDebugSnapshot', () => {
+  it('returns ancestors oldest-first (root → host parent), matching the documented order', () => {
+    // Build a small DOM tree:  body > article > section > main > host
+    // Snapshot's `ancestors` must come back as
+    // [body, article, section, main] (oldest → youngest).
+    const article = document.createElement('article');
+    const section = document.createElement('section');
+    const main = document.createElement('main');
+    const host = document.createElement('div');
+    section.appendChild(main);
+    article.appendChild(section);
+    document.body.appendChild(article);
+    main.appendChild(host);
+
+    const { result } = renderHook(() => useTerminal('s1'));
+    act(() => result.current.attach(host));
+
+    const snapshot = captureTerminalDebugSnapshot();
+    const entry = snapshot.entries.find((e) => e.sessionId === 's1');
+    expect(entry).toBeDefined();
+    const tags = entry!.ancestors.map((a) => a.tag);
+    // describeAncestors walks `host.parentElement` upward (host = the div
+    // attached above), so closest-first that's [main, section, article,
+    // body, html]. Reversed for oldest-first → [html, body, ...main].
+    expect(tags[0]).toBe('html');
+    expect(tags[tags.length - 1]).toBe('main');
+    expect(tags).toEqual(['html', 'body', 'article', 'section', 'main']);
   });
 });

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -357,6 +357,13 @@ export interface UseTerminalApi {
    * attached or has zero dimensions.
    */
   refit: () => void;
+  /**
+   * Current xterm `cols`/`rows` for this session, or `null` if the
+   * terminal has no entry yet (created lazily on first `attach`/render).
+   * Used by callers that need to drive a backend respawn at the right
+   * size (e.g. `session_restart` after a crash).
+   */
+  getDimensions: () => InitialPtyDims | null;
 }
 
 export function useTerminal(sessionId: SessionId): UseTerminalApi {
@@ -389,13 +396,146 @@ export function useTerminal(sessionId: SessionId): UseTerminalApi {
     refitEntry(id, entry);
   }, []);
 
+  const getDimensions = useCallback(() => getTerminalDimensions(sessionIdRef.current), []);
+
   // Eagerly create the terminal so `session://output` events are buffered
   // by xterm even before `attach` runs.
   useEffect(() => {
     getOrCreate(sessionId);
   }, [sessionId]);
 
-  return useMemo(() => ({ attach, detach, focus, refit }), [attach, detach, focus, refit]);
+  return useMemo(
+    () => ({ attach, detach, focus, refit, getDimensions }),
+    [attach, detach, focus, refit, getDimensions],
+  );
+}
+
+/**
+ * Initial PTY dimensions handed to `session_create` / `session_restart`
+ * before the frontend has a chance to mount + fit the xterm Terminal.
+ *
+ * The pre-fix bug: the backend always opened the PTY at
+ * `DEFAULT_PTY_SIZE` (80×24), so the CLI's first paint (the splash, the
+ * first prompt) was rendered at 80 cols regardless of how wide the
+ * actual host turned out to be. The eventual `session_resize` from
+ * `fitAddon.fit()` came after the splash had already been drawn into
+ * scrollback at 80-col layout. Frontend code now passes the real
+ * intended dims at create/restart time so the child's first byte sees
+ * the right width.
+ *
+ * This file is the right home because the per-session xterm registry
+ * (where existing terminals can be sampled for accurate dims) is
+ * module-private here.
+ */
+export interface InitialPtyDims {
+  cols: number;
+  rows: number;
+}
+
+/**
+ * Conservative starting point used when no live terminal exists to
+ * sample (very-first-session boot) and the DOM probe also fails. Wider
+ * than the historical 80-col default so the splash isn't artificially
+ * narrow on the rare bad-measure path; the post-mount `fitAddon.fit()`
+ * will issue a `session_resize` to the true host width within a frame
+ * either way.
+ */
+export const FALLBACK_PTY_DIMS: Readonly<InitialPtyDims> = Object.freeze({
+  cols: 132,
+  rows: 40,
+});
+
+const PROBE_SAMPLE_TEXT = 'M'.repeat(80);
+
+/** Inner padding (px on each side) of `TerminalView`'s host wrapper. */
+const TERMINAL_HOST_INNER_PADDING_PX = 8;
+
+/**
+ * Read the current cols/rows of an existing terminal entry. Returns
+ * `null` if the session has no entry yet, or if its terminal hasn't been
+ * sized (cols/rows non-positive). Used by `session_restart` callers so
+ * the respawn lands at the size xterm currently shows, not at
+ * `DEFAULT_PTY_SIZE`.
+ */
+export function getTerminalDimensions(sessionId: SessionId): InitialPtyDims | null {
+  const entry = registry.get(sessionId);
+  if (!entry) return null;
+  const cols = entry.term.cols;
+  const rows = entry.term.rows;
+  if (cols <= 0 || rows <= 0) return null;
+  return { cols, rows };
+}
+
+/**
+ * Estimate the cols/rows a brand-new session's PTY should be opened at
+ * so the CLI's first paint matches the eventual `fitAddon.fit()` size.
+ *
+ * Strategy, in order:
+ *   1. Reuse any already-attached terminal's `cols`/`rows`. All sessions
+ *      share the same `<main>` host, so cell metrics (and therefore
+ *      cols/rows) are identical.
+ *   2. Fall back to a one-off DOM probe: measure a hidden monospace
+ *      `<span>` for cell-width × cell-height and divide the `<main>`
+ *      element's rect (minus `TerminalView`'s 8-px padding) by it.
+ *   3. If the DOM isn't available (jsdom without a `<main>`, or any
+ *      probe failure), return [`FALLBACK_PTY_DIMS`].
+ */
+export function measureInitialPtyDimensions(): InitialPtyDims {
+  for (const entry of registry.values()) {
+    // Require an *attached and connected* host: a stale registry entry
+    // whose host has been detached (e.g. a session whose
+    // `TerminalView` has unmounted but the dispose subscription
+    // hasn't fired yet) would happily pass the truthy-`host` check
+    // and could hand back stale cols/rows from the previous parent's
+    // size. The cell metrics still match — every host shares the
+    // same `<main>` font — but cols/rows reflect the OLD host, which
+    // can be wrong if the layout has changed since.
+    const host = entry.host;
+    if (host !== null && host.isConnected && entry.term.cols > 0 && entry.term.rows > 0) {
+      return { cols: entry.term.cols, rows: entry.term.rows };
+    }
+  }
+
+  if (typeof document === 'undefined') {
+    return { ...FALLBACK_PTY_DIMS };
+  }
+
+  const main = document.querySelector('main');
+  if (!main) return { ...FALLBACK_PTY_DIMS };
+
+  const rect = main.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) {
+    // `<main>` is in the tree but laid out at 0×0 (e.g. an ancestor is
+    // `display: none` mid-transition). Clamping `0/cellW` to a 20-col
+    // floor would silently produce a tiny PTY — the very thing the
+    // splash-too-narrow regression test guards against. Bail to the
+    // fallback so the post-mount `fitAddon.fit()` corrects it.
+    return { ...FALLBACK_PTY_DIMS };
+  }
+
+  let cellWidth = 0;
+  let cellHeight = 0;
+  try {
+    const probe = document.createElement('span');
+    probe.textContent = PROBE_SAMPLE_TEXT;
+    probe.style.cssText =
+      'position:absolute;left:-9999px;top:-9999px;visibility:hidden;' +
+      'white-space:pre;font-family:monospace;font-size:15px;line-height:normal;';
+    document.body.appendChild(probe);
+    cellWidth = probe.offsetWidth / PROBE_SAMPLE_TEXT.length;
+    cellHeight = probe.offsetHeight;
+    document.body.removeChild(probe);
+  } catch {
+    // jsdom or hostile environment — fall through to defaults.
+  }
+
+  if (cellWidth <= 0 || cellHeight <= 0) return { ...FALLBACK_PTY_DIMS };
+
+  const usableW = Math.max(rect.width - TERMINAL_HOST_INNER_PADDING_PX * 2, 0);
+  const usableH = Math.max(rect.height - TERMINAL_HOST_INNER_PADDING_PX * 2, 0);
+  const cols = Math.max(20, Math.floor(usableW / cellWidth));
+  const rows = Math.max(5, Math.floor(usableH / cellHeight));
+  return { cols, rows };
 }
 
 export function disposeTerminal(sessionId: SessionId): void {

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -180,15 +180,61 @@ function teardownObserver(entry: RegistryEntry): void {
 }
 
 /**
+ * Shape of the bits of xterm's `_core` we poke at via private API to fix
+ * fit-time DOM-sizing quirks (see `refitEntry`). Any missing piece is
+ * silently skipped — every call site uses optional chaining.
+ */
+interface XtermCorePeek {
+  _core?: {
+    _renderService?: {
+      clear?: () => void;
+      handleCharSizeChanged?: () => void;
+    };
+  };
+}
+
+/**
  * Re-measure + repaint a single terminal. Safe to call on an unattached or
  * zero-size terminal (no-ops). Only emits `sessionResize` when cols/rows
- * have actually changed since the last successful fit. Always calls
- * `term.refresh()` when the renderer has a non-zero viewport — this is the
- * recovery path for stale canvas state after a visibility transition or a
- * pre-font-load initial measurement.
+ * have actually changed since the last successful fit.
+ *
+ * Why this is more than just `fitAddon.fit()` plus `refresh()`:
+ *
+ * The renderer writes the `.xterm-screen` and row elements' size as
+ * **inline styles** in pixels (DomRenderer._updateDimensions: width =
+ * `cols × cell.width`, height = `rows × cell.height`). Those inline sizes
+ * are only refreshed by four code paths inside xterm: `term.resize()`,
+ * the `onCharSizeChange` event, the `onDevicePixelRatioChange` handler,
+ * and an option change. When the renderer's inline sizes drift out of
+ * sync with the host's actual CSS box (the easy way: any sequence where
+ * the host's box is sized AFTER the renderer first wrote inline pixels —
+ * visibility transition, late layout pass, parent flex resolving after
+ * mount) the terminal looks "squished" or "doesn't fit" until something
+ * triggers one of those four paths.
+ *
+ * `FitAddon.fit()` only triggers `term.resize()` when proposed cols/rows
+ * differ from current. Window resizes naturally take that branch (the
+ * host's CSS width genuinely changes); tab activation, fonts.ready, and
+ * the manual force-refit hit the no-op branch and leave stale inline
+ * sizes intact. We mirror what fit() *would* have done by:
+ *
+ *   1. Calling `_renderService.handleCharSizeChanged()` after fit() —
+ *      forces `_updateDimensions` to re-apply `cols × cell.width` and
+ *      `rows × cell.height` to every row + `.xterm-screen` element.
+ *      Cheap when nothing actually changed; effective when the inline
+ *      sizes were stale.
+ *   2. Calling `_renderService.clear()` so the renderer drops any cached
+ *      paint state from the previous (stale) layout — same call FitAddon
+ *      itself uses internally on the resize branch.
+ *
+ * Both pokes use private xterm APIs that `FitAddon` itself uses
+ * internally. They are guarded with optional chaining so a future xterm
+ * major that renames or removes them simply degrades to today's
+ * stale-state behavior rather than crashing.
  */
 function refitEntry(sessionId: SessionId, entry: RegistryEntry): void {
   if (!entry.wrapper || !entry.wrapper.isConnected) return;
+
   try {
     entry.fitAddon.fit();
   } catch {
@@ -212,11 +258,29 @@ function refitEntry(sessionId: SessionId, entry: RegistryEntry): void {
   const rows = entry.term.rows;
   if (cols <= 0 || rows <= 0) return;
 
-  // Force the renderer to repaint the visible viewport. xterm's canvas
-  // renderer can hold stale state when the element transitioned from
-  // visibility:hidden → visible, or when fit() computed the same dims as
-  // last time and skipped the implicit refresh. `refresh()` is bounded
-  // (viewport only, not scrollback) so this is cheap.
+  const renderService = (entry.term as unknown as XtermCorePeek)._core?._renderService;
+
+  // (1) Force re-application of the renderer's inline sizes
+  // (.xterm-screen + row elements) from current cols × cell.width. See
+  // the doc comment above for why this is the missing piece that makes a
+  // programmatic refit behave like a window resize.
+  try {
+    renderService?.handleCharSizeChanged?.();
+  } catch {
+    // Ignore — best-effort.
+  }
+
+  // (2) Drop any cached paint state so the next render frame starts
+  // fresh. Same call FitAddon uses on its resize branch.
+  try {
+    renderService?.clear?.();
+  } catch {
+    // Ignore — best-effort.
+  }
+
+  // Belt-and-suspenders: refresh the visible viewport so any renderer
+  // that ignored clear() (or that batches dirty rows) still repaints.
+  // Bounded to viewport (not scrollback) so this is cheap.
   try {
     entry.term.refresh(0, rows - 1);
   } catch {

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -451,17 +451,23 @@ const PROBE_SAMPLE_TEXT = 'M'.repeat(80);
 const TERMINAL_HOST_INNER_PADDING_PX = 8;
 
 /**
- * Read the current cols/rows of an existing terminal entry. Returns
- * `null` if the session has no entry yet, or if its terminal hasn't been
- * sized (cols/rows non-positive). Used by `session_restart` callers so
- * the respawn lands at the size xterm currently shows, not at
- * `DEFAULT_PTY_SIZE`.
+ * Read the *measured* cols/rows of an existing terminal entry. Returns
+ * `null` unless the entry is attached to a connected host AND has been
+ * successfully fit at least once.
+ *
+ * Why the strict gate: a fresh `Terminal` defaults to 80×24 even before
+ * `open()`/`fit()`, so a naive `term.cols/term.rows` read can leak the
+ * old hardcoded default into `session_restart`. We use `entry.lastCols`
+ * /`lastRows` as the proven-fit signal — those are written only by a
+ * successful `refitEntry()` (which itself requires a connected wrapper
+ * and a non-throwing `fit()`).
  */
 export function getTerminalDimensions(sessionId: SessionId): InitialPtyDims | null {
   const entry = registry.get(sessionId);
   if (!entry) return null;
-  const cols = entry.term.cols;
-  const rows = entry.term.rows;
+  if (!entry.wrapper?.isConnected) return null;
+  const cols = entry.lastCols;
+  const rows = entry.lastRows;
   if (cols <= 0 || rows <= 0) return null;
   return { cols, rows };
 }
@@ -693,13 +699,17 @@ function safeComputed(el: Element | null): CSSStyleDeclaration | null {
 }
 
 function describeAncestors(host: HTMLElement | null, max = 6): TerminalDebugAncestor[] {
-  const out: TerminalDebugAncestor[] = [];
+  // Walk parent chain bottom-up (closest-first, capped at `max`), then
+  // reverse so the returned array is oldest-first (root → host's parent)
+  // as documented on `TerminalDebugEntry.ancestors`. Reading the snapshot
+  // top-down matches how DevTools shows the DOM tree.
+  const collected: TerminalDebugAncestor[] = [];
   let cur: HTMLElement | null = host?.parentElement ?? null;
   let depth = 0;
   while (cur && depth < max) {
     const cs = safeComputed(cur);
     const r = safeRect(cur);
-    out.push({
+    collected.push({
       tag: cur.tagName.toLowerCase(),
       classes: cur.className || '',
       display: cs?.display ?? '',
@@ -711,7 +721,7 @@ function describeAncestors(host: HTMLElement | null, max = 6): TerminalDebugAnce
     cur = cur.parentElement;
     depth += 1;
   }
-  return out;
+  return collected.reverse();
 }
 
 function describeEntry(sessionId: SessionId, entry: RegistryEntry): TerminalDebugEntry {

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -391,3 +391,182 @@ export function __resetTerminalRegistryForTests(): void {
 export function __getTerminalRegistryForTests(): ReadonlyMap<SessionId, RegistryEntry> {
   return registry;
 }
+
+// --------------------------------------------------------------------------
+// Debug helpers (Sidebar "Fit" button)
+// --------------------------------------------------------------------------
+//
+// `forceRefitAllTerminals` is the imperative escape hatch users can hit when
+// the renderer looks wrong. It runs the same `refitEntry` path that the
+// debounced ResizeObserver and the activation rAF would, on every entry —
+// not just the active one — so a hidden tab also gets corrected before the
+// user switches to it.
+//
+// `captureTerminalDebugSnapshot` produces a JSON-serializable snapshot of
+// each registry entry plus environment context (DPR, fonts state,
+// visibility, window size). The Sidebar button captures one snapshot
+// BEFORE forcing a refit and another AFTER, so a paste-back into a fresh
+// debug session shows both the suspected-bad state and what the manual
+// refit changed.
+
+export function forceRefitAllTerminals(): void {
+  for (const [id, entry] of registry) {
+    refitEntry(id, entry);
+  }
+}
+
+export interface TerminalDebugRect {
+  width: number;
+  height: number;
+  top: number;
+  left: number;
+}
+
+export interface TerminalDebugAncestor {
+  tag: string;
+  classes: string;
+  display: string;
+  visibility: string;
+  position: string;
+  width: number;
+  height: number;
+}
+
+export interface TerminalDebugEntry {
+  sessionId: SessionId;
+  isAttached: boolean;
+  hostConnected: boolean;
+  wrapperConnected: boolean;
+  termCols: number;
+  termRows: number;
+  lastReportedCols: number;
+  lastReportedRows: number;
+  fontFamily: string | undefined;
+  fontSize: number | undefined;
+  hostRect: TerminalDebugRect | null;
+  wrapperRect: TerminalDebugRect | null;
+  screenRect: TerminalDebugRect | null;
+  /** Approximate cell dims derived from `.xterm-screen` rect / cols/rows. */
+  approxCellWidth: number | null;
+  approxCellHeight: number | null;
+  /** Computed style of the host element. */
+  hostDisplay: string | null;
+  hostVisibility: string | null;
+  /** A few ancestors, oldest-first (root → host's parent). */
+  ancestors: TerminalDebugAncestor[];
+}
+
+export interface TerminalDebugSnapshot {
+  capturedAt: string;
+  windowInnerWidth: number | null;
+  windowInnerHeight: number | null;
+  devicePixelRatio: number | null;
+  documentVisibility: string | null;
+  documentHasFocus: boolean | null;
+  fontsStatus: string | null;
+  darkMode: boolean | null;
+  registrySize: number;
+  entries: TerminalDebugEntry[];
+}
+
+function safeRect(el: Element | null): TerminalDebugRect | null {
+  if (!el) return null;
+  try {
+    const r = el.getBoundingClientRect();
+    return { width: r.width, height: r.height, top: r.top, left: r.left };
+  } catch {
+    return null;
+  }
+}
+
+function safeComputed(el: Element | null): CSSStyleDeclaration | null {
+  if (!el || typeof window === 'undefined') return null;
+  try {
+    return window.getComputedStyle(el);
+  } catch {
+    return null;
+  }
+}
+
+function describeAncestors(host: HTMLElement | null, max = 6): TerminalDebugAncestor[] {
+  const out: TerminalDebugAncestor[] = [];
+  let cur: HTMLElement | null = host?.parentElement ?? null;
+  let depth = 0;
+  while (cur && depth < max) {
+    const cs = safeComputed(cur);
+    const r = safeRect(cur);
+    out.push({
+      tag: cur.tagName.toLowerCase(),
+      classes: cur.className || '',
+      display: cs?.display ?? '',
+      visibility: cs?.visibility ?? '',
+      position: cs?.position ?? '',
+      width: r?.width ?? 0,
+      height: r?.height ?? 0,
+    });
+    cur = cur.parentElement;
+    depth += 1;
+  }
+  return out;
+}
+
+function describeEntry(sessionId: SessionId, entry: RegistryEntry): TerminalDebugEntry {
+  const host = entry.host;
+  const wrapper = entry.wrapper;
+  const screen = wrapper?.querySelector<HTMLElement>('.xterm-screen') ?? null;
+  const screenRect = safeRect(screen);
+  const cols = entry.term.cols;
+  const rows = entry.term.rows;
+  const hostCs = safeComputed(host);
+
+  // Best-effort font info — xterm's options are typed loosely; coerce.
+  let fontFamily: string | undefined;
+  let fontSize: number | undefined;
+  try {
+    const opts = entry.term.options as { fontFamily?: string; fontSize?: number } | undefined;
+    fontFamily = opts?.fontFamily;
+    fontSize = opts?.fontSize;
+  } catch {
+    // ignore
+  }
+
+  return {
+    sessionId,
+    isAttached: !!host,
+    hostConnected: host?.isConnected ?? false,
+    wrapperConnected: wrapper?.isConnected ?? false,
+    termCols: cols,
+    termRows: rows,
+    lastReportedCols: entry.lastCols,
+    lastReportedRows: entry.lastRows,
+    fontFamily,
+    fontSize,
+    hostRect: safeRect(host),
+    wrapperRect: safeRect(wrapper),
+    screenRect,
+    approxCellWidth: screenRect && cols > 0 ? screenRect.width / cols : null,
+    approxCellHeight: screenRect && rows > 0 ? screenRect.height / rows : null,
+    hostDisplay: hostCs?.display ?? null,
+    hostVisibility: hostCs?.visibility ?? null,
+    ancestors: describeAncestors(host),
+  };
+}
+
+export function captureTerminalDebugSnapshot(): TerminalDebugSnapshot {
+  const hasWindow = typeof window !== 'undefined';
+  const hasDoc = typeof document !== 'undefined';
+  const fonts = hasDoc ? (document as Document & { fonts?: { status?: string } }).fonts : undefined;
+  return {
+    capturedAt: new Date().toISOString(),
+    windowInnerWidth: hasWindow ? window.innerWidth : null,
+    windowInnerHeight: hasWindow ? window.innerHeight : null,
+    devicePixelRatio: hasWindow ? window.devicePixelRatio : null,
+    documentVisibility: hasDoc ? document.visibilityState : null,
+    documentHasFocus:
+      hasDoc && typeof document.hasFocus === 'function' ? document.hasFocus() : null,
+    fontsStatus: fonts?.status ?? null,
+    darkMode: hasDoc ? document.documentElement.classList.contains('dark') : null,
+    registrySize: registry.size,
+    entries: Array.from(registry, ([id, entry]) => describeEntry(id, entry)),
+  };
+}

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -477,9 +477,11 @@ export function getTerminalDimensions(sessionId: SessionId): InitialPtyDims | nu
  * so the CLI's first paint matches the eventual `fitAddon.fit()` size.
  *
  * Strategy, in order:
- *   1. Reuse any already-attached terminal's `cols`/`rows`. All sessions
- *      share the same `<main>` host, so cell metrics (and therefore
- *      cols/rows) are identical.
+ *   1. Reuse any *proven-fit* terminal's measured cols/rows (delegates
+ *      to [`getTerminalDimensions`], which gates on a successful fit
+ *      so the xterm 80×24 default never leaks out). All sessions share
+ *      the same `<main>` host, so cell metrics (and therefore cols/rows)
+ *      are identical between proven-fit entries.
  *   2. Fall back to a one-off DOM probe: measure a hidden monospace
  *      `<span>` for cell-width × cell-height and divide the `<main>`
  *      element's rect (minus `TerminalView`'s 8-px padding) by it.
@@ -487,19 +489,18 @@ export function getTerminalDimensions(sessionId: SessionId): InitialPtyDims | nu
  *      probe failure), return [`FALLBACK_PTY_DIMS`].
  */
 export function measureInitialPtyDimensions(): InitialPtyDims {
-  for (const entry of registry.values()) {
-    // Require an *attached and connected* host: a stale registry entry
-    // whose host has been detached (e.g. a session whose
-    // `TerminalView` has unmounted but the dispose subscription
-    // hasn't fired yet) would happily pass the truthy-`host` check
-    // and could hand back stale cols/rows from the previous parent's
-    // size. The cell metrics still match — every host shares the
-    // same `<main>` font — but cols/rows reflect the OLD host, which
-    // can be wrong if the layout has changed since.
-    const host = entry.host;
-    if (host !== null && host.isConnected && entry.term.cols > 0 && entry.term.rows > 0) {
-      return { cols: entry.term.cols, rows: entry.term.rows };
-    }
+  // Reuse fast-path: any *proven-fit* terminal entry. We delegate to
+  // `getTerminalDimensions`, which gates on `wrapper.isConnected` AND
+  // `entry.lastCols/lastRows > 0`. A plain `entry.term.cols/rows`
+  // check here would silently hand back the xterm 80×24 default for
+  // an entry whose host is connected but currently zero-size (so its
+  // first `fitAddon.fit()` threw and `lastCols/lastRows` stayed 0) —
+  // exactly the splash-too-narrow regression we're guarding against.
+  // Cell metrics are identical across entries (all share the same
+  // `<main>` font), so any proven-fit entry is as good as another.
+  for (const id of registry.keys()) {
+    const dims = getTerminalDimensions(id);
+    if (dims !== null) return dims;
   }
 
   if (typeof document === 'undefined') {

--- a/src/lib/tauri-bridge.test.ts
+++ b/src/lib/tauri-bridge.test.ts
@@ -68,6 +68,8 @@ describe('sessionCreate', () => {
       tool: 'claude' as const,
       worktreePath: '/repo/feat',
       instructionSetId: 'claude-default',
+      cols: 100,
+      rows: 30,
     };
 
     const result = await bridge.sessionCreate(args);
@@ -90,12 +92,18 @@ describe('session id-only commands', () => {
   it.each([
     ['sessionClose', 'session_close'],
     ['sessionFocus', 'session_focus'],
-    ['sessionRestart', 'session_restart'],
   ] as const)('%s wraps args under `args`', async (fn, command) => {
     invokeMock.mockResolvedValueOnce(undefined);
     const args = { sessionId: 'sid-1' };
     await (bridge[fn] as (a: { sessionId: string }) => Promise<void>)(args);
     expect(invokeMock).toHaveBeenCalledWith(command, { args });
+  });
+
+  it('sessionRestart wraps {sessionId, cols, rows} under `args`', async () => {
+    invokeMock.mockResolvedValueOnce(undefined);
+    const args = { sessionId: 'sid-1', cols: 120, rows: 40 };
+    await bridge.sessionRestart(args);
+    expect(invokeMock).toHaveBeenCalledWith('session_restart', { args });
   });
 });
 

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -50,10 +50,33 @@ export interface SessionCreateArgs {
   tool: Tool;
   worktreePath: string;
   instructionSetId?: InstructionSetId;
+  /**
+   * Initial PTY dimensions in character cells. Required so the CLI's first
+   * paint (e.g. a Claude/Copilot splash) is rendered at the actual host
+   * width — see DESIGN §5.1 step 4 and the regression in
+   * `tests/session_lifecycle_fake.rs::create_passes_initial_size_to_spawner`.
+   *
+   * MIRROR: `src-tauri/src/types.rs::SessionCreateArgs`.
+   */
+  cols: number;
+  rows: number;
 }
 
 export interface SessionIdArg {
   sessionId: SessionId;
+}
+
+/**
+ * Arguments for `session_restart`. Mirrors `session_create` in passing the
+ * caller-measured initial PTY dimensions so the respawned child paints at
+ * the real host size from the first byte (DESIGN §5.4).
+ *
+ * MIRROR: `src-tauri/src/types.rs::SessionRestartArgs`.
+ */
+export interface SessionRestartArgs {
+  sessionId: SessionId;
+  cols: number;
+  rows: number;
 }
 
 /**
@@ -160,9 +183,10 @@ export function sessionInput(args: SessionInputArgs): Promise<void> {
 
 /**
  * Re-spawn `sessionId` from its persisted `composedCommand`. The command
- * is reused verbatim — never recomposed (DESIGN §5.4).
+ * is reused verbatim — never recomposed (DESIGN §5.4). The caller passes
+ * the current xterm dims so the new PTY is opened at the right size.
  */
-export function sessionRestart(args: SessionIdArg): Promise<void> {
+export function sessionRestart(args: SessionRestartArgs): Promise<void> {
   return invoke<void>('session_restart', { args });
 }
 

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -51,10 +51,11 @@ export interface SessionCreateArgs {
   worktreePath: string;
   instructionSetId?: InstructionSetId;
   /**
-   * Initial PTY dimensions in character cells. Required so the CLI's first
-   * paint (e.g. a Claude/Copilot splash) is rendered at the actual host
-   * width — see DESIGN §5.1 step 4 and the regression in
-   * `tests/session_lifecycle_fake.rs::create_passes_initial_size_to_spawner`.
+   * Initial PTY dimensions in character cells. Required: the backend
+   * opens the child PTY at exactly this size so the CLI's first paint
+   * (e.g. a Claude/Copilot splash) renders at the host's actual width
+   * instead of the OS-default 80 cols. Frontend callers should derive
+   * these from `measureInitialPtyDimensions()` (see DESIGN §5.5b).
    *
    * MIRROR: `src-tauri/src/types.rs::SessionCreateArgs`.
    */

--- a/src/store/session-store.test.ts
+++ b/src/store/session-store.test.ts
@@ -82,15 +82,21 @@ describe('create', () => {
       activeId: 'old',
     });
 
-    const view = await useSessionStore
-      .getState()
-      .actions.create({ tool: 'claude', worktreePath: '/repo/new', instructionSetId: 'd' });
+    const view = await useSessionStore.getState().actions.create({
+      tool: 'claude',
+      worktreePath: '/repo/new',
+      instructionSetId: 'd',
+      cols: 80,
+      rows: 24,
+    });
 
     expect(view).toEqual(created);
     expect(bridgeMock.sessionCreate).toHaveBeenCalledWith({
       tool: 'claude',
       worktreePath: '/repo/new',
       instructionSetId: 'd',
+      cols: 80,
+      rows: 24,
     });
     expect(useSessionStore.getState().sessions.map((s) => s.id)).toEqual(['old', 'new']);
     expect(useSessionStore.getState().activeId).toBe('new');


### PR DESCRIPTION
Fixes the intermittent `the console doesn't fit on first load / after switching sessions / after window focus` bug. Also bundles the debug snapshot button (kept) and the renderer-poke defensive fix from the earlier exploration (also kept; addresses a secondary class of bug).

## Root cause

The PTY child was always opened at the hardcoded `DEFAULT_PTY_SIZE = 80x24` in `portable_pty::openpty`, regardless of how wide the host actually was. The CLI (Copilot/Claude) renders its splash + first prompt at 80 cols and that output sits in xterm's scrollback at 80-col layout forever. The post-mount `fitAddon.fit()` correctly resizes the PTY to the real width (114, etc.) — but only the **subsequent** output reflows; the splash is permanently broken (Copilot logo misaligned, prompt input drifting).

This explains every reported symptom:

- `first load`: the brand-new PTY's first emission is the splash at 80
- `switching sessions / focus return`: cosmetic re-paint exposes the same already-corrupted scrollback
- `Resize 100% resolves the issue every time`: a real OS resize triggers `term.resize()` -> SIGWINCH to the child, which re-renders its prompt from scratch at the new width

## Fix

1. **`PtySize` is explicit on every spawn path.** `PtySpawner::spawn` and `PtyPool::{spawn,respawn_existing}` no longer default; `DEFAULT_PTY_SIZE` is a tests-only constant.

2. **Frontend measures and passes its actual dims** for `session_create` and the new `session_restart` (which now takes `cols`/`rows` via `SessionRestartArgs` instead of the shared `SessionIdArg`). New `measureInitialPtyDimensions()` helper:
   - Prefers reusing an attached & connected terminal entry's cols/rows (same `<main>` host -> identical cell metrics).
   - Falls back to a one-off DOM probe (hidden monospace span x `<main>` rect minus 8-px padding).
   - Falls back to `FALLBACK_PTY_DIMS = 132x40` for the very-first-session path or any zero-rect `<main>`.

3. **Restore-on-launch defers the spawn** until the frontend's first `session_resize`. `restore_all_sessions` registers each restored `Session` (already AI-resume-augmented if applicable) in a `pending_spawn: HashMap<SessionId, Session>`. `session_resize_impl` atomically `remove()`s the entry and spawns at the resize's `PtySize`. Avoids the `spawn-if-missing` TOCTOU pattern flagged in design review.

4. **`frontend_ready` awaits restore** so the frontend's first synchronous `session_resize` (issued by `attachToHost` -> `refitEntry` once `setStatus('ready')` triggers MainArea to mount) is guaranteed to find the pending entry.

## Tests

**Backend (`cargo test --workspace`: 293 tests, all green):**

- `create_passes_initial_size_to_spawner` — asserts `FakeSpawner::last_size == args.{cols,rows}`
- `restart_passes_dims_to_respawn` — same for restart
- `restore_defers_spawn_until_first_session_resize` — asserts `restore_all_sessions` does NOT touch the spawner; `session_resize` does, at the resize's size; composed command unchanged

**Frontend (`npm test --run`: 263 tests, all green):**

- `getTerminalDimensions returns null for unknown sessions`
- `measureInitialPtyDimensions reuses an attached terminal`
- `measureInitialPtyDimensions ignores stale registry entries whose host is not connected`
- `measureInitialPtyDimensions falls back to defaults when no <main> exists`
- `measureInitialPtyDimensions falls back to defaults when <main> is laid out at 0x0`
- Updated `sessionRestart` arg-shape test with explicit cols/rows
- Updated `NewSessionDialog` create assertions to allow new dim args

## Docs

- DESIGN.md S6 command table updated for the new `cols`/`rows` args on `session_create` and `session_restart`.
- New S5.5b `Deferred-spawn-on-first-resize` section documents the rationale, the `pending_spawn` claim map, and the boot-ordering happens-before edge.

## Acceptance gate (all green locally)

- `npm run lint`
- `npm test -- --run`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Also kept in this PR (from the earlier exploration commits)

- **Sidebar Fit debug button** (`forceRefitAllTerminals` + `captureTerminalDebugSnapshot`) — escape hatch + paste-to-debug-session UX. Useful even after this fix lands for any future layout-corruption reports.
- **xterm renderer pokes in `refitEntry`** (`_renderService.handleCharSizeChanged()` + `clear()`) — addresses a *secondary* class of bug (renderer inline-pixel sizes drifting out of sync with the host CSS box during visibility/font transitions). Defensive, guarded with optional chaining; does not address the primary spawn-size bug but is harmless to keep.