### PR TITLE
Seal canonical-path invariant on workspace_key with CanonicalPath newtype

### DIFF
--- a/src-tauri/src/boot.rs
+++ b/src-tauri/src/boot.rs
@@ -314,13 +314,13 @@ pub fn resolve_boot_workspace(
 ) -> Result<Option<(PathBuf, BootSource)>, BootError> {
     if let Some(p) = &args.workspace {
         let canon = canonicalise_existing(p)?;
-        validate_repo_root(&canon, git_runner, BootSource::Cli)?;
-        return Ok(Some((canon, BootSource::Cli)));
+        validate_repo_root(canon.as_path(), git_runner, BootSource::Cli)?;
+        return Ok(Some((canon.into_inner(), BootSource::Cli)));
     }
     if let Some(p) = read_hint(app_data_dir, branch) {
         match canonicalise_existing(&p) {
-            Ok(canon) => match validate_repo_root(&canon, git_runner, BootSource::Hint) {
-                Ok(()) => return Ok(Some((canon, BootSource::Hint))),
+            Ok(canon) => match validate_repo_root(canon.as_path(), git_runner, BootSource::Hint) {
+                Ok(()) => return Ok(Some((canon.into_inner(), BootSource::Hint))),
                 Err(e) => warn!(
                     path = ?canon, error = %e,
                     "hint workspace is no longer a git repository; ignoring"
@@ -331,26 +331,30 @@ pub fn resolve_boot_workspace(
     }
     if let Some(p) = read_legacy_workspace_root(app_data_dir) {
         match canonicalise_existing(&p) {
-            Ok(canon) => match validate_repo_root(&canon, git_runner, BootSource::Legacy) {
-                Ok(()) => return Ok(Some((canon, BootSource::Legacy))),
-                Err(e) => warn!(
-                    path = ?canon, error = %e,
-                    "legacy workspace_root is no longer a git repository; ignoring"
-                ),
-            },
+            Ok(canon) => {
+                match validate_repo_root(canon.as_path(), git_runner, BootSource::Legacy) {
+                    Ok(()) => return Ok(Some((canon.into_inner(), BootSource::Legacy))),
+                    Err(e) => warn!(
+                        path = ?canon, error = %e,
+                        "legacy workspace_root is no longer a git repository; ignoring"
+                    ),
+                }
+            }
             Err(_) => warn!(path = ?p, "legacy workspace_root no longer exists; ignoring"),
         }
     }
     Ok(None)
 }
 
-fn canonicalise_existing(p: &Path) -> Result<PathBuf, BootError> {
-    let canon = dunce::canonicalize(p).map_err(|source| BootError::Canonicalise {
-        path: p.to_path_buf(),
-        source,
+fn canonicalise_existing(p: &Path) -> Result<crate::store_layout::CanonicalPath, BootError> {
+    let canon = crate::store_layout::CanonicalPath::canonicalise(p).map_err(|source| {
+        BootError::Canonicalise {
+            path: p.to_path_buf(),
+            source,
+        }
     })?;
-    if !canon.is_dir() {
-        return Err(BootError::InvalidWorkspace(canon));
+    if !canon.as_path().is_dir() {
+        return Err(BootError::InvalidWorkspace(canon.into_inner()));
     }
     Ok(canon)
 }
@@ -466,9 +470,9 @@ pub fn bind_workspace(
     origin: BootSource,
 ) -> Result<WorkspaceBinding, BootError> {
     let canon = canonicalise_existing(workspace_root)?;
-    validate_repo_root(&canon, git_runner, origin)?;
+    validate_repo_root(canon.as_path(), git_runner, origin)?;
     let root = StoreRoot::new(app_data_dir, branch);
-    let layout = root.for_workspace(canon.clone());
+    let layout = root.for_workspace(&canon);
 
     fs::create_dir_all(layout.workspace_dir())?;
 
@@ -477,12 +481,12 @@ pub fn bind_workspace(
         Err(LockError::Contention) => {
             return Err(BootError::Contention {
                 branch: branch.to_string(),
-                workspace: canon,
+                workspace: canon.into_inner(),
             });
         }
         Err(LockError::Io(source)) => {
             return Err(BootError::Lock {
-                workspace: canon,
+                workspace: canon.into_inner(),
                 source,
             });
         }
@@ -497,7 +501,7 @@ pub fn bind_workspace(
         })?;
 
     Ok(WorkspaceBinding {
-        workspace_root: canon,
+        workspace_root: canon.into_inner(),
         layout,
         store,
         lock,
@@ -1213,8 +1217,8 @@ mod tests {
         // No side-effects: lock/seed must NOT have run for a rejected
         // path. (Otherwise we'd leave a stray .lock under app_data_dir
         // for a workspace that was never actually bound.)
-        let layout =
-            StoreRoot::new(&app_data, "main").for_workspace(dunce::canonicalize(&ws).unwrap());
+        let layout = StoreRoot::new(&app_data, "main")
+            .for_workspace(&crate::store_layout::CanonicalPath::canonicalise(&ws).unwrap());
         assert!(
             !layout.lock_path().exists(),
             "lock file must not be created when bind_workspace rejects the path"
@@ -1261,8 +1265,8 @@ mod tests {
 
         // No side-effects: a rejected worktree path must not leave a
         // lock or any seeded state under app_data_dir.
-        let layout =
-            StoreRoot::new(&app_data, "main").for_workspace(dunce::canonicalize(&ws).unwrap());
+        let layout = StoreRoot::new(&app_data, "main")
+            .for_workspace(&crate::store_layout::CanonicalPath::canonicalise(&ws).unwrap());
         assert!(
             !layout.lock_path().exists(),
             "lock file must not be created when bind_workspace rejects a linked worktree"
@@ -1327,8 +1331,8 @@ mod tests {
 
         // Pre-create the storage layout's config.json as a directory so
         // the post-bind save fails.
-        let canon_ws = dunce::canonicalize(&ws).unwrap();
-        let layout = StoreRoot::new(&app_data, "main").for_workspace(canon_ws);
+        let canon_ws = crate::store_layout::CanonicalPath::canonicalise(&ws).unwrap();
+        let layout = StoreRoot::new(&app_data, "main").for_workspace(&canon_ws);
         std::fs::create_dir_all(layout.workspace_dir()).unwrap();
         std::fs::create_dir_all(layout.settings_path()).unwrap();
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1568,21 +1568,21 @@ pub fn workspace_validate_impl(
     if path.is_relative() {
         return Ok(invalid("path must be absolute"));
     }
-    let canon = match dunce::canonicalize(path) {
+    let canon = match crate::store_layout::CanonicalPath::canonicalise(path) {
         Ok(c) => c,
         Err(e) => return Ok(invalid(&format!("path could not be resolved: {e}"))),
     };
-    if !canon.is_dir() {
+    if !canon.as_path().is_dir() {
         return Ok(invalid("path is not a directory"));
     }
     let toplevel = ctx
         .git_runner
-        .git_toplevel(&canon)
+        .git_toplevel(canon.as_path())
         .map_err(AppError::from)?;
     let Some(toplevel) = toplevel else {
         return Ok(invalid("path is not a git repository"));
     };
-    if toplevel != canon {
+    if toplevel != *canon.as_path() {
         return Ok(invalid(&format!(
             "path must be the repository root ({})",
             toplevel.display()
@@ -1596,7 +1596,7 @@ pub fn workspace_validate_impl(
     // a workspace would make every session-creation flow break. Mirrors
     // the parallel check in [`crate::boot::validate_repo_root`]; keep
     // the two in sync.
-    if !canon.join(".git").is_dir() {
+    if !canon.as_path().join(".git").is_dir() {
         return Ok(invalid(
             "path is a linked git worktree, not a primary repository root \
              (Arborist cannot spawn worktrees from inside another worktree; \
@@ -1607,7 +1607,7 @@ pub fn workspace_validate_impl(
     // Phase 8 — advisory contention probe. Only meaningful for callers
     // that supplied `app_data_dir`; tests typically don't.
     let already_open = app_data_dir.and_then(|root| {
-        let layout = crate::store_layout::StoreRoot::new(root, branch).for_workspace(canon.clone());
+        let layout = crate::store_layout::StoreRoot::new(root, branch).for_workspace(&canon);
         match crate::workspace_lock::WorkspaceLockGuard::probe(layout.lock_path()) {
             Ok(free) => Some(!free),
             Err(e) => {

--- a/src-tauri/src/config_store.rs
+++ b/src-tauri/src/config_store.rs
@@ -1775,7 +1775,9 @@ mod tests {
             app_data.path().to_path_buf(),
             "feature-x".to_owned(),
         );
-        let layout = root.for_workspace(workspace_canon.clone());
+        let workspace_canon_typed =
+            crate::store_layout::CanonicalPath::assume_canonical(workspace_canon.clone());
+        let layout = root.for_workspace(&workspace_canon_typed);
         let expected_settings_path = layout.settings_path();
         let expected_workspace_dir = layout.workspace_dir();
 
@@ -1785,7 +1787,7 @@ mod tests {
         assert_eq!(store.dir(), expected_workspace_dir.as_path());
         // The retained layout points back at the same workspace.
         let retained = store.layout().expect("layout retained");
-        assert_eq!(retained.workspace(), workspace_canon.as_path());
+        assert_eq!(retained.workspace().as_path(), workspace_canon.as_path());
         assert_eq!(retained.settings_path(), expected_settings_path);
 
         // Round-trip: a save persists to the layout's settings path.
@@ -1814,15 +1816,16 @@ mod tests {
     fn from_layout_is_deterministic_for_same_inputs() {
         let app_data = TempDir::new().expect("app_data");
         let workspace = TempDir::new().expect("workspace");
-        let canonical = canon(workspace.path());
+        let canonical =
+            crate::store_layout::CanonicalPath::assume_canonical(canon(workspace.path()));
 
         let root_a = crate::store_layout::StoreRoot::new(
             app_data.path().to_path_buf(),
             "feature-x".to_owned(),
         );
         let root_b = root_a.clone();
-        let store_a = ConfigStore::from_layout(root_a.for_workspace(canonical.clone())).expect("a");
-        let store_b = ConfigStore::from_layout(root_b.for_workspace(canonical.clone())).expect("b");
+        let store_a = ConfigStore::from_layout(root_a.for_workspace(&canonical)).expect("a");
+        let store_b = ConfigStore::from_layout(root_b.for_workspace(&canonical)).expect("b");
         assert_eq!(store_a.dir(), store_b.dir());
     }
 
@@ -1839,8 +1842,14 @@ mod tests {
             app_data.path().to_path_buf(),
             "feature-x".to_owned(),
         );
-        let store_a = ConfigStore::from_layout(root.for_workspace(canon(ws_a.path()))).expect("a");
-        let store_b = ConfigStore::from_layout(root.for_workspace(canon(ws_b.path()))).expect("b");
+        let store_a = ConfigStore::from_layout(root.for_workspace(
+            &crate::store_layout::CanonicalPath::assume_canonical(canon(ws_a.path())),
+        ))
+        .expect("a");
+        let store_b = ConfigStore::from_layout(root.for_workspace(
+            &crate::store_layout::CanonicalPath::assume_canonical(canon(ws_b.path())),
+        ))
+        .expect("b");
         assert_ne!(
             store_a.dir(),
             store_b.dir(),

--- a/src-tauri/src/seed.rs
+++ b/src-tauri/src/seed.rs
@@ -293,7 +293,7 @@ fn should_seed_from_legacy_config(legacy_path: &Path, layout: &StoreLayout) -> b
         return false;
     }
     match read_legacy_workspace_root(legacy_path) {
-        Some(Some(legacy_root)) => paths_equal(&legacy_root, layout.workspace()),
+        Some(Some(legacy_root)) => paths_equal(&legacy_root, layout.workspace().as_path()),
         Some(None) => layout.root().is_canonical(),
         None => {
             // Parse failure on the candidate seed source: skip with a
@@ -319,7 +319,7 @@ fn legacy_workspace_root_matches(legacy_config_path: &Path, layout: &StoreLayout
     }
     matches!(
         read_legacy_workspace_root(legacy_config_path),
-        Some(Some(root)) if paths_equal(&root, layout.workspace()),
+        Some(Some(root)) if paths_equal(&root, layout.workspace().as_path()),
     )
 }
 
@@ -403,7 +403,7 @@ fn write_marker_create_new(layout: &StoreLayout, dest: &Path) -> io::Result<()> 
         .map(|d| d.as_secs())
         .unwrap_or(0);
     let meta = WorkspaceMeta {
-        workspace: layout.workspace().to_path_buf(),
+        workspace: layout.workspace().as_path().to_path_buf(),
         branch: layout.root().branch().to_owned(),
         initialised_at: now,
     };
@@ -437,8 +437,8 @@ mod tests {
         fs::write(path, serde_json::to_vec_pretty(body).unwrap()).unwrap();
     }
 
-    fn canon(p: &Path) -> PathBuf {
-        dunce::canonicalize(p).unwrap()
+    fn canon(p: &Path) -> crate::store_layout::CanonicalPath {
+        crate::store_layout::CanonicalPath::canonicalise(p).unwrap()
     }
 
     /// First-launch with no seed source: marker is written, no other
@@ -449,7 +449,7 @@ mod tests {
         let workspace = TempDir::new().unwrap();
 
         let root = StoreRoot::new(app_data.path().to_path_buf(), "feature-x".to_owned());
-        let layout = root.for_workspace(canon(workspace.path()));
+        let layout = root.for_workspace(&canon(workspace.path()));
 
         let report = initialise_workspace_dir(&layout).unwrap();
         assert!(!report.already_seeded);
@@ -477,7 +477,7 @@ mod tests {
         let workspace_canon = canon(workspace.path());
 
         let canonical_root = StoreRoot::new(app_data.path().to_path_buf(), "main".to_owned());
-        let canonical_layout = canonical_root.for_workspace(workspace_canon.clone());
+        let canonical_layout = canonical_root.for_workspace(&workspace_canon);
         // Pre-seed the canonical workspace settings, including
         // session-list fields the strip must remove.
         touch_json(
@@ -495,7 +495,7 @@ mod tests {
         fs::write(canonical_layout.sessions_path(), b"{}").unwrap();
 
         let branch_root = StoreRoot::new(app_data.path().to_path_buf(), "feature-x".to_owned());
-        let branch_layout = branch_root.for_workspace(workspace_canon.clone());
+        let branch_layout = branch_root.for_workspace(&workspace_canon);
         let report = initialise_workspace_dir(&branch_layout).unwrap();
 
         assert!(!report.already_seeded);
@@ -548,7 +548,7 @@ mod tests {
         let workspace_canon = canon(workspace.path());
 
         let root = StoreRoot::new(app_data.path().to_path_buf(), "feature-x".to_owned());
-        let layout = root.for_workspace(workspace_canon.clone());
+        let layout = root.for_workspace(&workspace_canon);
 
         // Legacy config from an old canonical install, with a
         // matching workspaceRoot so the seed is allowed.
@@ -556,7 +556,7 @@ mod tests {
             &root.legacy_config_path(),
             &serde_json::json!({
                 "configVersion": 4,
-                "workspaceRoot": workspace_canon.to_string_lossy(),
+                "workspaceRoot": workspace_canon.as_path().to_string_lossy(),
                 "instructionSetsDir": "/y",
                 "lastOpenSessions": ["550e8400-e29b-41d4-a716-446655440001"],
                 "tabOrder": ["550e8400-e29b-41d4-a716-446655440001"],
@@ -585,7 +585,7 @@ mod tests {
         );
         assert_eq!(
             obj.get("workspaceRoot").and_then(|v| v.as_str()),
-            Some(workspace_canon.to_string_lossy().as_ref()),
+            Some(workspace_canon.as_path().to_string_lossy().as_ref()),
             "workspaceRoot must survive the strip"
         );
     }
@@ -601,13 +601,13 @@ mod tests {
         let workspace_canon = canon(workspace.path());
 
         let root = StoreRoot::new(app_data.path().to_path_buf(), "main".to_owned());
-        let layout = root.for_workspace(workspace_canon.clone());
+        let layout = root.for_workspace(&workspace_canon);
 
         touch_json(
             &root.legacy_config_path(),
             &serde_json::json!({
                 "configVersion": 4,
-                "workspaceRoot": workspace_canon.to_string_lossy(),
+                "workspaceRoot": workspace_canon.as_path().to_string_lossy(),
                 "lastOpenSessions": ["550e8400-e29b-41d4-a716-446655440000"],
                 "tabOrder": ["550e8400-e29b-41d4-a716-446655440000"],
                 "activeSessionId": "550e8400-e29b-41d4-a716-446655440000",
@@ -649,13 +649,13 @@ mod tests {
         let workspace_canon = canon(workspace.path());
 
         let root = StoreRoot::new(app_data.path().to_path_buf(), "main".to_owned());
-        let layout = root.for_workspace(workspace_canon.clone());
+        let layout = root.for_workspace(&workspace_canon);
 
         touch_json(
             &root.legacy_config_path(),
             &serde_json::json!({
                 "configVersion": 4,
-                "workspaceRoot": canon(other.path()).to_string_lossy(),
+                "workspaceRoot": canon(other.path()).as_path().to_string_lossy(),
             }),
         );
         fs::write(root.legacy_sessions_path(), b"{}").unwrap();
@@ -676,7 +676,7 @@ mod tests {
         let workspace_canon = canon(workspace.path());
 
         let root = StoreRoot::new(app_data.path().to_path_buf(), "main".to_owned());
-        let layout = root.for_workspace(workspace_canon);
+        let layout = root.for_workspace(&workspace_canon);
 
         touch_json(
             &root.legacy_config_path(),
@@ -700,7 +700,7 @@ mod tests {
         let workspace = TempDir::new().unwrap();
 
         let root = StoreRoot::new(app_data.path().to_path_buf(), "feature-x".to_owned());
-        let layout = root.for_workspace(canon(workspace.path()));
+        let layout = root.for_workspace(&canon(workspace.path()));
 
         touch_json(
             &root.legacy_config_path(),
@@ -722,14 +722,14 @@ mod tests {
         let workspace_canon = canon(workspace.path());
 
         let root = StoreRoot::new(app_data.path().to_path_buf(), "main".to_owned());
-        let layout = root.for_workspace(workspace_canon.clone());
+        let layout = root.for_workspace(&workspace_canon);
         // Seed source so the winner has work to do (makes the test
         // more sensitive to races than a pure-Fresh case).
         touch_json(
             &root.legacy_config_path(),
             &serde_json::json!({
                 "configVersion": 4,
-                "workspaceRoot": workspace_canon.to_string_lossy(),
+                "workspaceRoot": workspace_canon.as_path().to_string_lossy(),
             }),
         );
 
@@ -764,7 +764,7 @@ mod tests {
         let workspace_canon = canon(workspace.path());
 
         let root = StoreRoot::new(app_data.path().to_path_buf(), "main".to_owned());
-        let layout = root.for_workspace(workspace_canon.clone());
+        let layout = root.for_workspace(&workspace_canon);
 
         // First call: nothing to seed, marker written.
         let first = initialise_workspace_dir(&layout).unwrap();
@@ -776,7 +776,7 @@ mod tests {
             &root.legacy_config_path(),
             &serde_json::json!({
                 "configVersion": 4,
-                "workspaceRoot": workspace_canon.to_string_lossy(),
+                "workspaceRoot": workspace_canon.as_path().to_string_lossy(),
             }),
         );
         fs::write(root.legacy_sessions_path(), b"{}").unwrap();
@@ -795,7 +795,7 @@ mod tests {
         let workspace = TempDir::new().unwrap();
 
         let root = StoreRoot::new(app_data.path().to_path_buf(), "main".to_owned());
-        let layout = root.for_workspace(canon(workspace.path()));
+        let layout = root.for_workspace(&canon(workspace.path()));
 
         fs::create_dir_all(root.legacy_config_path().parent().unwrap()).unwrap();
         fs::write(root.legacy_config_path(), b"not json {{{").unwrap();
@@ -816,7 +816,7 @@ mod tests {
         let app_data = TempDir::new().unwrap();
         let workspace = TempDir::new().unwrap();
         let root = StoreRoot::new(app_data.path().to_path_buf(), "main".to_owned());
-        let layout = root.for_workspace(canon(workspace.path()));
+        let layout = root.for_workspace(&canon(workspace.path()));
 
         // Hand-write a marker (NOT via initialise) — simulates a
         // sibling process that won the seed first.

--- a/src-tauri/src/store_layout.rs
+++ b/src-tauri/src/store_layout.rs
@@ -45,6 +45,81 @@ use sha2::{Digest, Sha256};
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
+/// A `PathBuf` that is **statically asserted** to have been canonicalised
+/// before construction. The hashing in [`workspace_key`] and the
+/// directory layout in [`StoreRoot::for_workspace`] are stable only over
+/// canonical paths — two equivalent-but-byte-different forms of the
+/// same workspace would split its on-disk state across two storage
+/// dirs. Wrapping the path in this newtype makes that invariant
+/// compile-checkable: every call site that wants to derive a layout
+/// must show a `CanonicalPath`, and the only public way to get one is
+/// [`CanonicalPath::canonicalise`] (which actually canonicalises) or
+/// [`CanonicalPath::assume_canonical`] (which is a deliberate
+/// escape-hatch — see its doc).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CanonicalPath(PathBuf);
+
+impl CanonicalPath {
+    /// Canonicalise `p` via [`dunce::canonicalize`] (which avoids the
+    /// `\\?\` UNC prefix on Windows that
+    /// [`std::fs::canonicalize`] would otherwise produce). The path
+    /// must exist on disk; symlinks are resolved, `..` components are
+    /// removed, and on Windows the case is normalised to whatever the
+    /// filesystem reports.
+    ///
+    /// This is the *only* fallible constructor. Production code should
+    /// prefer this entry point so the resulting `CanonicalPath` is
+    /// genuinely canonical, not merely declared so.
+    pub fn canonicalise(p: impl AsRef<Path>) -> std::io::Result<Self> {
+        dunce::canonicalize(p.as_ref()).map(Self)
+    }
+
+    /// Construct a `CanonicalPath` from a `PathBuf` that the caller
+    /// **already canonicalised by some other route**.
+    ///
+    /// **Use sparingly.** This bypasses the runtime canonicalisation
+    /// guarantee and trusts the caller's claim. Legitimate uses:
+    /// - The path was just produced by [`Self::canonicalise`] upstream
+    ///   (e.g. plumbed through a struct field as `PathBuf`) and we
+    ///   want to re-tag it without a redundant filesystem round-trip.
+    /// - Synthetic test fixtures whose paths intentionally do not
+    ///   exist on disk (e.g. the unit tests in this module that
+    ///   exercise `workspace_key` against `/repos/x` literals).
+    ///
+    /// Do **not** use this to wrap raw user input. It's a deliberate
+    /// foot-gun preserved only because the alternative — forcing
+    /// every test fixture to materialise a real directory just to be
+    /// canonicalised — is more harmful than the foot-gun.
+    #[must_use]
+    pub fn assume_canonical(p: PathBuf) -> Self {
+        Self(p)
+    }
+
+    /// Borrow the inner path.
+    #[must_use]
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+
+    /// Consume self and return the inner `PathBuf`.
+    #[must_use]
+    pub fn into_inner(self) -> PathBuf {
+        self.0
+    }
+}
+
+impl AsRef<Path> for CanonicalPath {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for CanonicalPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.display().fmt(f)
+    }
+}
+
 /// Returns `true` if `branch` represents the canonical (top-level) build.
 ///
 /// Both an empty string (no git info / detached HEAD / shallow clone) and
@@ -61,31 +136,29 @@ pub fn is_canonical_build(branch: &str) -> bool {
 /// key for a workspace. 16 hex chars = 64 bits = collision-free for any
 /// realistic number of workspaces.
 ///
-/// **The caller MUST pass an already-canonicalised absolute path.** The
-/// hash is computed over the path's platform-native byte representation,
-/// so two equivalent paths that aren't byte-identical (different case
-/// on Windows, with vs without a trailing separator, symlink vs target,
-/// etc.) would otherwise produce different keys and accidentally split
-/// a single workspace's state across two storage dirs.
-///
-/// On Unix we hash the raw `OsStr` bytes (paths are opaque byte
-/// sequences and may not be valid UTF-8). On Windows we hash the UTF-16
-/// LE code units. We deliberately do **not** route through
-/// `to_string_lossy`, which would replace invalid UTF-8 with `U+FFFD`
-/// and could collide two genuinely distinct non-UTF-8 paths to the
-/// same key.
+/// The input is statically required to be a [`CanonicalPath`] so two
+/// equivalent paths that aren't byte-identical (different case on
+/// Windows, with vs without a trailing separator, symlink vs target,
+/// etc.) cannot be passed in by accident. The hash is computed over
+/// the path's platform-native byte representation: on Unix the raw
+/// `OsStr` bytes (paths are opaque byte sequences and may not be valid
+/// UTF-8); on Windows the UTF-16 LE code units. We deliberately do
+/// **not** route through `to_string_lossy`, which would replace
+/// invalid UTF-8 with `U+FFFD` and could collide two genuinely
+/// distinct non-UTF-8 paths to the same key.
 #[must_use]
-pub fn workspace_key(canonical_path: &Path) -> String {
+pub fn workspace_key(canonical_path: &CanonicalPath) -> String {
+    let path = canonical_path.as_path();
     let mut hasher = Sha256::new();
     #[cfg(unix)]
     {
         use std::os::unix::ffi::OsStrExt as _;
-        hasher.update(canonical_path.as_os_str().as_bytes());
+        hasher.update(path.as_os_str().as_bytes());
     }
     #[cfg(windows)]
     {
         use std::os::windows::ffi::OsStrExt as _;
-        for wide in canonical_path.as_os_str().encode_wide() {
+        for wide in path.as_os_str().encode_wide() {
             hasher.update(wide.to_le_bytes());
         }
     }
@@ -93,7 +166,7 @@ pub fn workspace_key(canonical_path: &Path) -> String {
     {
         // Fallback for exotic platforms: lossy string. None of our
         // supported targets reach this branch.
-        hasher.update(canonical_path.to_string_lossy().as_bytes());
+        hasher.update(path.to_string_lossy().as_bytes());
     }
     let digest = hasher.finalize();
     let mut hex = String::with_capacity(16);
@@ -216,7 +289,10 @@ impl StoreRoot {
     /// Returns `None` when this root **is** the canonical root — a
     /// canonical build seeding from itself makes no sense.
     #[must_use]
-    pub fn canonical_workspace_settings_path(&self, canonical_workspace: &Path) -> Option<PathBuf> {
+    pub fn canonical_workspace_settings_path(
+        &self,
+        canonical_workspace: &CanonicalPath,
+    ) -> Option<PathBuf> {
         if self.is_canonical() {
             None
         } else {
@@ -230,13 +306,14 @@ impl StoreRoot {
     }
 
     /// Promote this root to a full per-workspace [`StoreLayout`].
-    /// `canonical_workspace` MUST already be canonicalised — see
-    /// [`workspace_key`] for the stability requirement.
+    /// Requires a [`CanonicalPath`] so [`workspace_key`]'s stability
+    /// invariant cannot be silently broken by an un-canonicalised
+    /// caller.
     #[must_use]
-    pub fn for_workspace(&self, canonical_workspace: impl Into<PathBuf>) -> StoreLayout {
+    pub fn for_workspace(&self, canonical_workspace: &CanonicalPath) -> StoreLayout {
         StoreLayout {
             root: self.clone(),
-            workspace: canonical_workspace.into(),
+            workspace: canonical_workspace.clone(),
         }
     }
 }
@@ -250,7 +327,7 @@ impl StoreRoot {
 #[derive(Debug, Clone)]
 pub struct StoreLayout {
     root: StoreRoot,
-    workspace: PathBuf,
+    workspace: CanonicalPath,
 }
 
 impl StoreLayout {
@@ -262,7 +339,7 @@ impl StoreLayout {
 
     /// The canonicalised workspace path this layout is keyed on.
     #[must_use]
-    pub fn workspace(&self) -> &Path {
+    pub fn workspace(&self) -> &CanonicalPath {
         &self.workspace
     }
 
@@ -322,6 +399,13 @@ mod tests {
         StoreRoot::new(PathBuf::from(app_data), branch.to_string())
     }
 
+    /// Test helper: wrap a synthetic path literal as canonical without
+    /// touching the filesystem. Real production code uses
+    /// [`CanonicalPath::canonicalise`].
+    fn cp(p: &str) -> CanonicalPath {
+        CanonicalPath::assume_canonical(PathBuf::from(p))
+    }
+
     // ----- is_canonical_build -------------------------------------------
 
     #[test]
@@ -345,20 +429,20 @@ mod tests {
 
     #[test]
     fn workspace_key_is_deterministic() {
-        let p = PathBuf::from("/repos/arborist");
+        let p = cp("/repos/arborist");
         assert_eq!(workspace_key(&p), workspace_key(&p));
     }
 
     #[test]
     fn workspace_key_differs_for_different_paths() {
-        let a = workspace_key(&PathBuf::from("/repos/arborist"));
-        let b = workspace_key(&PathBuf::from("/repos/other"));
+        let a = workspace_key(&cp("/repos/arborist"));
+        let b = workspace_key(&cp("/repos/other"));
         assert_ne!(a, b);
     }
 
     #[test]
     fn workspace_key_is_16_lowercase_hex() {
-        let key = workspace_key(&PathBuf::from("/some/workspace/path"));
+        let key = workspace_key(&cp("/some/workspace/path"));
         assert_eq!(key.len(), 16, "key must be exactly 16 hex chars");
         assert!(
             key.chars()
@@ -377,8 +461,8 @@ mod tests {
     fn workspace_key_does_not_collide_non_utf8_unix_paths() {
         use std::ffi::OsStr;
         use std::os::unix::ffi::OsStrExt;
-        let a = PathBuf::from(OsStr::from_bytes(b"/tmp/test\xFF"));
-        let b = PathBuf::from(OsStr::from_bytes(b"/tmp/test\xFE"));
+        let a = CanonicalPath::assume_canonical(PathBuf::from(OsStr::from_bytes(b"/tmp/test\xFF")));
+        let b = CanonicalPath::assume_canonical(PathBuf::from(OsStr::from_bytes(b"/tmp/test\xFE")));
         assert_ne!(
             workspace_key(&a),
             workspace_key(&b),
@@ -420,12 +504,12 @@ mod tests {
 
     #[test]
     fn workspace_dir_for_whitespace_branch_matches_trimmed_layout() {
-        let ws = PathBuf::from("/repos/x");
+        let ws = cp("/repos/x");
         let r1 = root("/data", "feat");
         let r2 = root("/data", "  feat  ");
         assert_eq!(
-            r1.for_workspace(ws.clone()).workspace_dir(),
-            r2.for_workspace(ws).workspace_dir(),
+            r1.for_workspace(&ws).workspace_dir(),
+            r2.for_workspace(&ws).workspace_dir(),
             "whitespace-padded branch must hash to the same workspace dir",
         );
     }
@@ -464,7 +548,7 @@ mod tests {
     fn canonical_workspace_settings_path_is_none_for_canonical_root() {
         let r = root("/data", "main");
         assert_eq!(
-            r.canonical_workspace_settings_path(&PathBuf::from("/repos/x")),
+            r.canonical_workspace_settings_path(&cp("/repos/x")),
             None,
             "canonical build seeding from itself makes no sense",
         );
@@ -473,7 +557,7 @@ mod tests {
     #[test]
     fn canonical_workspace_settings_path_points_at_canonical_layout_for_branch() {
         let r = root("/data", "feat");
-        let ws = PathBuf::from("/repos/x");
+        let ws = cp("/repos/x");
         let key = workspace_key(&ws);
         assert_eq!(
             r.canonical_workspace_settings_path(&ws),
@@ -485,8 +569,8 @@ mod tests {
 
     #[test]
     fn workspace_dir_for_canonical_omits_branch_segment() {
-        let layout = root("/data", "main").for_workspace(PathBuf::from("/repos/x"));
-        let key = workspace_key(&PathBuf::from("/repos/x"));
+        let layout = root("/data", "main").for_workspace(&cp("/repos/x"));
+        let key = workspace_key(&cp("/repos/x"));
         assert_eq!(
             layout.workspace_dir(),
             PathBuf::from(format!("/data/workspaces/{key}")),
@@ -495,8 +579,8 @@ mod tests {
 
     #[test]
     fn workspace_dir_for_branch_includes_branch_segment() {
-        let layout = root("/data", "feat").for_workspace(PathBuf::from("/repos/x"));
-        let key = workspace_key(&PathBuf::from("/repos/x"));
+        let layout = root("/data", "feat").for_workspace(&cp("/repos/x"));
+        let key = workspace_key(&cp("/repos/x"));
         assert_eq!(
             layout.workspace_dir(),
             PathBuf::from(format!("/data/branches/feat/workspaces/{key}")),
@@ -505,7 +589,7 @@ mod tests {
 
     #[test]
     fn leaf_paths_live_under_workspace_dir() {
-        let layout = root("/data", "feat").for_workspace(PathBuf::from("/repos/x"));
+        let layout = root("/data", "feat").for_workspace(&cp("/repos/x"));
         let dir = layout.workspace_dir();
         assert_eq!(layout.settings_path(), dir.join("config.json"));
         assert_eq!(layout.sessions_path(), dir.join("sessions.json"));
@@ -520,8 +604,8 @@ mod tests {
     #[test]
     fn two_layouts_for_different_workspaces_do_not_collide() {
         let r = root("/data", "feat");
-        let a = r.for_workspace(PathBuf::from("/repos/x"));
-        let b = r.for_workspace(PathBuf::from("/repos/y"));
+        let a = r.for_workspace(&cp("/repos/x"));
+        let b = r.for_workspace(&cp("/repos/y"));
         assert_ne!(a.workspace_dir(), b.workspace_dir());
         assert_ne!(a.settings_path(), b.settings_path());
         assert_ne!(a.lock_path(), b.lock_path());
@@ -529,11 +613,36 @@ mod tests {
 
     #[test]
     fn two_layouts_for_different_branches_same_workspace_do_not_collide() {
-        let ws = PathBuf::from("/repos/x");
-        let a = root("/data", "main").for_workspace(ws.clone());
-        let b = root("/data", "feat").for_workspace(ws);
+        let ws = cp("/repos/x");
+        let a = root("/data", "main").for_workspace(&ws);
+        let b = root("/data", "feat").for_workspace(&ws);
         assert_ne!(a.workspace_dir(), b.workspace_dir());
         assert_ne!(a.settings_path(), b.settings_path());
         assert_ne!(a.lock_path(), b.lock_path());
+    }
+
+    // ----- CanonicalPath -----------------------------------------------
+
+    #[test]
+    fn assume_canonical_round_trips() {
+        let p = PathBuf::from("/repos/x");
+        let cp = CanonicalPath::assume_canonical(p.clone());
+        assert_eq!(cp.as_path(), p.as_path());
+        assert_eq!(cp.clone().into_inner(), p);
+    }
+
+    #[test]
+    fn canonicalise_resolves_real_path() {
+        // Use the system temp dir which is always canonicalisable on
+        // every platform we ship to.
+        let td = tempfile::TempDir::new().expect("tempdir");
+        let canon = CanonicalPath::canonicalise(td.path()).expect("canonicalise tempdir");
+        // Directory should still exist and the inner path should be a
+        // valid canonicalised form of the input.
+        assert!(canon.as_path().is_dir());
+        assert!(
+            canon.as_path().is_absolute(),
+            "canonicalise must return an absolute path"
+        );
     }
 }

--- a/src-tauri/tests/workspace_command.rs
+++ b/src-tauri/tests/workspace_command.rs
@@ -262,7 +262,7 @@ fn workspace_validate_reports_held_lock_as_already_open_windows() {
 
     let canon = dunce::canonicalize(dir.path()).unwrap();
     let layout = arborist_lib::store_layout::StoreRoot::new(app_data_dir.path(), "main")
-        .for_workspace(canon);
+        .for_workspace(&arborist_lib::store_layout::CanonicalPath::assume_canonical(canon));
     std::fs::create_dir_all(layout.workspace_dir()).unwrap();
     let _holder = arborist_lib::workspace_lock::WorkspaceLockGuard::acquire(layout.lock_path())
         .expect("hold the lock from the test process");
@@ -377,7 +377,7 @@ fn build_switch_ctx(
     let canon =
         dunce::canonicalize(workspace_a).expect("canonicalise initial workspace for test ctx");
     let layout = arborist_lib::store_layout::StoreRoot::new(app_data_dir, branch)
-        .for_workspace(canon.clone());
+        .for_workspace(&arborist_lib::store_layout::CanonicalPath::assume_canonical(canon.clone()));
     std::fs::create_dir_all(layout.workspace_dir()).unwrap();
     let lock = WorkspaceLockGuard::acquire(layout.lock_path()).expect("acquire initial test lock");
     let store = ConfigStore::from_layout(layout).expect("from_layout for test");
@@ -452,7 +452,9 @@ async fn workspace_switch_happy_path_swaps_and_emits() {
 
     // The OLD lock has been dropped; we can re-acquire it.
     let old_layout = arborist_lib::store_layout::StoreRoot::new(app_data_dir.path(), "main")
-        .for_workspace(ws_a_canon.clone());
+        .for_workspace(
+            &arborist_lib::store_layout::CanonicalPath::assume_canonical(ws_a_canon.clone()),
+        );
     let _re = WorkspaceLockGuard::acquire(old_layout.lock_path())
         .expect("old workspace lock must be free after switch");
 
@@ -552,7 +554,9 @@ async fn workspace_switch_returns_locked_when_target_is_held() {
     runner.set_repo_root(ws_b.path());
     let canon_b = dunce::canonicalize(ws_b.path()).unwrap();
     let layout_b = arborist_lib::store_layout::StoreRoot::new(app_data_dir.path(), "main")
-        .for_workspace(canon_b.clone());
+        .for_workspace(
+            &arborist_lib::store_layout::CanonicalPath::assume_canonical(canon_b.clone()),
+        );
     std::fs::create_dir_all(layout_b.workspace_dir()).unwrap();
 
     // Note: on Unix, fs2 per-process flock semantics may allow same-process
@@ -661,7 +665,9 @@ async fn workspace_switch_parks_old_sessions_preserving_records() {
     // ❗ The crucial assertion: A's records must STILL be on disk under
     // its branch-scoped workspace dir, untouched by the park.
     let layout_a = arborist_lib::store_layout::StoreRoot::new(app_data_dir.path(), "main")
-        .for_workspace(ws_a_canon.clone());
+        .for_workspace(
+            &arborist_lib::store_layout::CanonicalPath::assume_canonical(ws_a_canon.clone()),
+        );
     let store_a_after =
         ConfigStore::from_layout(layout_a.clone()).expect("re-open A's store after switch");
     let a_sessions = store_a_after.load_sessions();


### PR DESCRIPTION
Code-review finding **4** — type-system enforcement of the
must be canonicalised before use invariant on the storage layout.

## Why

store_layout::workspace_key and StoreRoot::for_workspace previously
took &Path, with the invariant only enforced by rustdoc and defensive
comments at every caller. Two canonicalisations of the same worktree
(e.g. one via `dunce`, one via the legacy config peek) could hash to
different keys and silently split a workspace's settings across two
storage dirs — exactly the failure mode the review called out.

## What

Introduce `CanonicalPath` — a newtype around `PathBuf` with two
constructors:

* `CanonicalPath::canonicalise(p)` — fallible, wraps `dunce::canonicalize`.
* `CanonicalPath::assume_canonical(p)` — escape-hatch with strong
  rustdoc warning, used only at test sites where the caller has already
  canonicalised.

Signature changes:

| API | Before | After |
|---|---|---|
| `workspace_key` | `&Path` | `&CanonicalPath` |
| `StoreRoot::for_workspace` | `impl Into<PathBuf>` | `&CanonicalPath` |
| `StoreRoot::canonical_workspace_settings_path` | `&Path` | `&CanonicalPath` |
| `StoreLayout::workspace` | `PathBuf` field | `CanonicalPath` field; accessor returns `&CanonicalPath` |

Production callers (boot, `workspace_validate_impl`, seed) thread the
newtype through. `WorkspaceBinding.workspace_root` deliberately stays
`PathBuf` to keep the public-type blast radius minimal.

## Tests

* `cargo test --workspace` — all green (439 tests across all suites).
* `cargo clippy --workspace --all-targets -- -D warnings` clean.
* Existing `two canonicalisations hash to different keys` test in
  `store_layout.rs` is preserved; two new tests cover the newtype's
  own contracts.

## Out of scope

* Changing `WorkspaceBinding.workspace_root` to `CanonicalPath`
  (downstream consumers across types.rs, workspace_scope.rs,
  config_store.rs, commands/session.rs would need updating — separate PR
  if/when desired).
* The `paths_equal` helper in `seed.rs` defensively re-canonicalises
  its first argument because the legacy path comes from a config file
  written by an older binary that may not have canonicalised. Left
  as-is intentionally.

Stacks on top of #36 and #35.