### PR TITLE
ci(release): attest installer artifacts with Sigstore build provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,11 @@ jobs:
     needs: verify
     permissions:
       contents: write
+      # Required by actions/attest-build-provenance to mint a short-lived
+      # OIDC token and to write the resulting Sigstore-signed attestation
+      # back to the repository's attestations store.
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -127,6 +132,7 @@ jobs:
       - run: npm ci
 
       - uses: tauri-apps/tauri-action@v0
+        id: tauri
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -135,9 +141,40 @@ jobs:
           releaseBody: |
             See the assets below to download installers for your platform.
 
-            **Note:** these builds are unsigned. See the
+            **Note:** these builds are not OS code-signed (no Apple
+            notarization or Authenticode signature), so each OS will show a
+            one-time warning on first launch. See the
             [README](https://github.com/${{ github.repository }}#install) for
             first-run instructions on macOS, Windows, and Linux.
+
+            Every published asset has a Sigstore-signed
+            [GitHub build attestation](https://github.com/${{ github.repository }}/attestations).
+            Verify a downloaded file with the GitHub CLI:
+
+            ```sh
+            gh attestation verify <file> --repo ${{ github.repository }}
+            ```
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.platform.args }}
+
+      # Generate a Sigstore-signed SLSA build provenance attestation for
+      # every artifact tauri-action produced. Each matrix job attests only
+      # the artifacts it built; together the three jobs cover every
+      # platform's installers (msi/exe/dmg/deb/AppImage). The attestation is
+      # uploaded to GitHub's attestations API and can be verified by users
+      # with `gh attestation verify <file> --repo ${{ github.repository }}`.
+      #
+      # tauri-action's `artifactPaths` output is a JSON array of file paths;
+      # we expand it into the comma-separated form `subject-path` accepts
+      # (see actions/attest-build-provenance@v2 README — comma and newline
+      # delimited lists are both supported and each entry is trimmed). Tauri
+      # bundle filenames never contain commas, so this is unambiguous.
+      #
+      # No explicit `if:` guard is needed: tauri-action throws when no
+      # artifacts are produced (because we set `tagName`), which fails the
+      # job and causes this step to be skipped automatically.
+      - name: Attest build provenance for release artifacts
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ join(fromJSON(steps.tauri.outputs.artifactPaths), ',') }}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,17 @@ It gives each worktree its own persistent terminal session — Claude CLI or Git
 Pre-built installers for Windows, macOS, and Linux are published on the
 [Releases page](https://github.com/mcaden/arborist/releases). Download the
 asset for your platform and follow the first-run notes below — the binaries
-are **unsigned**, so each OS will show a one-time warning.
+are not OS code-signed (no Apple notarization or Authenticode signature),
+so each OS will show a one-time warning on first launch.
+
+Every published asset has a Sigstore-signed
+[GitHub build attestation](https://github.com/mcaden/arborist/attestations)
+linking it to the exact source commit and release workflow run that produced
+it. To verify a downloaded file before installing:
+
+```sh
+gh attestation verify <downloaded-file> --repo mcaden/arborist
+```
 
 - **Windows** (`Arborist_<version>_x64-setup.exe` or `Arborist_<version>_x64_en-US.msi`)
   — double-click to install. Windows SmartScreen will say "Windows protected


### PR DESCRIPTION
## Summary

Adds Sigstore-signed [SLSA build provenance](https://slsa.dev/spec/v1.0/provenance) attestations for every installer the release workflow publishes (msi, setup.exe, dmg, deb, AppImage). End users can verify that a downloaded file was built from a specific source commit by this exact workflow run with:

```sh
gh attestation verify <downloaded-file> --repo mcaden/arborist
```

## What changed

- **`.github/workflows/release.yml`**
  - Granted the `build` job `id-token: write` + `attestations: write` (required by `actions/attest-build-provenance@v2`).
  - Added `id: tauri` to the `tauri-apps/tauri-action@v0` step so its `artifactPaths` output is addressable.
  - Added an `actions/attest-build-provenance@v2` step that expands `tauri-action`'s JSON-array output into the comma-delimited `subject-path` the attest action accepts, generating an attestation per platform.
  - Updated the release body to point users at the verification command.

- **`README.md`** — clarified that "unsigned" meant "no Apple notarization or Authenticode signature" (the binaries are now Sigstore-signed) and added the same `gh attestation verify` snippet.

## How it works

- `tauri-action` outputs `artifactPaths` as `JSON.stringify` of the produced artifact paths (verified in [tauri-apps/tauri-action src/index.ts](https://github.com/tauri-apps/tauri-action/blob/dev/src/index.ts)).
- `actions/attest-build-provenance@v2` (a wrapper over `actions/attest@v4.1.0`) accepts `subject-path` as a comma- or newline-delimited list with per-entry trimming (verified in the action README).
- Each matrix job attests only its own artifacts; together the three jobs cover every platform.
- No `if:` guard is needed — when `tagName` is set, `tauri-action` throws on empty artifacts, which fails the job and skips the attest step.

## Notes

- macOS `.app` directories are filtered out / repackaged as `.app.tar.gz` by `tauri-action` before `artifactPaths` is set, so the attest step only ever sees real files.
- `artifact-metadata: write` is not needed because we don't `push-to-registry`.
- Historical releases predating this change won't have attestations; the new wording is accurate going forward.

## Test plan

- [x] YAML parses cleanly (`js-yaml` round-trip).
- [x] Cross-checked permissions and `subject-path` expression against upstream `actions/attest-build-provenance@v2` and `tauri-apps/tauri-action` source.
- [ ] End-to-end verification on the next `workflow_dispatch` release run.