### PR TITLE
Single switch_lock + switch_pending workspace-switch barrier (PR4)

### DIFF
--- a/dev/docs/DESIGN.md
+++ b/dev/docs/DESIGN.md
@@ -447,11 +447,48 @@ workspace directory. Two instances cannot bind the same pair concurrently.
 **In-app switch**
 
 Triggered from the workspace indicator. The frontend invokes the
-`workspace_switch` command with the new path; the backend serialises the
-entire transaction behind a single `tokio::sync::Mutex` (`switch_serialise`)
-and runs the steps in this order (matching `workspace_switch_impl_inner`):
+`workspace_switch` command with the new path. The backend uses **two**
+concurrency primitives held on `AppContext`:
 
-1. Acquire `switch_serialise`.
+* `switch_lock: Arc<tokio::sync::RwLock<()>>` — a single writer-preferring
+  lock. Workspace-scoped command handlers (`session_create`,
+  `session_close`, `session_restart`, `session_focus`, `session_resize`,
+  `config_set`, `frontend_ready`'s restore branch) take `try_read()` at
+  their impl entry and hold the guard for the full impl body. The switch
+  itself takes `write().await` at its impl entry and holds it for the full
+  pipeline. Concurrent switches queue serially on the write side; in-flight
+  handlers' read guards must drop before the write resolves.
+* `switch_pending: Arc<AtomicUsize>` — incremented by the switch BEFORE
+  awaiting `write()`, decremented when the switch returns (RAII via
+  `SwitchPendingGuard`). Handlers use a **take-then-check** pattern:
+  acquire `try_read()` first, then `load` the counter; if non-zero, drop
+  the guard and reject. This closes a real race in tokio's `try_read`
+  fairness — `try_read` consults only the current permit count, not the
+  wait queue, so it can succeed while a writer is queued behind active
+  readers. The counter is the source of truth for "a switch is in
+  flight."
+
+Lock-ordering discipline: `switch_lock` is the outermost lock; the
+existing `workspace` `RwLock`, `pending_spawn` `Mutex`, and per-store
+`write_lock` are taken briefly inside the read/write guard and released
+before any `.await` not under the outer guard. There are no cycles.
+
+Rejection semantics:
+
+| Handler | On contention |
+|---|---|
+| `session_create` / `session_close` / `session_restart` / `session_focus` / `config_set` | `WorkspaceSwitchInProgress` (user-initiated, surfaces as a toast — but the frontend overlay disables UI during a switch so this is defence-in-depth) |
+| `session_resize` | `Ok(())` silently — the next `ResizeObserver` fire after the switch completes corrects dimensions |
+| `frontend_ready` (restore branch) | `Ok(())` silently — frontend re-issues after `workspace://changed` |
+
+The switch runs the steps in this order (matching
+`workspace_switch_impl_inner`):
+
+1. Bump `switch_pending` (RAII) and acquire `switch_lock.write().await`.
+   The counter is set BEFORE awaiting the lock so handlers issued after
+   this point reject (or silently `Ok`). The `write().await` then waits
+   for in-flight read guards to drop before resolving. Both guards drop
+   at function return (success or unwind).
 2. `workspace_validate_impl(new_path, app_data_dir = None, branch)` —
    skip the advisory probe; the authoritative acquire below will surface
    the same contention as a hard error if it persists. Then canonicalise
@@ -459,76 +496,73 @@ and runs the steps in this order (matching `workspace_switch_impl_inner`):
 3. **No-op fast path**: if the canonicalised path equals the currently
    bound workspace root, return `{ workspaceRoot, noOp: true }`
    immediately. No event is emitted, no other state mutates.
-4. Flip `switch_in_progress = true` via a `GateGuard` RAII handle. From
-   here until step 12, `session_create` / `session_restart` /
-   `session_focus` / `session_close` / `config_set` / `frontend_ready`
-   refuse with `WorkspaceSwitchInProgress`. The guard's `Drop` clears
-   the gate on unwind, so a panic anywhere in steps 5–11 cannot leave
-   the gate stuck.
-5. `bind_workspace(new)` — create the new per-(branch, workspace)
+4. `bind_workspace(new)` — create the new per-(branch, workspace)
    directory if needed, run seed-on-first-launch under
    `.config-seed.lock`, and **acquire the new `.lock`**. On contention
-   the switch aborts with `WorkspaceLocked`, the gate is restored, and
-   the old workspace remains bound.
-6. **`ensure_workspace_root_in_config` on the NEW store — pre-swap,
+   the switch aborts with `WorkspaceLocked`, both guards drop, and the
+   old workspace remains bound.
+5. **`ensure_workspace_root_in_config` on the NEW store — pre-swap,
    aborts the switch on failure.** Persists the new workspace's path
    into its own `config.json` *before* committing the scope swap. If
    this write fails, the early-return drops `binding` (releasing the
    newly-acquired OS lock), the old `WorkspaceScope` is still bound,
-   and `GateGuard::drop` clears `switch_in_progress`. This is the
-   **asymmetric counterpart** to `boot_select_workspace`, which
-   tolerates the same failure because boot is one-shot and the user
-   can restart; mid-session switching cannot leave the backend bound
-   to a workspace whose `config.json` reports `workspaceRoot: null`,
-   because the post-switch frontend rehydrate would then fall back
-   to the first-boot picker even though the swap had already
-   committed — a self-contradictory state with no clean recovery.
-7. **Quiesce metrics watchers + drain `pending_spawn`** under the
-   `deferred_spawn_quiesce` write guard. The write guard waits until
-   every concurrent `session_resize_impl` deferred-spawn block (which
-   holds a read guard) has released, ensuring every started watcher
-   is in the metrics registry. Then `pending_spawn.clear()` and
-   `metrics.stop_all_and_join()` run together. Any `session_resize`
-   that arrives after the write guard releases sees an empty
-   `pending_spawn` and falls through to `pool.resize`, which fails
-   benignly with `NotFound` once park has killed the PTY. This step
-   must run **before** park because the per-session `metrics.stop()`
-   calls inside `park_session_for_switch_impl` remove handles from
-   the registry, leaving `stop_all_and_join` with nothing to join.
-   Stopping watchers while the old PTYs are still alive is harmless:
-   the worker's next poll sees `running = false` and exits cleanly.
-8. **Park** every live session — for each id in
-   `store.load_sessions()`, call `metrics.stop(&id)`, drop any
-   `pending_spawn` entry, and best-effort `pool.kill(&id)`. The
-   persisted record (`sessions.json`, `last_open_sessions`,
-   `tab_order`, `active_session_id`) is **left untouched** so the
-   later switch-back can revive the session via `restore_all_sessions`
-   without the user losing tab state or AI conversation context
-   (Claude/Copilot `--resume` is spliced at restore-spawn time per
-   §5.5). This is best-effort: a failed `pool.kill` only leaks a
+   and both `switch_lock` write guard and `switch_pending` counter
+   release. This is the **asymmetric counterpart** to
+   `boot_select_workspace`, which tolerates the same failure because
+   boot is one-shot and the user can restart; mid-session switching
+   cannot leave the backend bound to a workspace whose `config.json`
+   reports `workspaceRoot: null`, because the post-switch frontend
+   rehydrate would then fall back to the first-boot picker even though
+   the swap had already committed — a self-contradictory state with no
+   clean recovery.
+6. **Drain the AI-discovery callback channel.** `pending_spawn.clear()`
+   drops any deferred-spawn entry queued by the old workspace's
+   restore, then `metrics.stop_all_and_join()` stops AND joins every
+   metrics watcher thread. After this returns, no AI-session-discovery
+   callback for an old session can fire again. Under the write guard
+   no resize-deferred-spawn / restore can be in flight (their read
+   guards have all dropped before our `write().await` resolved), so
+   the join is deterministic, and no new watchers can be armed until
+   we drop the write guard at function exit.
+7. **Park** every live session — for each id in `store.load_sessions()`,
+   drop any `pending_spawn` entry and best-effort `pool.kill(&id).await`.
+   `pool.kill` sets `killed=true` (so `pty_wait_loop` skips its final
+   status emit, see `pty_pool.rs`), awaits the bounded drain task, and
+   joins the wait thread before returning — draining the PTY-status
+   callback channel as a side effect. Park does **not** re-`stop` the
+   per-session metrics watcher; step 6's `stop_all_and_join` already
+   handled them, and under the write guard no new watcher can be armed
+   between step 6 and step 7. The persisted record (`sessions.json`,
+   `last_open_sessions`, `tab_order`, `active_session_id`) is **left
+   untouched** so a later switch-back can revive the session via
+   `restore_all_sessions` without losing tab state or AI conversation
+   context (Claude/Copilot `--resume` is spliced at restore-spawn time
+   per §5.5). Park is best-effort: a failed `pool.kill` only leaks a
    child PTY whose record stays in the store and will be re-spawned
    (and the orphan PTY harmlessly exits when the kernel reaps it on
    process exit). No abort path is needed because no irreversible
    store mutation happens here.
-9. Clear the in-memory `pending_spawn` map (defence-in-depth against
-   anything inserting between step 7 and here; nothing does today)
-   and reset the `restored` atomic so the new workspace's
+8. Reset the `restored` atomic so the new workspace's
    `restore_all_sessions` can fire when the frontend re-issues
    `frontend_ready`.
-10. Atomically swap the `WorkspaceScope` (under `Arc<RwLock>`). The OLD
-    `WorkspaceLockGuard` inside the old scope is dropped at this
-    assignment, releasing the OS lock on the old workspace.
-11. **Best-effort post-swap hint write.** Persist
+9. Atomically swap the `WorkspaceScope` (under `Arc<RwLock>`). The OLD
+   `WorkspaceLockGuard` inside the old scope is dropped at this
+   assignment, releasing the OS lock on the old workspace. Steps 6 and
+   7 ensured the only callbacks that could still fire are post-emit
+   Tauri event deliveries to the JS side (handled by the
+   `NotFound`-tolerant store re-resolution in `commands::mod`).
+10. **Best-effort post-swap hint write.** Persist
     `branches/<branch>/last-workspace.json` (or the canonical
     `last-workspace.json` for a `main` build) via `write_hint`. The
     hint is only consulted at the *next* process boot to skip the
     picker; failure is logged and ignored. The single-source-of-truth
-    `workspaceRoot` was already persisted in step 6 above, so the
+    `workspaceRoot` was already persisted in step 5 above, so the
     post-switch frontend rehydrate is correct regardless of whether
     this hint lands.
-12. Lift `switch_in_progress` (`GateGuard::disarm`) and emit
-    `workspace://changed { workspaceRoot }`. Return
-    `{ workspaceRoot, noOp: false }`.
+11. Emit `workspace://changed { workspaceRoot }` and return
+    `{ workspaceRoot, noOp: false }`. Returning drops both guards
+    (write lock + `switch_pending` decrement), allowing queued
+    lifecycle handlers to proceed against the new scope.
 
 The frontend treats `workspace://changed` as authoritative — it does not
 re-derive scope from any other event. Sessions belonging to the old
@@ -669,7 +703,7 @@ All commands are gated by Tauri capability declarations in `capabilities/main.js
 | `instructions_list` | — | `InstructionSet[]` | List available instruction sets from `instructionSetsDir` |
 | `worktrees_list` | `{ repoRoot: string }` | `WorktreeInfo[]` | Enumerate git worktrees rooted at `repoRoot`. Implemented via the injectable `GitRunner` seam (production: `git worktree list --porcelain`, parsed in `src-tauri/src/git.rs`). **Always returns `Ok(vec![])` on failure** — git missing, repo_root not a directory, repo_root is not a git repository, or any IO/parse error degrades to an empty list (logged with `code="GitUnavailable"`) so the UI's "Browse…" fallback is never blocked by an error toast. `WorktreeInfo = { path, branch?, isMain, isLocked }`. |
 | `workspace_validate` | `{ path: string }` | `{ valid: boolean, error?: string, alreadyOpenInAnotherInstance?: boolean }` | Validate a candidate workspace root for the first-boot picker (Roadmap §1.1) and the in-app workspace switcher (§5.5c). Returns `valid: true` only when `path` is an absolute, existing directory that is a **primary git repository root** — i.e. `git -C <path> rev-parse --show-toplevel` equals `path` itself **AND** `<path>/.git` is a *directory*. Linked git worktrees (where `.git` is a *file* containing `gitdir: <path-into-primary>`) and submodule working trees are explicitly rejected, because Arborist's session model spawns child worktrees from a primary repo root and a linked worktree cannot host its own worktrees (`git worktree add` from inside one fails). Subdirectories of a repo are also rejected (toplevel != path). On failure, `error` carries a short human-readable reason (`"path is not an absolute directory"`, `"not a git repository"`, `"path is a linked git worktree, not a primary repository root"`, `"path must be the repository root (...)"`, …). Never throws an `AppError` for the "invalid" case — the picker shows inline feedback. The same rules are enforced at boot by `crate::boot::validate_repo_root`; the two MUST stay in sync. **`alreadyOpenInAnotherInstance` is an advisory contention probe** (set only when the caller can supply an `app_data_dir` — i.e. the public Tauri command path; internal in-app callers pass `None` and leave the field as `undefined`). When set, it is the result of a non-destructive `WorkspaceLockGuard::probe` against the per-(branch, workspace) `.lock` file: `true` ⇒ another Arborist instance is currently bound here, `false` ⇒ free at probe time, `undefined` ⇒ no probe was performed. The signal is purely advisory — there is an inherent race window between probe and the authoritative acquire performed by `bind_workspace`/`workspace_switch`. The picker MUST render this as a warning and NOT a hard block; persistent contention surfaces later as a `WorkspaceLocked` error from the acquire. |
-| `workspace_switch` | `{ path: string }` | `{ workspaceRoot: string, noOp: boolean }` | Atomically swap the running process from the current (branch, workspace) pair to the new one identified by `path` (§5.5c). The full transaction (validate → no-op fast path → flip switch-in-progress gate → acquire new lock → **persist `workspaceRoot` into new `config.json` (aborts switch on failure)** → quiesce metrics watchers + drain pending-spawn under `deferred_spawn_quiesce` write guard → **park** old sessions (kill PTYs but preserve every persisted record) → reset restore gate → swap `WorkspaceScope` → best-effort persist hint → emit `workspace://changed`) runs under a single `tokio::sync::Mutex` so concurrent calls are serialised. Returns `noOp: true` (no event emitted, no work done) when `path` canonicalises to the currently bound root. Returns `WorkspaceLocked` on lock-contention with the old workspace still bound; the frontend should surface this as a hard error. On success (`noOp: false`), the frontend listens for `workspace://changed`, re-hydrates `configStore` + `sessionStore`, and re-issues `frontend_ready` to drive `restore_all_sessions` against the new workspace. **Park semantics**: the old workspace's `sessions.json`, `last_open_sessions`, `tab_order`, and `active_session_id` are left untouched, so a later switch-back resurrects every session at its previous position with Claude/Copilot `--resume` keeping AI conversation context alive (§5.5c step 8). |
+| `workspace_switch` | `{ path: string }` | `{ workspaceRoot: string, noOp: boolean }` | Atomically swap the running process from the current (branch, workspace) pair to the new one identified by `path` (§5.5c). The full transaction (validate → no-op fast path → acquire new lock → **persist `workspaceRoot` into new `config.json` (aborts switch on failure)** → drain AI-discovery callbacks (`metrics.stop_all_and_join`) → **park** old sessions (`pool.kill` drains PTY-status callbacks; persisted records are preserved) → reset restore gate → swap `WorkspaceScope` → best-effort persist hint → emit `workspace://changed`) runs under a `tokio::sync::RwLock<()>` write guard (`switch_lock`) held for the entire function body, paired with an `AtomicUsize` counter (`switch_pending`) bumped before the lock is awaited. The pair quiesces in-flight workspace-mutating handlers before the swap and rejects new ones with `WorkspaceSwitchInProgress` for the duration; concurrent switches queue serially on the write side. Returns `noOp: true` (no event emitted, no work done) when `path` canonicalises to the currently bound root. Returns `WorkspaceLocked` on lock-contention with the old workspace still bound; the frontend should surface this as a hard error. On success (`noOp: false`), the frontend listens for `workspace://changed`, re-hydrates `configStore` + `sessionStore`, and re-issues `frontend_ready` to drive `restore_all_sessions` against the new workspace. **Park semantics**: the old workspace's `sessions.json`, `last_open_sessions`, `tab_order`, and `active_session_id` are left untouched, so a later switch-back resurrects every session at its previous position with Claude/Copilot `--resume` keeping AI conversation context alive (§5.5c step 7). |
 | `worktree_create` | `{ name: string }` | `{ path: string }` | Create a new linked worktree at `<workspaceRoot>/.worktrees/<name>` on a fresh branch named `<name>` (Roadmap §2.2). Requires `workspaceRoot` to be set in `AppConfig`; errors with `NotFound` otherwise. The `name` is re-validated server-side via the same rules as `validateWorktreeName` (no spaces; no `..`, `~`, `^`, `:`, `?`, `*`, `[`, `\\`; cannot start/end with `.` or `/`; cannot end with `.lock`; cannot be `@`; 1–255 chars); `InvalidPath` is returned for any rule violation. Runs `git -C <workspaceRoot> worktree add .worktrees/<name> -b <name>` via the injected `GitRunner`; bubbles up the captured stderr in the `Internal` error message on git failure. Returns the canonical absolute path to the new worktree directory. |
 
 > **Test-only seam.** The Rust backend consults two env vars,
@@ -690,7 +724,7 @@ All commands are gated by Tauri capability declarations in `capabilities/main.js
 | `session://status` | `{ sessionId, status }` | Notify session state changes (including `'error'`) |
 | `session://activity` | `{ sessionId, kind: 'title' \| 'attention' \| 'working' \| 'idle' \| 'promptStart' \| 'commandStart' \| 'commandEnd' \| 'turnStart' \| 'turnEnd' \| 'toolStart' \| 'toolEnd' \| 'awaitingPermission' \| 'permissionResolved', value?, exit?, durationMs?, toolName?, toolCallId?, success?, requestId?, permissionKind?, summary?, approved? }` | Per-session activity. Two sources: (1) the legacy PTY-byte scanner in `src-tauri/src/activity.rs` (OSC parsing + output byte-rate) emits `title`/`attention`/`working`/`idle`/`promptStart`/`commandStart`/`commandEnd` for **all** tools; (2) the Copilot `events.jsonl` tailer in `src-tauri/src/copilot_events.rs` emits the richer `turnStart`/`turnEnd`/`toolStart`/`toolEnd`/`awaitingPermission`/`permissionResolved` variants for Copilot sessions whose `ai_session_id` is known. The frontend reducer keeps both axes — they're additive; the `selectDisplayStatus` priority order is `error > starting > exited > awaitingPermission > attention > runningTool > thinking > working > awaiting > idle`. Best-effort & advisory — UI must degrade gracefully if a CLI emits nothing. |
 | `session://metrics` | `{ sessionId, model?, contextUsedPct?, contextTokensUsed?, contextTokensLimit?, inputTokens?, outputTokens?, observedAt }` | Per-session token usage / context-window utilization. Emitted by `src-tauri/src/session_metrics.rs`, which polls Claude's `~/.claude/projects/<encoded-cwd>/<sid>.jsonl` transcripts (heuristic cwd+mtime mapping) and extracts cumulative `usage` from the latest assistant turn. Claude-only in v1; Copilot tabs receive no events. Drives the compact second line on each sidebar tab. Best-effort & debounced — UI must degrade gracefully when no snapshot is present. |
-| `workspace://changed` | `{ workspaceRoot: string }` | Emitted at the end of a successful, non-no-op `workspace_switch` (§5.5c). Frontend listeners must treat the running process as freshly bound to `workspaceRoot`: re-hydrate `configStore` + `sessionStore`, then re-issue `frontend_ready` so `restore_all_sessions` runs against the new workspace. The backend serialises emits behind the same `switch_serialise` mutex that owns the swap, so listeners see exactly one event per successful switch. No event is emitted when the switch is a no-op (target equals current workspace). |
+| `workspace://changed` | `{ workspaceRoot: string }` | Emitted at the end of a successful, non-no-op `workspace_switch` (§5.5c). Frontend listeners must treat the running process as freshly bound to `workspaceRoot`: re-hydrate `configStore` + `sessionStore`, then re-issue `frontend_ready` so `restore_all_sessions` runs against the new workspace. The backend emits exactly one event per successful switch — the emit happens inside the same `switch_lock` write-guarded section that owns the swap, and the no-op fast path returns before any emit. No event is emitted when the switch is a no-op (target equals current workspace). |
 
 ### Plugin commands routed via the bridge
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -69,21 +69,16 @@ pub async fn config_get(app: tauri::AppHandle) -> Result<AppConfig, AppError> {
 /// Deep-merges `partial` into the persisted [`AppConfig`].
 ///
 /// Refused while a workspace switch is in progress — the swap relies on
-/// no new writes landing in the *old* store between the gate flip and
-/// the actual `WorkspaceScope` swap. See `AppContext::store` for the
-/// residual snapshot race that the gate alone cannot close.
+/// no new writes landing in the *old* store between the
+/// `switch_pending` bump and the actual `WorkspaceScope` swap. See
+/// [`AppContext::switch_lock`] for the full barrier protocol.
 #[tauri::command]
 pub async fn config_set(app: tauri::AppHandle, partial: PartialAppConfig) -> Result<(), AppError> {
     let ctx = ctx_of(&app)?;
-    if ctx
-        .switch_in_progress
-        .load(std::sync::atomic::Ordering::SeqCst)
-    {
-        return Err(AppError::new(
-            "WorkspaceSwitchInProgress",
-            "A workspace switch is in progress; retry once it completes.",
-        ));
-    }
+    // Take-then-check; matches `acquire_switch_read`. The guard is
+    // held across `save_config` so the switch's `write().await` waits
+    // for the persist to commit before swapping the workspace scope.
+    let _switch = session::acquire_switch_read(&ctx)?;
     ctx.store().save_config(partial).map_err(AppError::from)?;
     Ok(())
 }
@@ -130,25 +125,10 @@ pub async fn session_close(
     args: SessionCloseArgs,
 ) -> Result<SessionCloseResult, AppError> {
     let ctx = ctx_of(&app)?;
-    // Refuse user-initiated close while a workspace switch is in
-    // progress. Without this gate, a frontend-issued close can run
-    // concurrently with the switch's own step-7 close loop; the two
-    // load-then-mutate sequences against the old store can lose
-    // updates to `tab_order` / `active_session_id` (the per-store
-    // write-mutex serialises file writes, but not the read-modify-
-    // write computation each `_impl` does between snapshot and
-    // save). Gated at the wrapper so the switch's *internal* calls
-    // to `session::session_close_impl` are not blocked by their own
-    // gate.
-    if ctx
-        .switch_in_progress
-        .load(std::sync::atomic::Ordering::SeqCst)
-    {
-        return Err(AppError::new(
-            "WorkspaceSwitchInProgress",
-            "A workspace switch is in progress; retry once it completes.",
-        ));
-    }
+    // Workspace-switch rejection lives inside `session_close_impl` (it
+    // takes a `try_read()` on `AppContext::switch_lock` for the full
+    // body, including across `pool.kill().await`). Kept thin here so
+    // the impl is the single source of truth for the gating policy.
     session::session_close_impl(&ctx, args.session_id, args.delete_worktree).await
 }
 
@@ -193,28 +173,62 @@ pub async fn session_restart(
 /// resize-arrives-before-restore race would silently drop the deferred
 /// spawn (`pool.resize` → `NotFound`), leaving the session stuck in
 /// `Starting` with no PTY child.
+///
+/// **Workspace-switch coordination.** We acquire an
+/// `OwnedRwLockReadGuard` on [`AppContext::switch_lock`] and move it
+/// into the `spawn_blocking` task that runs `restore_all_sessions`.
+/// This bounds the entire restore loop by the same barrier that gates
+/// every other workspace-mutating handler: a switch's `write().await`
+/// cannot proceed until restore returns. We additionally check
+/// [`AppContext::switch_pending`] both before and after taking the
+/// owned guard (matching [`session::acquire_switch_read`]'s ordering)
+/// because tokio's `try_read_owned` is permit-based and does NOT
+/// reject when a writer is queued behind active readers — the counter
+/// is what closes that gap. On a negative outcome we silently
+/// `Ok(())` so the frontend can re-issue after the
+/// `workspace://changed` event.
 #[tauri::command]
 pub async fn frontend_ready(app: tauri::AppHandle) -> Result<(), AppError> {
     let ctx = ctx_of(&app)?;
-    if session::frontend_ready_impl(&ctx) {
-        let ctx_for_task = Arc::clone(&ctx);
-        // `restore_all_sessions` no longer spawns PTYs (it only does
-        // disk IO + HashMap inserts), so the work is bounded — but we
-        // still run it on a blocking thread because materialise_temp_files
-        // / cleanup_orphans / store IO can block. We *await* completion
-        // here so the resolution of `frontend_ready` becomes a
-        // happens-before edge for the frontend's first `session_resize`.
-        tauri::async_runtime::spawn_blocking(move || {
-            session::restore_all_sessions(&ctx_for_task);
-        })
-        .await
-        .map_err(|join_err| {
-            AppError::new(
-                "Internal",
-                format!("restore_all_sessions task panicked: {join_err}"),
-            )
-        })?;
+    // Pre-check: cheap atomic load avoids touching the lock during a
+    // switch.
+    if ctx.switch_pending.load(std::sync::atomic::Ordering::SeqCst) > 0 {
+        return Ok(());
     }
+    let switch_guard = match Arc::clone(&ctx.switch_lock).try_read_owned() {
+        Ok(g) => g,
+        Err(_) => return Ok(()),
+    };
+    // Post-check: closes the take-then-set race the same way
+    // `acquire_switch_read` does. See [`AppContext::switch_lock`].
+    if ctx.switch_pending.load(std::sync::atomic::Ordering::SeqCst) > 0 {
+        return Ok(());
+    }
+    if !session::frontend_ready_impl(&ctx) {
+        // Already restored — drop guard and return.
+        return Ok(());
+    }
+    let ctx_for_task = Arc::clone(&ctx);
+    // `restore_all_sessions` no longer spawns PTYs (it only does
+    // disk IO + HashMap inserts), so the work is bounded — but we
+    // still run it on a blocking thread because materialise_temp_files
+    // / cleanup_orphans / store IO can block. We *await* completion
+    // here so the resolution of `frontend_ready` becomes a
+    // happens-before edge for the frontend's first `session_resize`.
+    tauri::async_runtime::spawn_blocking(move || {
+        // Move the owned switch read guard into the closure so it
+        // stays held for the full restore loop. Dropped when the
+        // closure returns.
+        let _switch = switch_guard;
+        session::restore_all_sessions(&ctx_for_task);
+    })
+    .await
+    .map_err(|join_err| {
+        AppError::new(
+            "Internal",
+            format!("restore_all_sessions task panicked: {join_err}"),
+        )
+    })?;
     Ok(())
 }
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -22,7 +22,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -97,37 +97,127 @@ pub struct AppContext {
     /// lock as the membership check, which a `RwLock` cannot give us
     /// atomically.
     pub pending_spawn: Arc<Mutex<HashMap<SessionId, Session>>>,
-    /// Phase 7 in-app workspace switch — serialises concurrent
-    /// `workspace_switch` invocations so the close-all + bind + swap
-    /// pipeline cannot interleave with itself. Held across `.await`s
-    /// inside `workspace_switch_impl`, hence `tokio::sync::Mutex`.
-    pub switch_serialise: tokio::sync::Mutex<()>,
-    /// Phase 7 in-app workspace switch — set to `true` while a switch
-    /// is mid-pipeline (after `switch_serialise` is acquired and before
-    /// the swap commits). Other workspace-mutating commands
-    /// (`session_create`, `session_restart`, `frontend_ready`) check
-    /// this flag and return [`AppError::WorkspaceSwitchInProgress`]
-    /// if set. Read-only / per-session commands (`session_input`,
-    /// `session_resize`, `session_close`) intentionally pass — they
-    /// must succeed during teardown so the close-all loop in the
-    /// switch can complete, and they cannot create *new* orphan state.
-    pub switch_in_progress: AtomicBool,
-    /// Quiesce barrier for [`session_resize_impl`]'s deferred-spawn
-    /// branch. Held as a **read** guard for the duration of the claim,
-    /// `pool.spawn`, and `metrics.start` block; held as a **write**
-    /// guard by [`workspace_switch_impl_inner`] across the
-    /// `pending_spawn` drain and `metrics.stop_all_and_join` so the
-    /// switch can be sure no in-flight deferred spawn will register a
-    /// new metrics watcher *after* it has joined the registry. Without
-    /// this barrier, a `session_resize` that claimed a pending entry
-    /// just before the gate flipped (`switch_in_progress = true`)
-    /// could finish its `metrics.start(...)` *after* the switch's
-    /// `stop_all_and_join`, leaking a watcher past the workspace swap
-    /// (see the residual #2 mitigation on [`Self::store`]). The
-    /// [`RwLock`] lets multiple concurrent deferred spawns proceed in
-    /// parallel; only the switch (rare) waits for all of them to
-    /// complete before draining.
-    pub deferred_spawn_quiesce: Arc<RwLock<()>>,
+    /// **Workspace-switch barrier — quiesce side** (Phase 7).
+    ///
+    /// Used in tandem with [`Self::switch_pending`]. Together the pair
+    /// answers two questions a workspace-mutating handler must resolve
+    /// before touching `ctx.store()`:
+    ///
+    /// 1. *Is a switch about to swap the scope out from under me?*
+    ///    → consult `switch_pending`.
+    /// 2. *Once I have decided to proceed, can the switch wait for me
+    ///    to finish before it swaps?*
+    ///    → hold a `try_read()` guard on `switch_lock` for my full body.
+    ///
+    /// Why both are needed:
+    ///
+    /// * `switch_lock` (this field) — `tokio::sync::RwLock<()>`. The
+    ///   switch acquires `write().await` and holds it for the entire
+    ///   pipeline. The `write().await` waits for every reader to drop
+    ///   before it proceeds, which **quiesces** in-flight handlers /
+    ///   restore / resize-deferred-spawn before the swap, the
+    ///   `metrics.stop_all_and_join` drain, and the
+    ///   `pending_spawn.clear` run. Concurrent switches queue serially
+    ///   on the write side via tokio's FIFO waker queue, so we get
+    ///   serialisation for free.
+    /// * [`Self::switch_pending`] — `AtomicUsize` counter, incremented
+    ///   immediately *before* the switch awaits the write lock and
+    ///   decremented when its RAII guard drops. We need a counter
+    ///   separate from the lock itself because tokio's
+    ///   `RwLock::try_read` is permit-based and does NOT honour
+    ///   writer-preferring fairness for non-awaiting callers — a
+    ///   queued writer behind active readers does not bump out new
+    ///   `try_read` calls. Without the counter, a handler issued
+    ///   between "switch task spawned" and "switch's write().await
+    ///   resolved" could acquire `try_read` successfully, complete a
+    ///   mutation against the soon-to-be-discarded old store, and
+    ///   silently lose the user's write. The counter lets handlers
+    ///   detect the queued switch and bail out.
+    ///
+    /// Per-handler gating policy:
+    ///
+    /// * **Workspace-scoped lifecycle handlers** (`session_create`,
+    ///   `session_close`, `session_restart`, `session_focus`,
+    ///   `config_set`) call [`acquire_switch_read`] at impl entry —
+    ///   it takes the read guard, then checks `switch_pending`. If the
+    ///   counter is non-zero (or the read guard cannot be acquired),
+    ///   return [`AppError::WorkspaceSwitchInProgress`] so the user
+    ///   sees the failure and can retry. Otherwise hold the guard for
+    ///   the **full impl body** (including across `.await` for async
+    ///   impls — tokio guards are `Send` for `T: Send + Sync`) so the
+    ///   switch cannot start swapping mid-handler.
+    /// * **`session_resize` and `frontend_ready`** apply the same
+    ///   take-then-check pattern but return `Ok(())` silently on a
+    ///   negative outcome. There is no useful error to surface — the
+    ///   next `ResizeObserver` fire (resize) or `workspace://changed`
+    ///   round-trip (frontend_ready) re-issues the call against the
+    ///   new scope, and a "switch in progress" toast for an
+    ///   automatically-issued background command would be noise.
+    /// * **`restore_all_sessions`** (called from `frontend_ready`'s
+    ///   wrapper inside `spawn_blocking`) inherits an
+    ///   `OwnedRwLockReadGuard` moved into the task, so the entire
+    ///   restore loop is bounded by the same barrier — a switch
+    ///   cannot start swapping while restore is mid-iteration.
+    /// * **`session_input`** is intentionally ungated — it operates by
+    ///   id on the PTY pool (workspace-agnostic), and writes to a PTY
+    ///   about to be parked are benign (the bytes go to a soon-killed
+    ///   child). Gating would impose lock contention on every
+    ///   keystroke for no correctness benefit.
+    /// * **Read-only commands** (`session_list`, `config_get`,
+    ///   `instructions_list`) are ungated — they see a consistent
+    ///   `ctx.store()` snapshot for the duration of one call, which is
+    ///   all the consistency they owe their caller.
+    ///
+    /// **Lock ordering / no deadlock cycles.** `switch_lock` is the
+    /// outermost lock taken by every gated handler. Inner locks
+    /// (`workspace`, `pending_spawn`, per-store `write_lock`) are
+    /// taken briefly inside handler bodies and never re-acquire
+    /// `switch_lock`. Concurrent switches queue serially on the write
+    /// side; readers and writers never form cycles.
+    ///
+    /// **Background callbacks** (PTY status, AI-session discovery)
+    /// fire from worker threads outside the request handler chain and
+    /// remain outside this barrier — gating them would require a lock
+    /// acquisition on every PTY byte. Instead they re-resolve the
+    /// current store on every invocation and tolerate `NotFound` from
+    /// a swapped-out store (see `commands::mod::build_production_sink`
+    /// and `build_production_ai_session_discover`). The switch drains
+    /// them deterministically before swapping (see steps 6 and 7 of
+    /// `workspace_switch_impl_inner`) so the only callbacks that can
+    /// fire post-swap are post-emit Tauri event deliveries to the JS
+    /// side, which the `NotFound` tolerance handles cleanly.
+    pub switch_lock: Arc<tokio::sync::RwLock<()>>,
+    /// **Workspace-switch barrier — rejection counter** (Phase 7).
+    /// See [`Self::switch_lock`] for why a counter separate from the
+    /// lock itself is necessary.
+    ///
+    /// Incremented **before** `workspace_switch_impl_inner` awaits the
+    /// write lock; decremented by [`SwitchPendingGuard::drop`] on any
+    /// exit (normal return, early return, panic). Handlers load this
+    /// counter under their read guard to detect a queued switch and
+    /// reject (or silently `Ok` for resize/frontend_ready).
+    pub switch_pending: Arc<AtomicUsize>,
+}
+
+/// RAII counter for [`AppContext::switch_pending`]. Increments on
+/// `new`, decrements on drop. Held by `workspace_switch_impl_inner`
+/// for the entire pipeline so any concurrent handler that loads the
+/// counter sees a non-zero value and rejects. Drop on panic
+/// guarantees the counter cannot get stuck above zero and lock the
+/// app out of all workspace-mutating commands.
+pub(crate) struct SwitchPendingGuard(Arc<AtomicUsize>);
+
+impl SwitchPendingGuard {
+    fn new(counter: Arc<AtomicUsize>) -> Self {
+        counter.fetch_add(1, Ordering::SeqCst);
+        Self(counter)
+    }
+}
+
+impl Drop for SwitchPendingGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
 }
 
 impl AppContext {
@@ -204,9 +294,8 @@ impl AppContext {
             ai_session_discover,
             turn_emit,
             pending_spawn: Arc::new(Mutex::new(HashMap::new())),
-            switch_serialise: tokio::sync::Mutex::new(()),
-            switch_in_progress: AtomicBool::new(false),
-            deferred_spawn_quiesce: Arc::new(RwLock::new(())),
+            switch_lock: Arc::new(tokio::sync::RwLock::new(())),
+            switch_pending: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -232,63 +321,17 @@ impl AppContext {
     /// across a downstream operation — call this once per command,
     /// then operate on the returned owned handle.
     ///
-    /// **Residual snapshot race (documented, partially mitigated).**
-    /// Because the returned [`ConfigStore`] is an owned clone, the
-    /// per-store `write_lock: Arc<Mutex<()>>` it carries is *unique to
-    /// the old store*: it does not serialise against the new store
-    /// after a workspace swap. A handler that snapshots **before**
-    /// `switch_in_progress` is set can finish writing **after** the
-    /// swap, against the file path of the just-released old workspace.
-    /// The window is small (the file I/O between snapshot and `persist`
-    /// — microseconds to milliseconds) and the practical exposure in
-    /// v1 is limited because:
-    ///
-    ///   1. `session_create`, `session_restart`, `frontend_ready`,
-    ///      `session_focus`, `session_close`, and `config_set` are
-    ///      all gated on `switch_in_progress` — they refuse outright
-    ///      once the switch has flipped the gate.
-    ///   2. There is no in-app settings UI in v1 (SPEC §7), so
-    ///      user-driven `config_set` calls during a switch are rare.
-    ///   3. Sessions that were live in the old workspace are torn
-    ///      down by step 7 of [`workspace_switch_impl_inner`]; their
-    ///      writers are joined before the swap.
-    ///
-    /// **Known residual #1 — pre-snapshot write.** A write that
-    /// snapshotted *immediately before* the gate flip and is
-    /// mid-`persist` when the swap happens still races. The window
-    /// is the file I/O between snapshot and persist (microseconds
-    /// to milliseconds).
-    ///
-    /// **Known residual #2 — `session_resize` deferred-spawn race.**
-    /// `session_resize_impl` is intentionally *not* gated on
-    /// `switch_in_progress`: it fires on every UI resize and a hard
-    /// refusal would noisily break legitimate resizes during a switch.
-    /// Both arms of its deferred-spawn branch race the swap:
-    ///
-    ///   * The **failure** arm calls `update_session_status(..., Error,
-    ///     ...)` (rare; only when `pool.spawn` itself errors), which can
-    ///     land in the old store if the snapshot was taken before the
-    ///     gate flip. Mitigated by step 7 of the switch draining
-    ///     `pending_spawn` (no further deferred spawns can fire after
-    ///     the drain).
-    ///   * The **success** arm calls `metrics.start(...)` to register a
-    ///     new watcher. Without coordination, that registration could
-    ///     land *after* the switch's `metrics.stop_all_and_join`,
-    ///     leaking a watcher tied to the old workspace scope past the
-    ///     swap. Closed by [`Self::deferred_spawn_quiesce`]: resize
-    ///     holds a read guard across the entire spawn + `metrics.start`
-    ///     block; the switch holds a write guard across the drain +
-    ///     `stop_all_and_join`. The write guard cannot be acquired
-    ///     while any deferred spawn is in flight, so by the time
-    ///     `stop_all_and_join` runs every started watcher is in the
-    ///     registry and gets joined.
-    ///
-    /// A truly air-tight fix for both residuals is a workspace-wide
-    /// write barrier (e.g. an `Arc<RwLock<()>>` separate from the
-    /// scope, where every store-writing handler takes a read guard
-    /// for the duration of the write and the swap takes the write
-    /// guard before drop). That refactor is deliberately deferred —
-    /// see the follow-up tracked on this comment.
+    /// **Workspace-switch atomicity.** Workspace-mutating handlers
+    /// must call `store()` once at the top of their impl and operate
+    /// on the returned handle for the whole body. They must also be
+    /// holding a `switch_lock` read guard (acquired via
+    /// [`acquire_switch_read`]) for that same body, so the switch
+    /// cannot start its scope swap mid-handler. With both rules
+    /// followed, a handler's snapshot is guaranteed to still be the
+    /// current scope's store at every persist call — there is no
+    /// window where a handler can mutate a store that has just been
+    /// released by the switch. See [`Self::switch_lock`] for the full
+    /// barrier contract and the per-handler gating policy.
     ///
     /// Will `panic!` if the workspace lock is poisoned (which can only
     /// happen if a writer panicked mid-mutation; recovery is
@@ -336,7 +379,7 @@ pub fn session_create_impl(
     ctx: &AppContext,
     args: SessionCreateArgs,
 ) -> Result<SessionView, AppError> {
-    ensure_no_switch_in_progress(ctx)?;
+    let _switch = acquire_switch_read(ctx)?;
     validate_pty_dims(args.cols, args.rows)?;
 
     // 1. Validate worktree (canonicalises; rejects relative/missing).
@@ -539,6 +582,12 @@ pub async fn session_close_impl(
     id: SessionId,
     delete_worktree: bool,
 ) -> Result<SessionCloseResult, AppError> {
+    // Reject if a workspace switch is queued/active. Held for the full
+    // lifetime of this call (including across `pool.kill().await`) so
+    // the switch's `write().await` cannot proceed until our teardown
+    // completes against the old store. See [`AppContext::switch_lock`].
+    let _switch = acquire_switch_read(ctx)?;
+
     // 0. Stop the metrics watcher (Issue #3) before tearing the rest down
     //    so it never observes a half-cleaned session.
     ctx.metrics.stop(&id);
@@ -664,21 +713,27 @@ pub async fn session_close_impl(
 /// the key behavioural difference vs. `session_close_impl`, which
 /// destroys persisted state and therefore historically had to
 /// hard-fail the switch on partial close.
+///
+/// **Metrics watchers are stopped by the caller**, not here. By the
+/// time this runs, the switch has already acquired
+/// [`AppContext::switch_lock`] for write and called
+/// [`MetricsRegistry::stop_all_and_join`]. The write guard prevents
+/// any new watchers from being armed (every lifecycle handler / resize
+/// deferred-spawn has either drained their read guard before the
+/// switch acquired write, or is rejected outright by `try_read`), so
+/// a per-session `metrics.stop` here would be unconditionally a no-op.
 async fn park_session_for_switch_impl(ctx: &AppContext, id: SessionId) {
-    // 1. Stop the metrics watcher (mirrors session_close_impl step 0
-    //    and step 6 of workspace_switch which already drained all
-    //    watchers up front; this is belt-and-braces for any watcher
-    //    that may have been re-armed between then and now).
-    ctx.metrics.stop(&id);
-
-    // 2. Drop any deferred-spawn registration so a stale resize for
+    // 1. Drop any deferred-spawn registration so a stale resize for
     //    this id can't trigger a phantom spawn against the new
-    //    (post-swap) workspace.
+    //    (post-swap) workspace. (Belt-and-braces: the switch's
+    //    write-guard step already cleared `pending_spawn`; this is
+    //    defense-in-depth against future code paths that might insert
+    //    after the drain.)
     if let Ok(mut g) = ctx.pending_spawn.lock() {
         g.remove(&id);
     }
 
-    // 3. Best-effort kill. Temp dir is removed by pool.kill itself
+    // 2. Best-effort kill. Temp dir is removed by pool.kill itself
     //    (step 6 inside pool::kill); restore re-materialises temp
     //    files from the persisted `Session.temp_files` so this is
     //    safe.
@@ -840,13 +895,12 @@ fn delete_worktree_after_close(
 // ---------------------------------------------------------------------------
 
 pub fn session_focus_impl(ctx: &AppContext, id: SessionId) -> Result<(), AppError> {
-    // Refuse during a workspace switch. Without the gate, a stale focus
-    // event from the frontend (e.g. user clicked a tab a moment before
-    // triggering a switch) could write `active_session_id` for a
-    // not-yet-torn-down old-workspace session into a snapshot of the
-    // *old* store that races the swap (see Issue 3 in the Phase 9
-    // review and the residual race documented on `AppContext::store`).
-    ensure_no_switch_in_progress(ctx)?;
+    // Reject if a workspace switch is queued/active. Without this, a
+    // stale focus event from the frontend (e.g. user clicked a tab a
+    // moment before triggering a switch) could write
+    // `active_session_id` for a not-yet-torn-down old-workspace
+    // session into a snapshot of the *old* store that races the swap.
+    let _switch = acquire_switch_read(ctx)?;
     let sessions = ctx.store().load_sessions();
     if !sessions.contains_key(&id) {
         return Err(AppError::from(Error::NotFound(format!(
@@ -873,6 +927,29 @@ pub fn session_resize_impl(ctx: &AppContext, args: SessionResizeArgs) -> Result<
         rows,
     } = args;
 
+    // Skip silently if a workspace switch is queued or active. The next
+    // `ResizeObserver` event after the switch completes will re-fire
+    // this resize against the new workspace's PTY (or a no-op if the
+    // session was parked); no error is propagated to the UI. Held for
+    // the full body so the deferred-spawn arm cannot interleave with
+    // the switch's `pending_spawn` drain or `metrics.stop_all_and_join`.
+    //
+    // **Pre-check**: cheap atomic load avoids the `try_read` permit
+    // dance during a switch (resize is hot-path; ResizeObservers can
+    // fire dozens of times in a switch window). **Post-check** (after
+    // taking the guard) closes the take-then-set race the same way
+    // [`acquire_switch_read`] does. See [`AppContext::switch_lock`].
+    if ctx.switch_pending.load(Ordering::SeqCst) > 0 {
+        return Ok(());
+    }
+    let _switch = match ctx.switch_lock.try_read() {
+        Ok(g) => g,
+        Err(_) => return Ok(()),
+    };
+    if ctx.switch_pending.load(Ordering::SeqCst) > 0 {
+        return Ok(());
+    }
+
     // Reject 0×0 up front. Without this, the deferred-spawn branch below
     // would forward zeros into `pool.spawn` and the live-resize branch
     // into `pool.resize`, both of which surface OS-level openpty/ioctl
@@ -895,21 +972,6 @@ pub fn session_resize_impl(ctx: &AppContext, args: SessionResizeArgs) -> Result<
     };
 
     if let Some(session) = pending {
-        // Quiesce barrier — see `AppContext::deferred_spawn_quiesce`.
-        // Held across the entire `pool.spawn` + `metrics.start` block
-        // so the workspace switch (which acquires the matching write
-        // guard) cannot run `stop_all_and_join` between our spawn and
-        // metrics.start, which would leak the watcher past the swap.
-        // Multiple concurrent deferred spawns hold read guards in
-        // parallel — the lock is contention-free for the common case.
-        // Forbidden re-entrant calls *inside* this block: anything that
-        // takes a write guard on `deferred_spawn_quiesce` (only
-        // workspace_switch_impl_inner does today) — if a future change
-        // adds one, this `read()` deadlocks.
-        let _quiesce = ctx
-            .deferred_spawn_quiesce
-            .read()
-            .map_err(|_| AppError::new("Internal", "deferred_spawn_quiesce poisoned"))?;
         let size = PtySize {
             cols,
             rows,
@@ -977,7 +1039,7 @@ pub fn session_input_impl(ctx: &AppContext, args: SessionInputArgs) -> Result<()
 // ---------------------------------------------------------------------------
 
 pub fn session_restart_impl(ctx: &AppContext, args: SessionRestartArgs) -> Result<(), AppError> {
-    ensure_no_switch_in_progress(ctx)?;
+    let _switch = acquire_switch_read(ctx)?;
     validate_pty_dims(args.cols, args.rows)?;
 
     let id = args.session_id;
@@ -1130,32 +1192,64 @@ pub fn session_restart_impl(ctx: &AppContext, args: SessionRestartArgs) -> Resul
 /// Idempotent: returns `true` if this call won the CAS and triggered the
 /// restore path, `false` if restore had already been kicked off.
 ///
-/// While a workspace switch is in progress (Phase 7), this returns
-/// `false` without touching the CAS — the frontend will re-issue
-/// `frontend_ready` after the `workspace://changed` event arrives, at
-/// which point the gate is open and the CAS can fire for the new
-/// workspace.
+/// **Workspace-switch coordination** is handled by the Tauri wrapper
+/// (`commands::frontend_ready`), not here: the wrapper takes an
+/// `OwnedRwLockReadGuard` on [`AppContext::switch_lock`] and moves it
+/// into the `spawn_blocking` task that runs [`restore_all_sessions`],
+/// so the entire restore loop is bounded by the same barrier as every
+/// other workspace-mutating handler.
 pub fn frontend_ready_impl(ctx: &AppContext) -> bool {
-    if ctx.switch_in_progress.load(Ordering::SeqCst) {
-        return false;
-    }
     ctx.restored
         .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
         .is_ok()
 }
 
-/// Phase 7 helper — refuse new-state-creating commands while a workspace
-/// switch is in progress. Returns the wire-shape `WorkspaceSwitchInProgress`
-/// error so the frontend can branch on it (typically: ignore + retry once
-/// the `workspace://changed` event arrives).
-fn ensure_no_switch_in_progress(ctx: &AppContext) -> Result<(), AppError> {
-    if ctx.switch_in_progress.load(Ordering::SeqCst) {
+/// Phase 7 helper — acquire a read guard on [`AppContext::switch_lock`]
+/// for handlers that must REJECT (with `WorkspaceSwitchInProgress`)
+/// when a workspace switch is queued or active. Used by
+/// `session_create`, `session_close`, `session_restart`,
+/// `session_focus`, and `config_set` impls.
+///
+/// The returned guard MUST be held for the full lifetime of any
+/// store-mutating, PTY-spawning, or metrics-arming work the handler
+/// performs — the switch's `write().await` waits for the guard to drop
+/// before commencing. Holding it past `.await`s is safe; tokio's
+/// `RwLockReadGuard<()>` is `Send + Sync`.
+///
+/// **Take-then-check ordering** (load-bearing). We take the read
+/// guard *before* checking `switch_pending`. Reasoning:
+///
+/// 1. If the switch hasn't yet incremented `switch_pending`, we
+///    acquire the guard and the switch's later `write().await`
+///    waits for our drop — no race.
+/// 2. If the switch already incremented `switch_pending` but hasn't
+///    yet acquired write (or we beat it to `try_read`), we take the
+///    guard, observe the non-zero counter, drop the guard, and reject.
+///    The brief held-then-dropped guard means the switch's
+///    `write().await` waits an extra moment for our drop, which is
+///    fine.
+///
+/// The reverse order (check-then-take) would have a race window
+/// between the load and the `try_read` where the switch could
+/// acquire write and the handler still see a stale "no pending"
+/// reading.
+pub(crate) fn acquire_switch_read(
+    ctx: &AppContext,
+) -> Result<tokio::sync::RwLockReadGuard<'_, ()>, AppError> {
+    let guard = ctx.switch_lock.try_read().map_err(|_| {
+        AppError::new(
+            "WorkspaceSwitchInProgress",
+            "A workspace switch is in progress; retry once it completes.",
+        )
+    })?;
+    if ctx.switch_pending.load(Ordering::SeqCst) > 0 {
+        drop(guard);
         return Err(AppError::new(
             "WorkspaceSwitchInProgress",
             "A workspace switch is in progress; retry once it completes.",
         ));
     }
-    Ok(())
+    Ok(guard)
 }
 
 /// Friendly UI message when a session's worktree directory is no longer
@@ -1278,11 +1372,11 @@ fn trim_unknown_session_refs_with_store(
 /// (post-swap) store, with the OLD session ids of the workspace we
 /// were restoring. The pinned snapshot keeps every write in this
 /// invocation aimed at the workspace whose `sessions` we loaded.
-/// Additionally, each iteration checks `switch_in_progress` and
-/// bails early so the new workspace's own `restore_all_sessions`
-/// (kicked off by the frontend re-issuing `frontend_ready` after
-/// the `workspace://changed` event) doesn't have to dodge stale
-/// `pending_spawn` inserts from this loop.
+/// **Workspace-switch coordination** is handled by the caller: the
+/// `frontend_ready` Tauri wrapper holds an `OwnedRwLockReadGuard` on
+/// [`AppContext::switch_lock`] for the full duration of this function,
+/// so a switch cannot start its scope swap until restore returns —
+/// the loop body itself does not need to consult any switch state.
 pub fn restore_all_sessions(ctx: &AppContext) {
     // Pin the store for the lifetime of this invocation — see fn doc
     // comment on workspace-binding stability.
@@ -1332,21 +1426,6 @@ pub fn restore_all_sessions(ctx: &AppContext) {
         .unwrap_or_default();
 
     for (id, session) in sessions {
-        // Bail if a workspace switch landed mid-loop — the new
-        // workspace's own restore will run when the frontend re-issues
-        // `frontend_ready` after the `workspace://changed` event, and
-        // any further work here would either silently no-op against
-        // the new store (since `id` won't exist there) or, worse, leak
-        // an old-workspace `pending_spawn` entry into the new binding
-        // (orphan map entry; self-healing on next switch but wasteful).
-        if ctx.switch_in_progress.load(Ordering::SeqCst) {
-            debug!(
-                session_id = %id,
-                "restore: workspace switch in progress; bailing out of restore loop",
-            );
-            return;
-        }
-
         if ctx.pool.contains(&id) || pending_ids.contains(&id) {
             debug!(session_id = %id, "restore: skipping already-live or already-pending session");
             continue;
@@ -1634,67 +1713,100 @@ pub fn workspace_validate_impl(
 // In-app workspace switch — transactional swap of the active
 // [`WorkspaceScope`] without restarting the process.
 //
+// Concurrency primitives used by this pipeline:
+// * [`AppContext::switch_pending`] (`AtomicUsize`) — bumped before
+//   the write lock is awaited; decremented when the
+//   `SwitchPendingGuard` drops at function return. This is what makes
+//   handlers' `try_read` rejections deterministic; see the rustdoc on
+//   [`AppContext::switch_lock`] for why tokio's writer-preferring
+//   fairness alone is insufficient.
+// * [`AppContext::switch_lock`] (`tokio::sync::RwLock<()>`) —
+//   acquired for write, held for the entire body. Quiesces in-flight
+//   handlers (their read guards must drop before our `write().await`
+//   resolves) and serialises concurrent switches.
+//
 // Pipeline:
-// 1. Acquire `switch_serialise` (so two concurrent switches cannot
-//    interleave their close-all + bind + swap steps).
+// 1. Bump `switch_pending` and acquire `switch_lock.write().await`.
+//    The counter is set BEFORE awaiting the lock so handlers issued
+//    after this point reject (with `WorkspaceSwitchInProgress`) or
+//    silently `Ok` (resize/frontend_ready) — see take-then-check in
+//    [`acquire_switch_read`] and the rustdoc on
+//    [`AppContext::switch_lock`] for why the counter is necessary in
+//    addition to the lock. The `write().await` then waits for any
+//    in-flight read guards (handlers whose work began before our
+//    bump) to drop before resolving — this is what makes the rest of
+//    the pipeline safe to run against an unobstructed scope. Both
+//    guards are held for the **entire** function body and drop at
+//    function return (success or error); concurrent switches queue
+//    serially on the write side via tokio's FIFO waker queue.
 // 2. Validate the new path is a real git-repository directory and
 //    canonicalise it. Reject early on any failure — no state mutated.
 // 3. No-op fast path: if the canonical new path equals the current
 //    workspace, return `{ no_op: true }` immediately. The existing
 //    binding stays valid; no event is emitted.
-// 4. Set `switch_in_progress = true` so [`session_create_impl`],
-//    [`session_restart_impl`], and [`frontend_ready_impl`] refuse new
-//    work while the switch is mid-pipeline.
-// 5. Acquire the OS lock + open `ConfigStore` for the new workspace
-//    via [`crate::boot::bind_workspace`]. While step 5 runs we hold
+// 4. Acquire the OS lock + open `ConfigStore` for the new workspace
+//    via [`crate::boot::bind_workspace`]. While step 4 runs we hold
 //    BOTH the old lock (inside the current `WorkspaceScope`) and the
 //    new lock (inside `WorkspaceBinding`). On
 //    [`crate::boot::BootError::Contention`] we abort the switch with
 //    `WorkspaceLocked` — the user stays on the current workspace.
-// 6. Persist `workspace_root` into the *new* store's `config.json`
+// 5. Persist `workspace_root` into the *new* store's `config.json`
 //    BEFORE the scope swap. If this write fails, abort cleanly:
-//    drop `binding` (releases the new OS lock), `gate`'s Drop
-//    clears `switch_in_progress`, and the old workspace remains
+//    drop `binding` (releases the new OS lock), the write guard's
+//    Drop releases `switch_lock`, and the old workspace remains
 //    bound. Doing this BEFORE the swap (rather than after) prevents
 //    the failure mode where the swap commits but the new store
 //    lacks `workspace_root`, which would make the post-switch
 //    rehydrate read `workspaceRoot: null` and pop the first-boot
 //    picker on top of an already-bound workspace.
-// 7. Quiesce concurrent `session_resize_impl` deferred-spawn blocks
-//    by acquiring the write guard on
-//    [`AppContext::deferred_spawn_quiesce`]; under that guard, drain
-//    `pending_spawn` (so future resizes can't claim) and call
-//    [`MetricsRegistry::stop_all_and_join`] (so every started watcher
-//    is in the registry and gets joined). This is BEFORE the
-//    per-session park in step 8 because `park_session_for_switch_impl`
-//    calls `metrics.stop()` per session, which **removes** the handle
-//    from the registry — if we joined first, the per-session stop
-//    would find nothing left and worker threads could outlive the
-//    swap.
-// 8. Quiesce the old workspace's sessions: enumerate from the *old*
-//    store, then [`park_session_for_switch_impl`] each. Park is
-//    best-effort (kills PTY, preserves the persisted record so a
-//    later switch-back can resurrect with `--resume`); failures are
-//    logged and swallowed.
-// 9. Defense-in-depth re-clear of `pending_spawn` (already drained in
-//    step 7) and reset `restored = false` so the new workspace's
+// 6. **Drain the AI-discovery callback channel.**
+//    `pending_spawn.clear()` drops any deferred-spawn entry queued
+//    by the old workspace's restore, then
+//    [`MetricsRegistry::stop_all_and_join`] stops AND joins every
+//    metrics watcher thread. After this returns, no AI-session-
+//    discovery callback for an old session can fire again. Under
+//    our write guard no resize-deferred-spawn / restore can be in
+//    flight (their read guards have all dropped before our
+//    `write().await` resolved), so the join is deterministic — and
+//    no new watchers can be armed until we drop the write guard at
+//    function exit.
+// 7. **Park** old workspace sessions — and, as a side effect, drain
+//    the PTY-status callback channel. We `pool.kill().await` per
+//    session: the kill sets `killed=true` (so the wait thread skips
+//    its final status emit, see `pty_pool::pty_wait_loop`), awaits
+//    the bounded drain task that pumps PTY output, and joins the
+//    wait thread before returning. After step 7 finishes, no PTY
+//    output / status callback for an old session can fire again. We
+//    **preserve** every session record (sessions.json,
+//    lastOpenSessions, tabOrder, activeSessionId untouched). When
+//    the user switches back to this workspace,
+//    [`restore_all_sessions`] re-spawns the PTYs from the persisted
+//    records — Claude/Copilot `--resume` splicing
+//    ([`compose::with_resume`]) keeps the AI conversation context
+//    alive across the round-trip. Park is *best-effort*: a failed
+//    `pool.kill` (rare; e.g. PTY already dead) is logged and
+//    ignored. There is no abort path because park performs zero
+//    irreversible store mutations.
+// 8. Reset `restored = false` so the new workspace's
 //    restore-on-launch can fire when the frontend re-issues
 //    `frontend_ready`.
-// 10. Swap [`AppContext::workspace`] under `RwLock` write — the old
-//     `WorkspaceLockGuard` inside the old scope is dropped here, in
-//     one atomic moment, releasing the OS lock on the old workspace.
-//     Other readers were unblocked from step 4 onward only in the no-
-//     op gate — during the swap itself, the very brief write lock
-//     blocks them.
-// 11. Best-effort: update the per-branch `last-workspace.json` hint
+// 9. Swap [`AppContext::workspace`] under `RwLock` write — the old
+//    `WorkspaceLockGuard` inside the old scope is dropped here, in
+//    one atomic moment, releasing the OS lock on the old workspace.
+//    Steps 6 and 7 ensured the only callbacks that *could* still
+//    fire are post-emit Tauri event deliveries to the JS side
+//    (handled by the `NotFound`-tolerant store re-resolution in
+//    `commands::mod::build_production_*`).
+// 10. Best-effort: update the per-branch `last-workspace.json` hint
 //     so the next launch resumes the new workspace by default.
-//     `workspace_root` was already persisted at step 6, so the
+//     `workspace_root` was already persisted at step 5, so the
 //     post-swap frontend rehydrate is correct regardless of whether
 //     this succeeds.
-// 12. Clear `switch_in_progress = false` and emit
-//     `workspace://changed`. The frontend reacts by re-fetching
+// 11. Emit `workspace://changed`. The frontend reacts by re-fetching
 //     config + sessions and re-issuing `frontend_ready` for the new
-//     workspace's restore.
+//     workspace's restore. Returning from the function drops both
+//     guards (write lock + `switch_pending` decrement), allowing
+//     queued lifecycle handlers to proceed against the new scope.
 
 /// Tauri-shaped wrapper around the inner switch implementation —
 /// converts the [`AppHandle`] into the testable seams the inner
@@ -1737,14 +1849,24 @@ pub async fn workspace_switch_impl_inner(
 ) -> Result<crate::types::WorkspaceSwitchResult, AppError> {
     use crate::types::{WorkspaceChangedEvent, WorkspaceSwitchResult};
 
-    // Step 1 — serialise concurrent switches.
-    let _serialise = ctx.switch_serialise.lock().await;
+    // Step 1 — bump `switch_pending` and acquire the workspace switch
+    // barrier for write. Held for the entire function body. The
+    // counter MUST be incremented *before* the `write().await` so
+    // concurrent `try_read`s in workspace-mutating handlers see a
+    // queued switch and reject (tokio's `RwLock::try_read` is
+    // permit-based and does NOT honour writer-preferring fairness for
+    // non-awaiting callers). The `SwitchPendingGuard` decrements on
+    // drop (normal return, early return, panic). Concurrent switches
+    // queue serially on the same `write().await`. See
+    // [`AppContext::switch_lock`].
+    let _pending_guard = SwitchPendingGuard::new(Arc::clone(&ctx.switch_pending));
+    let _switch = ctx.switch_lock.write().await;
 
     // Step 2 — validate + canonicalise. We re-use workspace_validate_impl
     // for parity with what the frontend already showed the user. Empty /
     // relative / non-dir / non-repo all turn into a clean error here.
     // Pass `None` for `app_data_dir` to skip the advisory contention
-    // probe — the authoritative lock acquire happens in step 5 anyway.
+    // probe — the authoritative lock acquire happens in step 4 anyway.
     let validate = workspace_validate_impl(ctx, new_path, None, branch)?;
     if !validate.valid {
         return Err(AppError::new(
@@ -1775,38 +1897,7 @@ pub async fn workspace_switch_impl_inner(
         });
     }
 
-    // Step 4 — flip the gate. From here until the explicit `disarm()`
-    // at the end of the success path, session_create / session_restart /
-    // session_focus / config_set / frontend_ready will refuse.
-    //
-    // The gate is wrapped in a small RAII guard so a *panic* inside any
-    // of the steps below — most plausibly inside a `session_close_impl`
-    // call in step 7, but also possible from the `expect()`s on poisoned
-    // workspace/pending_spawn locks — clears the gate on unwind. Without
-    // the guard, a panicked switch would leave the gate stuck `true`
-    // forever and every subsequent state-creating command would return
-    // `WorkspaceSwitchInProgress` until the user restarted the app.
-    struct GateGuard<'a>(&'a AtomicBool, bool);
-    impl<'a> GateGuard<'a> {
-        fn arm(flag: &'a AtomicBool) -> Self {
-            flag.store(true, Ordering::SeqCst);
-            Self(flag, true)
-        }
-        fn disarm(mut self) {
-            self.0.store(false, Ordering::SeqCst);
-            self.1 = false;
-        }
-    }
-    impl Drop for GateGuard<'_> {
-        fn drop(&mut self) {
-            if self.1 {
-                self.0.store(false, Ordering::SeqCst);
-            }
-        }
-    }
-    let gate = GateGuard::arm(&ctx.switch_in_progress);
-
-    // Step 5 — acquire OS lock + ConfigStore for the new workspace.
+    // Step 4 — acquire OS lock + ConfigStore for the new workspace.
     if let Err(e) = std::fs::create_dir_all(app_data_dir) {
         return Err(AppError::new(
             "Io",
@@ -1862,7 +1953,7 @@ pub async fn workspace_switch_impl_inner(
         }
     };
 
-    // Step 6 — persist `workspace_root` into the NEW workspace's
+    // Step 5 — persist `workspace_root` into the NEW workspace's
     // `config.json` BEFORE we commit the scope swap. If this write
     // fails, the post-switch frontend rehydrate would otherwise read
     // `workspaceRoot: null` from the new store and fall back to the
@@ -1875,7 +1966,7 @@ pub async fn workspace_switch_impl_inner(
     //   materialise on the new workspace.
     // * Old `WorkspaceScope` is still bound (we have not yet
     //   modified `ctx.workspace`).
-    // * `gate`'s Drop clears `switch_in_progress` so subsequent
+    // * `_switch`'s Drop releases the write guard so subsequent
     //   commands resume against the still-bound old workspace.
     //
     // This is the asymmetric counterpart to `boot_select_workspace`,
@@ -1890,41 +1981,20 @@ pub async fn workspace_switch_impl_inner(
         ));
     }
 
-    // Step 7 — quiesce metrics watchers and serialise against any
-    // in-flight `session_resize_impl` deferred-spawn block. The write
-    // guard on `deferred_spawn_quiesce` waits until every concurrent
-    // deferred spawn (read guard) has released, after which we know
-    // every started watcher is in the metrics registry and will be
-    // joined by `stop_all_and_join`. We hold the write guard across
-    // BOTH the `pending_spawn` drain and `stop_all_and_join` so any
-    // resize that arrives during the join either:
-    //   * (entered before us) has already registered + we'll join it; OR
-    //   * (entered after us) sees an empty `pending_spawn` and falls
-    //     through to `pool.resize` (which fails benignly with
-    //     `NotFound` once park has killed the PTY).
-    //
-    // We do this BEFORE `session_close` (in step 8 / park) so that the
-    // per-session `metrics.stop()` calls inside `park_session_for_switch_impl`
-    // don't drain the registry first (`stop()` removes the handle),
-    // leaving stop_all_and_join with nothing to join. Stopping watchers
-    // here while the old PTYs are still alive is harmless: the worker's
-    // next poll iteration sees `running = false` and exits cleanly.
-    {
-        let _quiesce = ctx
-            .deferred_spawn_quiesce
-            .write()
-            .map_err(|_| AppError::new("Internal", "deferred_spawn_quiesce poisoned"))?;
-        if let Ok(mut g) = ctx.pending_spawn.lock() {
-            g.clear();
-        }
-        ctx.metrics.stop_all_and_join();
+    // Step 6 — drain pending_spawn and join all metrics watchers.
+    // Under our write guard, no resize-deferred-spawn / restore /
+    // lifecycle handler can be in flight (every one of them either
+    // dropped its read guard before our `write().await` resolved, or
+    // is rejected outright by `try_read` while we hold this guard).
+    // So `stop_all_and_join` deterministically joins every armed
+    // worker, and no new watchers can be armed until we drop the
+    // write guard at function exit.
+    if let Ok(mut g) = ctx.pending_spawn.lock() {
+        g.clear();
     }
+    ctx.metrics.stop_all_and_join();
 
-    // Step 8 — quiesce old workspace sessions. Enumerate from the
-    // *current* store (still the old one until the swap in step 10).
-    // session_close_impl uses ctx.store() which clones from the old
-    // scope; safe.
-    // Step 8 — **park** old workspace sessions. We kill the PTYs but
+    // Step 7 — **park** old workspace sessions. We kill the PTYs but
     // **preserve** every session record (sessions.json, lastOpenSessions,
     // tabOrder, activeSessionId untouched). When the user switches back
     // to this workspace, restore_all_sessions will re-spawn the PTYs
@@ -1942,25 +2012,19 @@ pub async fn workspace_switch_impl_inner(
     // park, neither happens, so neither does the recovery.
     //
     // Enumerate from the *current* store (still the old one until the
-    // swap in step 10). park_session_for_switch_impl uses ctx.store()
+    // swap in step 9). park_session_for_switch_impl uses ctx.store()
     // which clones from the old scope; safe.
     let old_session_ids: Vec<SessionId> = ctx.store().load_sessions().keys().copied().collect();
     for id in old_session_ids {
         park_session_for_switch_impl(ctx, id).await;
     }
 
-    // Step 9 — reset the restore gate so the new workspace's
+    // Step 8 — reset the restore gate so the new workspace's
     // restore_all_sessions can fire when the frontend re-issues
-    // frontend_ready. `pending_spawn` was already drained under the
-    // quiesce write guard in step 7; this `clear()` is defense-in-depth
-    // against any code path that might insert into pending_spawn
-    // between step 7 and now (none today; park doesn't insert).
-    if let Ok(mut g) = ctx.pending_spawn.lock() {
-        g.clear();
-    }
+    // frontend_ready.
     ctx.restored.store(false, Ordering::SeqCst);
 
-    // Step 10 — swap WorkspaceScope. The OLD WorkspaceLockGuard inside
+    // Step 9 — swap WorkspaceScope. The OLD WorkspaceLockGuard inside
     // the old scope is dropped at this assignment, releasing the OS
     // lock on the old workspace.
     let new_scope = crate::boot::into_scope(binding);
@@ -1969,19 +2033,17 @@ pub async fn workspace_switch_impl_inner(
         *w = new_scope;
     }
 
-    // Step 11 — best-effort hint. `workspace_root` was already
-    // persisted at step 6, so the frontend rehydrate is correct
+    // Step 10 — best-effort hint. `workspace_root` was already
+    // persisted at step 5, so the frontend rehydrate is correct
     // regardless of whether this succeeds; the hint is only used at
     // the *next* process boot to skip the picker.
     if let Err(e) = crate::boot::write_hint(app_data_dir, branch, &canonical) {
         warn!(error = %e, "failed to persist last-workspace hint after switch; non-fatal");
     }
 
-    // Step 12 — open the gate and notify the frontend. `disarm()`
-    // explicitly clears the gate on the success path; if we panicked
-    // anywhere above, the GateGuard's Drop would have cleared it on
-    // unwind instead.
-    gate.disarm();
+    // Step 11 — notify the frontend. The write guard `_switch` is
+    // dropped at function return, allowing queued lifecycle handlers
+    // to proceed against the new scope.
     emit_changed(&WorkspaceChangedEvent {
         workspace_root: canonical.clone(),
     });

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -695,9 +695,9 @@ pub async fn session_close_impl(
 }
 
 /// **Park** an old-workspace session in preparation for a workspace
-/// switch. Tears down the live PTY (and ancillary metrics watcher,
-/// pending-spawn registration, temp-dir on disk) but **preserves
-/// every persisted record**: the entry in `sessions.json` stays put,
+/// switch. Tears down the live PTY (and the session's pending-spawn
+/// registration and temp-dir on disk) but **preserves every persisted
+/// record**: the entry in `sessions.json` stays put,
 /// `last_open_sessions` / `tab_order` / `active_session_id` are not
 /// touched. When the user switches back to this workspace,
 /// [`restore_all_sessions`] re-spawns the PTY from the unchanged
@@ -714,14 +714,16 @@ pub async fn session_close_impl(
 /// destroys persisted state and therefore historically had to
 /// hard-fail the switch on partial close.
 ///
-/// **Metrics watchers are stopped by the caller**, not here. By the
-/// time this runs, the switch has already acquired
+/// **Metrics watchers are NOT touched here — the caller has already
+/// stopped them.** By the time this runs, the switch has acquired
 /// [`AppContext::switch_lock`] for write and called
-/// [`MetricsRegistry::stop_all_and_join`]. The write guard prevents
-/// any new watchers from being armed (every lifecycle handler / resize
+/// [`MetricsRegistry::stop_all_and_join`] (step 6 of the pipeline,
+/// see `workspace_switch_impl_inner`). The write guard prevents any
+/// new watchers from being armed (every lifecycle handler / resize
 /// deferred-spawn has either drained their read guard before the
 /// switch acquired write, or is rejected outright by `try_read`), so
-/// a per-session `metrics.stop` here would be unconditionally a no-op.
+/// a per-session `metrics.stop` here would be unconditionally a no-op
+/// and is intentionally omitted.
 async fn park_session_for_switch_impl(ctx: &AppContext, id: SessionId) {
     // 1. Drop any deferred-spawn registration so a stale resize for
     //    this id can't trigger a phantom spawn against the new

--- a/src-tauri/tests/session_lifecycle_fake.rs
+++ b/src-tauri/tests/session_lifecycle_fake.rs
@@ -690,13 +690,17 @@ async fn resize_silently_skips_while_switch_write_held() {
     );
 }
 
-/// Regression for the rubber-duck's "queued-writer" finding: PR4's
-/// rejection semantics depend on tokio's writer-preferring `RwLock`
-/// fairness — once a writer is queued behind active readers, subsequent
-/// `try_read()` calls must fail. Simulate that exact scenario by
-/// holding a read guard, queueing a writer task, then asserting that
-/// gated handlers reject (or, for resize, silent-Ok) before letting the
-/// writer drain.
+/// Regression for the rubber-duck's "queued-writer" finding. The
+/// rejection contract here is the **`switch_pending` counter**, not
+/// tokio `RwLock` fairness alone: a queued writer does NOT bump out
+/// new `try_read()` calls (the lock is permit-based and `try_read`
+/// consults only the current permit count, not the wait queue), so
+/// the switch increments `switch_pending` *before* awaiting the write
+/// lock, and handlers detect the queued switch by loading the counter
+/// after taking their read guard (see `acquire_switch_read`). This
+/// test simulates that exact prologue: hold a read guard, spawn a
+/// task that bumps `switch_pending` and queues for write, then assert
+/// that gated handlers reject (and resize is silent-Ok).
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn lifecycle_handlers_refuse_when_switch_writer_is_queued() {
     let h = build_harness();
@@ -711,13 +715,12 @@ async fn lifecycle_handlers_refuse_when_switch_writer_is_queued() {
 
     // Spawn a task that mimics the *prologue* of
     // `workspace_switch_impl_inner`: bump `switch_pending` BEFORE
-    // awaiting the write lock, decrement on drop. This is the
-    // contract handlers actually rely on for rejection — tokio's
-    // `try_read` is permit-based and does NOT honour writer-preferring
-    // fairness for non-awaiting callers, so the counter is what closes
-    // the gap (see `AppContext::switch_lock` rustdoc).
+    // awaiting the write lock, decrement on drop. The task signals on
+    // `bumped_tx` immediately after the increment so the test can
+    // proceed deterministically — no sleeps, no fixed yield counts.
     let lock_for_writer = Arc::clone(&h.ctx.switch_lock);
     let pending_for_writer = Arc::clone(&h.ctx.switch_pending);
+    let (bumped_tx, bumped_rx) = tokio::sync::oneshot::channel::<()>();
     let (writer_done_tx, writer_done_rx) = tokio::sync::oneshot::channel::<()>();
     let writer_task = tokio::spawn(async move {
         pending_for_writer.fetch_add(1, Ordering::SeqCst);
@@ -728,18 +731,21 @@ async fn lifecycle_handlers_refuse_when_switch_writer_is_queued() {
             }
         }
         let _decr = Decr(pending_for_writer);
+        // Signal AFTER incrementing the counter but BEFORE awaiting
+        // the write lock. The send is synchronous, so by the time the
+        // test's `bumped_rx.await` resolves the counter is bumped and
+        // this task immediately suspends on `write().await` — the
+        // exact state the take-then-check contract is designed for.
+        let _ = bumped_tx.send(());
         let _w = lock_for_writer.write().await;
         let _ = writer_done_tx.send(());
     });
 
-    // Yield repeatedly so the writer task is polled on the other
-    // worker thread, bumps the pending counter, and registers itself
-    // as a queued waiter on the lock. We also sleep briefly to allow
-    // cross-thread scheduling on slower CI hardware.
-    for _ in 0..32 {
-        tokio::task::yield_now().await;
-    }
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    // Deterministic synchronisation point: writer task has bumped the
+    // counter and is now queued for write.
+    bumped_rx
+        .await
+        .expect("writer task signals after bumping switch_pending");
     assert_eq!(
         h.ctx.switch_pending.load(Ordering::SeqCst),
         1,

--- a/src-tauri/tests/session_lifecycle_fake.rs
+++ b/src-tauri/tests/session_lifecycle_fake.rs
@@ -592,15 +592,196 @@ async fn focus_updates_active_session_id_and_rejects_unknown() {
 async fn focus_refuses_while_workspace_switch_in_progress() {
     let h = build_harness();
     let v = session_create_impl(&h.ctx, create_args(&h)).unwrap();
-    h.ctx
-        .switch_in_progress
-        .store(true, std::sync::atomic::Ordering::SeqCst);
-    let err = session_focus_impl(&h.ctx, v.id).expect_err("must refuse mid-switch");
-    assert_eq!(err.code, "WorkspaceSwitchInProgress");
-    h.ctx
-        .switch_in_progress
-        .store(false, std::sync::atomic::Ordering::SeqCst);
+    {
+        // Simulate a queued/active workspace switch by holding the
+        // write guard on the unified switch barrier. Lifecycle
+        // handlers' `try_read()` then fails with TryLockError →
+        // `WorkspaceSwitchInProgress`.
+        let _w = h
+            .ctx
+            .switch_lock
+            .try_write()
+            .expect("switch_lock should be free in test");
+        let err = session_focus_impl(&h.ctx, v.id).expect_err("must refuse mid-switch");
+        assert_eq!(err.code, "WorkspaceSwitchInProgress");
+    }
     session_focus_impl(&h.ctx, v.id).expect("succeeds once gate clears");
+}
+
+/// Companion to `focus_refuses_…`. Each gated lifecycle handler must
+/// return `WorkspaceSwitchInProgress` while the unified switch barrier is
+/// write-held, then succeed once it drops. Covers the active-writer arm
+/// of the gate; the queued-writer arm is exercised separately below.
+#[tokio::test]
+async fn lifecycle_handlers_refuse_while_switch_write_held() {
+    let h = build_harness();
+    let v = session_create_impl(&h.ctx, create_args(&h)).unwrap();
+
+    {
+        let _w = h
+            .ctx
+            .switch_lock
+            .try_write()
+            .expect("switch_lock should be free in test");
+
+        // session_create
+        let err = session_create_impl(&h.ctx, create_args(&h)).expect_err("create must refuse");
+        assert_eq!(err.code, "WorkspaceSwitchInProgress");
+
+        // session_close (async; the impl takes the read guard internally)
+        let err = session_close_impl(&h.ctx, v.id, false)
+            .await
+            .expect_err("close must refuse");
+        assert_eq!(err.code, "WorkspaceSwitchInProgress");
+
+        // session_restart
+        let err = session_restart_impl(
+            &h.ctx,
+            SessionRestartArgs {
+                session_id: v.id,
+                cols: 80,
+                rows: 24,
+            },
+        )
+        .expect_err("restart must refuse");
+        assert_eq!(err.code, "WorkspaceSwitchInProgress");
+    }
+
+    // Once the switch guard drops, normal operation resumes.
+    session_restart_impl(
+        &h.ctx,
+        SessionRestartArgs {
+            session_id: v.id,
+            cols: 80,
+            rows: 24,
+        },
+    )
+    .expect("restart succeeds once gate clears");
+}
+
+/// `session_resize_impl` is the one gated handler that does **not**
+/// surface `WorkspaceSwitchInProgress` to the UI — it returns `Ok(())`
+/// silently and lets the next `ResizeObserver` event correct dimensions
+/// after the switch completes. Without this contract a flurry of
+/// resizes during a switch would spam error toasts (see PR4 design
+/// note in DESIGN §5.5c).
+#[tokio::test]
+async fn resize_silently_skips_while_switch_write_held() {
+    let h = build_harness();
+    let v = session_create_impl(&h.ctx, create_args(&h)).unwrap();
+
+    let _w = h
+        .ctx
+        .switch_lock
+        .try_write()
+        .expect("switch_lock should be free in test");
+
+    let res = session_resize_impl(
+        &h.ctx,
+        SessionResizeArgs {
+            session_id: v.id,
+            cols: 100,
+            rows: 30,
+        },
+    );
+    assert!(
+        res.is_ok(),
+        "resize during switch must return Ok(()) silently, got {res:?}",
+    );
+}
+
+/// Regression for the rubber-duck's "queued-writer" finding: PR4's
+/// rejection semantics depend on tokio's writer-preferring `RwLock`
+/// fairness — once a writer is queued behind active readers, subsequent
+/// `try_read()` calls must fail. Simulate that exact scenario by
+/// holding a read guard, queueing a writer task, then asserting that
+/// gated handlers reject (or, for resize, silent-Ok) before letting the
+/// writer drain.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn lifecycle_handlers_refuse_when_switch_writer_is_queued() {
+    let h = build_harness();
+    let v = session_create_impl(&h.ctx, create_args(&h)).unwrap();
+
+    // Take a read guard so writers must queue.
+    let read_guard = h
+        .ctx
+        .switch_lock
+        .try_read()
+        .expect("read guard available initially");
+
+    // Spawn a task that mimics the *prologue* of
+    // `workspace_switch_impl_inner`: bump `switch_pending` BEFORE
+    // awaiting the write lock, decrement on drop. This is the
+    // contract handlers actually rely on for rejection — tokio's
+    // `try_read` is permit-based and does NOT honour writer-preferring
+    // fairness for non-awaiting callers, so the counter is what closes
+    // the gap (see `AppContext::switch_lock` rustdoc).
+    let lock_for_writer = Arc::clone(&h.ctx.switch_lock);
+    let pending_for_writer = Arc::clone(&h.ctx.switch_pending);
+    let (writer_done_tx, writer_done_rx) = tokio::sync::oneshot::channel::<()>();
+    let writer_task = tokio::spawn(async move {
+        pending_for_writer.fetch_add(1, Ordering::SeqCst);
+        struct Decr(Arc<std::sync::atomic::AtomicUsize>);
+        impl Drop for Decr {
+            fn drop(&mut self) {
+                self.0.fetch_sub(1, Ordering::SeqCst);
+            }
+        }
+        let _decr = Decr(pending_for_writer);
+        let _w = lock_for_writer.write().await;
+        let _ = writer_done_tx.send(());
+    });
+
+    // Yield repeatedly so the writer task is polled on the other
+    // worker thread, bumps the pending counter, and registers itself
+    // as a queued waiter on the lock. We also sleep briefly to allow
+    // cross-thread scheduling on slower CI hardware.
+    for _ in 0..32 {
+        tokio::task::yield_now().await;
+    }
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(
+        h.ctx.switch_pending.load(Ordering::SeqCst),
+        1,
+        "writer task must have bumped switch_pending before we proceed",
+    );
+
+    // With a queued writer (and a non-zero `switch_pending`),
+    // lifecycle handlers must reject.
+    let err = session_focus_impl(&h.ctx, v.id).expect_err("queued writer must block focus");
+    assert_eq!(err.code, "WorkspaceSwitchInProgress");
+
+    let err =
+        session_create_impl(&h.ctx, create_args(&h)).expect_err("queued writer blocks create");
+    assert_eq!(err.code, "WorkspaceSwitchInProgress");
+
+    // …and resize is silently `Ok`.
+    let res = session_resize_impl(
+        &h.ctx,
+        SessionResizeArgs {
+            session_id: v.id,
+            cols: 90,
+            rows: 25,
+        },
+    );
+    assert!(
+        res.is_ok(),
+        "resize while writer queued must return Ok(()) silently, got {res:?}",
+    );
+
+    // Release the read guard and let the queued writer drain.
+    drop(read_guard);
+    tokio::time::timeout(Duration::from_secs(2), writer_done_rx)
+        .await
+        .expect("writer must acquire and release after readers drain")
+        .expect("writer task must signal completion");
+    writer_task.await.expect("writer task must complete");
+
+    // `switch_pending` is back to zero (the writer's `Decr` guard
+    // dropped). After the switch's writer finishes, lifecycle
+    // handlers succeed again.
+    assert_eq!(h.ctx.switch_pending.load(Ordering::SeqCst), 0);
+    session_focus_impl(&h.ctx, v.id).expect("focus succeeds once writer drains");
 }
 
 #[tokio::test]

--- a/src-tauri/tests/workspace_command.rs
+++ b/src-tauri/tests/workspace_command.rs
@@ -458,10 +458,14 @@ async fn workspace_switch_happy_path_swaps_and_emits() {
     let _re = WorkspaceLockGuard::acquire(old_layout.lock_path())
         .expect("old workspace lock must be free after switch");
 
-    // Switch gate is open again so subsequent commands are not blocked.
-    assert!(!ctx
-        .switch_in_progress
-        .load(std::sync::atomic::Ordering::SeqCst));
+    // Switch barrier is releasable again so subsequent commands are not
+    // blocked. After the switch returns, the write guard is dropped and
+    // `try_write` succeeds (no lifecycle handlers in flight in this
+    // test).
+    assert!(
+        ctx.switch_lock.try_write().is_ok(),
+        "switch_lock should be free after a completed switch",
+    );
 
     // Restored gate was reset so the new workspace's restore_all_sessions
     // can fire when frontend_ready re-issues.
@@ -529,10 +533,12 @@ async fn workspace_switch_refuses_invalid_target() {
     assert_eq!(err.code, "InvalidPath");
     assert!(captured.lock().unwrap().is_empty());
 
-    // Gate restored on failure.
-    assert!(!ctx
-        .switch_in_progress
-        .load(std::sync::atomic::Ordering::SeqCst));
+    // Barrier is releasable again on failure (write guard dropped on
+    // function return regardless of error path).
+    assert!(
+        ctx.switch_lock.try_write().is_ok(),
+        "switch_lock should be free after a failed switch",
+    );
 }
 
 #[tokio::test]
@@ -579,10 +585,11 @@ async fn workspace_switch_returns_locked_when_target_is_held() {
         .expect_err("must report contention");
         assert_eq!(err.code, "WorkspaceLocked");
         assert!(captured.lock().unwrap().is_empty());
-        // Gate restored on contention failure.
-        assert!(!ctx
-            .switch_in_progress
-            .load(std::sync::atomic::Ordering::SeqCst));
+        // Barrier is releasable again on contention failure.
+        assert!(
+            ctx.switch_lock.try_write().is_ok(),
+            "switch_lock should be free after a contention failure",
+        );
     }
 }
 


### PR DESCRIPTION
PR4 of the settings-flush code-review follow-ups. Replaces three concurrency primitives with a single `tokio::sync::RwLock<()>` (`switch_lock`) plus an `AtomicUsize` counter (`switch_pending`).

## Concurrency design

The pair answers two questions a workspace-mutating handler must resolve before touching `ctx.store()`:

1. *Is a switch about to swap the scope out from under me?* → consult `switch_pending` (atomic load, no lock).
2. *Once I've decided to proceed, can the switch wait for me to finish before it swaps?* → hold a `try_read()` guard on `switch_lock` for my full body.

The switch increments `switch_pending` BEFORE awaiting `write()`, then holds the write guard for the entire pipeline. Its `write().await` waits for in-flight readers to drop before resolving.

## Why both primitives are needed

Tokio's `RwLock::try_read` is permit-based and does **not** honour writer-preferring fairness for non-awaiting callers — a queued writer behind active readers does not bump out new `try_read` calls. Without a separate counter, a handler issued between *switch task spawned* and *switch's `write().await` resolved* could acquire `try_read` successfully, complete a mutation against the soon-to-be-discarded old store, and silently lose the user's write. The counter closes that gap; handlers use a take-then-check pattern (take read guard first, then load counter; if non-zero, drop and reject).

This was caught by the rubber-duck pass on PR2 (#36); PR2 was closed and the cleanup folded here.

## Per-handler gating policy

| Handler | On contention |
|---|---|
| `session_create` / `session_close` / `session_restart` / `session_focus` / `config_set` | `WorkspaceSwitchInProgress` |
| `session_resize` and `frontend_ready` | silent `Ok(())` (next ResizeObserver fire / `workspace://changed` round-trip re-issues against the new scope) |
| `restore_all_sessions` | inherits `OwnedRwLockReadGuard` from `frontend_ready` wrapper |
| `session_input` | intentionally ungated (workspace-agnostic; bytes to a soon-killed PTY are benign) |
| Read-only commands | ungated |

Lock ordering: `switch_lock` is the outermost lock taken by every gated handler. Inner locks (`workspace`, `pending_spawn`, per-store `write_lock`) are taken briefly inside handler bodies and never re-acquire `switch_lock`. Concurrent switches queue serially on the write side via tokio's FIFO waker queue.

## Background-callback drain

Steps 6 and 7 of the switch pipeline drain background callbacks deterministically before the swap:

- **Step 6** — `metrics.stop_all_and_join()` stops AND joins every AI-discovery watcher thread. Under the write guard no new watcher can be armed.
- **Step 7** — per-session `pool.kill().await` sets `killed=true` (so `pty_wait_loop` skips its final status emit), awaits the bounded drain task, and joins the wait thread before returning — draining the PTY-status callback channel as a side effect.

After step 7, the only callbacks that can still fire are post-emit Tauri event deliveries to JS, which the existing `NotFound`-tolerant store re-resolution in `commands::mod` handles cleanly.

Park no longer calls per-session `metrics.stop` — step 6 already joined every watcher and the write guard prevents new ones being armed, so it would be unconditionally a no-op. (This is the cleanup that was originally PR2.)

## Tests

Three new regression tests in `session_lifecycle_fake.rs`:

- `lifecycle_handlers_refuse_while_switch_write_held` — write guard held: handlers reject, resize is silent `Ok`.
- `resize_silently_skips_while_switch_write_held` — focused resize contract.
- `lifecycle_handlers_refuse_when_switch_writer_is_queued` — the take-then-check counter contract; specifically catches the tokio `try_read` fairness gap.

Updated existing `focus_refuses_while_workspace_switch_in_progress` and `workspace_command.rs` assertions to use the new primitive.

## Acceptance gate

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace` 439 passed
- `npm run lint`, `npm test -- --run`, `npm run build` clean
- Husky pre-commit + pre-push hooks ran to completion (no `--no-verify`).

## Docs

DESIGN.md §5.5c rewritten to describe the new pipeline (`switch_lock` + `switch_pending`, take-then-check rationale, explicit drain semantics in steps 6 and 7). Command + event tables updated.

## Code-review trace

Addresses code-review finding #4 ("Drop redundant `metrics.stop` from `park_session_for_switch_impl`") and the concurrency-primitive consolidation that motivated closing #36.