### PR TITLE
Update instructions and enhance skills documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,11 +17,11 @@ This repo is dogfooded: the user typically runs the **host** `arborist.exe` (or 
 
 Hard rules:
 
-- **Never** terminate `arborist.exe` / `arborist`, or its parent dev processes — `cargo run … arborist`, `npm run tauri:dev`, `tauri dev`, the Vite dev server, or any `node`/`cargo` process you did not personally spawn in this session. Treat them as the user's running editor.
+- **Never** terminate `arborist.exe` / `arborist`, or its parent dev processes — `cargo run … arborist`, `npm run tauri:dev`, `tauri dev`, the Vite dev server, or any `node`/`cargo` process you did not personally spawn in this session.
 - **Never** use name-based or pattern-based process kills — `Stop-Process -Name`, `taskkill /IM`, `pkill`, `killall`, `Get-Process … | Stop-Process`. They will sweep up the host. Do not use or work around these commands.
 - **Even with `Stop-Process -Id <PID>`**, only kill PIDs you captured from a child process you started yourself in this same session. If you didn't record the PID at spawn time, don't kill it.
 - If your `cargo build` / `cargo run` is blocked by a "file in use" / target-locked error, **stop and ask the user** — that lock almost always means the host arborist is running. Do not "free" the lock by killing processes.
-- Do not run `npm run tauri:dev` or `cargo run -p arborist` "to test changes" unless the user explicitly asks. The user already has it running. Use `cargo build`, `cargo test`, `npm run build`, or `npm test -- --run` for verification instead.
+- Do not run `npm run tauri:dev` or `cargo run -p arborist` unless the user explicitly asks during the current session. Use `cargo build`, `cargo test`, `npm run build`, or `npm test -- --run` for verification instead.
 
 If a task genuinely requires restarting the host, ask the user to do it — never do it yourself.
 
@@ -80,6 +80,12 @@ These are the patterns to follow when writing code in this repo. They are opinio
 - **Single source of truth for the API surface.** The command/event tables in DESIGN.md §6 are authoritative. When you add, rename, or change a command/event: (1) update DESIGN.md §6, (2) update the Rust `#[tauri::command]` handler, (3) update `src-tauri/capabilities/main.json`, (4) update the typed wrapper in `src/lib/tauri-bridge.ts`, (5) update mirrored TS types. All five in the same PR.
 - **No `any`, no `unwrap()` on the happy path.** TS `any` and Rust `.unwrap()`/`.expect()` are code smells outside of tests and truly-infallible invariants. Prefer `Result`/typed errors and exhaustive matching.
 - **Fail loud at boundaries, recover gracefully inside.** Validate inputs at the Tauri command boundary; once past it, types should make invalid states unrepresentable.
+
+### Code Comments
+
+- Focus comments on **why**, not **what**. The code already says what it does; comments should explain intent, constraints, trade-offs, or non-obvious design decisions.
+- Do not document changes to the spec in code comments — update the spec instead. The spec is the source of truth for design decisions; code comments are secondary annotations.
+- Inline comments inside method bodies are appropriate only when the logic would otherwise be opaque — link to tickets, specs, or external constraints when relevant.
 
 ## Rust (src-tauri/)
 
@@ -198,9 +204,8 @@ Two non-negotiable rules from that skill, restated here so they're always in con
 A change is mergeable when **all** of these hold:
 1. New/changed behavior has direct test coverage that fails without the change.
 2. `npm run lint`, `npm test`, `cargo clippy -D warnings`, `cargo test` all pass locally.
-3. The app launches via `npm run tauri dev` (run by the **user**, not the agent — see "Dogfooding safety") and the touched flow works end-to-end manually at least once.
-4. No `// @ts-ignore`, `any`, `.unwrap()`, `.expect()`, `console.log`, or `dbg!()` added without justification in a code comment.
-5. If a Rust struct in `types.rs` changed, its TS mirror changed in the same commit.
+3. No `// @ts-ignore`, `any`, `.unwrap()`, `.expect()`, `console.log`, or `dbg!()` added without justification in a code comment.
+4. If a Rust struct in `types.rs` changed, its TS mirror changed in the same commit.
 
 ## Common pitfalls (learned from the spec — don't repeat)
 

--- a/.github/skills/pr-comments/SKILL.md
+++ b/.github/skills/pr-comments/SKILL.md
@@ -5,24 +5,17 @@ description: Procedural reference for addressing GitHub PR review comments end-t
 
 # Address PR review comments — procedural reference
 
-This skill walks the agent through addressing review feedback on a GitHub
-pull request: discovering open threads, deciding what to do with each,
-making code changes for the ones it accepts, replying in-thread with the
-required AI-agent disclaimer, and resolving only the threads where code
-actually changed.
+This skill walks the agent through addressing review feedback on a GitHub pull request: discovering open threads, deciding what to do with each, making code changes for the ones it accepts, replying in-thread with the required AI-agent disclaimer, and resolving only the threads where code actually changed.
 
-It is intentionally self-contained — every command, query, and rule the
-agent needs is in this file. There is no separate "principles" doc.
+It is intentionally self-contained — every command, query, and rule the agent needs is in this file. There is no separate "principles" doc.
 
 ## 0. When to use this skill
 
 Invoke when the user asks to:
 
-- "Address the PR comments" / "handle PR review feedback" / "respond to
-  review on PR #N"
+- "Address the PR comments" / "handle PR review feedback" / "respond to review on PR #N"
 - "Resolve the comments you can" / "reply to the unresolved threads"
-- Anything that names a PR (`#N`, a URL, or "this branch's PR") and
-  implies acting on review threads
+- Anything that names a PR (`#N`, a URL, or "this branch's PR") and implies acting on review threads
 
 Do **not** use this skill for:
 
@@ -32,11 +25,7 @@ Do **not** use this skill for:
 
 ## 1. Toolchain
 
-Prefer `gh` CLI for everything — it's available in both Copilot CLI and
-Claude environments and authenticates with the user's existing token.
-The GitHub MCP server, when available, is acceptable for *read*
-operations (listing threads, fetching diffs); for *write* operations
-(replies, resolves) prefer `gh` so behavior is identical across agents.
+Prefer `gh` CLI for everything — it's available in both Copilot CLI and Claude environments and authenticates with the user's existing token. The GitHub MCP server, when available, is acceptable for *read* operations (listing threads, fetching diffs); for *write* operations (replies, resolves) prefer `gh` so behavior is identical across agents.
 
 ```sh
 gh --version                                  # confirm installed
@@ -44,36 +33,26 @@ gh auth status                                # confirm authenticated
 gh api user --jq .login                       # current login (used in disclaimer)
 ```
 
-If `gh auth status` shows logged out, stop and ask the user to run
-`gh auth login` — do not try to authenticate on their behalf.
+If `gh auth status` shows logged out, stop and ask the user to run `gh auth login` — do not try to authenticate on their behalf.
 
 ### Guardrails by category
 
-- Branch safety: never push to `main`; never force-push a branch with
-  commits from multiple contributors.
-- Quality gate: never bypass hooks with `--no-verify`; run the required
-  lint/test/format checks before finalizing.
-- Thread hygiene: always reply in-thread with the required disclaimer;
-  resolve only `accept` threads where code changed.
+- Branch safety: never push to `main`; never force-push a branch with commits from multiple contributors.
+- Quality gate: never bypass hooks with `--no-verify`; run the required lint/test/format checks before finalizing.
+- Thread hygiene: always reply in-thread with the required disclaimer; resolve only `accept` threads where code changed.
 
-> **Shell note**: examples below use POSIX shell syntax (`VAR=$(...)`,
-> single-quoted multi-line `-f query='...'` blocks). On Windows
-> PowerShell, adapt variable assignment (`$VAR = gh ...`) and quoting
-> (here-strings `@'...'@` for the GraphQL bodies). The `gh` arguments
-> themselves are identical across shells.
+> **Shell note**: examples below use POSIX shell syntax (`VAR=$(...)`, single-quoted multi-line `-f query='...'` blocks). On Windows PowerShell, adapt variable assignment (`$VAR = gh ...`) and quoting (here-strings `@'...'@` for the GraphQL bodies). The `gh` arguments themselves are identical across shells.
 
 ## 2. Identify the PR
 
-If the user named a PR number or URL, use it. Otherwise resolve from the
-current branch:
+If the user named a PR number or URL, use it. Otherwise resolve from the current branch:
 
 ```sh
 gh pr view --json number,headRefName,baseRefName,url,state \
   --jq '{number, head: .headRefName, base: .baseRefName, url, state}'
 ```
 
-If `state != "OPEN"`, stop and confirm with the user before proceeding —
-addressing comments on a closed/merged PR is almost always a mistake.
+If `state != "OPEN"`, stop and confirm with the user before proceeding — addressing comments on a closed/merged PR is almost always a mistake.
 
 Capture into shell variables you'll reuse:
 
@@ -86,15 +65,9 @@ ME=$(gh api user --jq .login)
 
 ## 3. Discover open review threads
 
-Review threads — the line-anchored conversations attached to a review —
-are the unit of work. PR-level conversation comments (`gh pr view
---comments`) are out of scope unless the user explicitly asks.
+Review threads — the line-anchored conversations attached to a review — are the unit of work. PR-level conversation comments (`gh pr view --comments`) are out of scope unless the user explicitly asks.
 
-Fetch all unresolved threads with their full comment history via GraphQL.
-**Always** request `pageInfo` on both `reviewThreads` and per-thread
-`comments` so the agent can detect truncation rather than silently
-miss data. Also fetch each comment's parent-review state so pending
-(unsubmitted) comments can be filtered out (§10):
+Fetch all unresolved threads with their full comment history via GraphQL. **Always** request `pageInfo` on both `reviewThreads` and per-thread `comments` so the agent can detect truncation rather than silently miss data. Also fetch each comment's parent-review state so pending (unsubmitted) comments can be filtered out (§10):
 
 ```sh
 gh api graphql -F owner="$OWNER" -F repo="$REPO" -F number="$PR" -f query='
@@ -130,40 +103,21 @@ gh api graphql -F owner="$OWNER" -F repo="$REPO" -F number="$PR" -f query='
   }'
 ```
 
-Filter the result locally to threads where `isResolved == false`. Drop
-any comment whose `pullRequestReview.state == "PENDING"` — those
-belong to an unsubmitted review and shouldn't be replied to. Keep
-`isOutdated` threads in scope but flag them — the line they reference
-may no longer exist, which changes how you respond.
+Filter the result locally to threads where `isResolved == false`. Drop any comment whose `pullRequestReview.state == "PENDING"` — those belong to an unsubmitted review and shouldn't be replied to. Keep `isOutdated` threads in scope but flag them — the line they reference may no longer exist, which changes how you respond.
 
-**Pagination.** Two connections in this query can paginate
-independently — handle each separately, since GraphQL cursors are
-per-connection (you cannot reuse a thread cursor for comments or
-vice versa):
+**Pagination.** Two connections in this query can paginate independently — handle each separately, since GraphQL cursors are per-connection (you cannot reuse a thread cursor for comments or vice versa):
 
-1. **`reviewThreads.pageInfo.hasNextPage == true`**: re-issue the
-   query above with an added `$cursor: String` variable and
-   `reviewThreads(first: 100, after: $cursor)`, threading the
-   returned `endCursor` through until `hasNextPage` is false.
-2. **Any thread's `comments.pageInfo.hasNextPage == true`**: that
-   thread has a long conversation. Issue a *separate* GraphQL query
-   per such thread to walk its comments connection — e.g.
-   `node(id: $threadId) { ... on PullRequestReviewThread {
-   comments(first: 50, after: $commentCursor) { pageInfo {...}
-   nodes {...} } } }` — until `hasNextPage` is false. Don't try to
-   page nested comments by adding `after` to the outer query; the
-   cursor types don't match.
+1. **`reviewThreads.pageInfo.hasNextPage == true`**: re-issue the query above with an added `$cursor: String` variable and `reviewThreads(first: 100, after: $cursor)`, threading the returned `endCursor` through until `hasNextPage` is false.
+2. **Any thread's `comments.pageInfo.hasNextPage == true`**: that thread has a long conversation. Issue a *separate* GraphQL query per such thread to walk its comments connection — e.g. `node(id: $threadId) { ... on PullRequestReviewThread { comments(first: 50, after: $commentCursor) { pageInfo {...} nodes {...} } } }` — until `hasNextPage` is false. Don't try to page nested comments by adding `after` to the outer query; the cursor types don't match.
 
-Don't proceed on a partial dataset — silently skipping threads (or
-silently truncating a long thread's history) is worse than asking
-the user to confirm the scope.
+Don't proceed on a partial dataset — silently skipping threads (or silently truncating a long thread's history) is worse than asking the user to confirm the scope.
 
 ## 4. Triage each thread
 
 For each unresolved thread, classify it before touching code:
 
 | Class | Meaning | Action |
-|---|---|---|
+| --- | --- | --- |
 | **accept** | Concrete, actionable, agent agrees | Implement → push → reply → **resolve** |
 | **decline** | Agent disagrees on technical grounds | Reply with reasoning → **do not resolve** |
 | **question** | Reviewer asked for clarification | Reply with answer → **do not resolve** |
@@ -180,42 +134,20 @@ Decision flow (use this order each time):
   `accept` => implement + reply + resolve.
   reply-only class => reply only, leave open.
 
-**Do not silently change a classification within the same run.** If you
-start implementing an `accept` and discover the suggestion is wrong,
-stop, revert, and explicitly reclassify as `decline` with a reply
-explaining what you found.
+**Do not silently change a classification within the same run.** If you start implementing an `accept` and discover the suggestion is wrong, stop, revert, and explicitly reclassify as `decline` with a reply explaining what you found.
 
 ### Timing rule: classifications are sticky from triage (single run)
 
-Classify each thread **once**, at triage time (step §4), using the
-discovery snapshot from §3. Carry that classification — and the
-captured `thread.id` — through implement → push → reply → resolve.
-**Do not re-fetch and re-classify** between push and resolve in the
-same run.
+Classify each thread **once**, at triage time (step §4), using the discovery snapshot from §3. Carry that classification — and the captured `thread.id` — through implement → push → reply → resolve. **Do not re-fetch and re-classify** between push and resolve in the same run.
 
-This matters because GitHub flips `isOutdated` to `true` as soon as
-your push moves the line a thread anchors to — which is exactly what
-happens to *every* thread you just successfully addressed. If the
-agent re-queries threads after pushing and re-classifies them, every
-`accept` would suddenly look like `outdated` and never get resolved.
+This matters because GitHub flips `isOutdated` to `true` as soon as your push moves the line a thread anchors to — which is exactly what happens to *every* thread you just successfully addressed. If the agent re-queries threads after pushing and re-classifies them, every `accept` would suddenly look like `outdated` and never get resolved.
 
-The `outdated` triage class is therefore narrow on purpose: it only
-applies to threads that were *already* `isOutdated: true` in the §3
-snapshot, before the agent did anything. Threads that flip to
-`isOutdated: true` *because of* the agent's push remain classified
-`accept` and get resolved. The thread ID stays valid and
-`resolveReviewThread` does not care whether the thread is currently
-outdated.
+The `outdated` triage class is therefore narrow on purpose: it only applies to threads that were *already* `isOutdated: true` in the §3 snapshot, before the agent did anything. Threads that flip to `isOutdated: true` *because of* the agent's push remain classified `accept` and get resolved. The thread ID stays valid and `resolveReviewThread` does not care whether the thread is currently outdated.
 
 ## 5. Implement accepted changes
 
-- One logical change per commit when practical; group only when changes
-  are genuinely interdependent.
-- Run the local quality gate **before pushing** (the recipe in §8 has
-  it as step 3, after the commit, so the staged-file lint that runs in
-  the pre-commit hook can do its job first). The exact set lives in
-  the `quality-workflow` skill, but for self-containment the required
-  commands are:
+- One logical change per commit when practical; group only when changes are genuinely interdependent.
+- Run the local quality gate **before pushing** (the recipe in §8 has it as step 3, after the commit, so the staged-file lint that runs in the pre-commit hook can do its job first). The exact set lives in the `quality-workflow` skill, but for self-containment the required commands are:
 
   ```sh
   npm run lint
@@ -225,18 +157,11 @@ outdated.
   cargo test --workspace
   ```
 
-  If any of these fail, fix in a follow-up commit on the same branch
-  (or amend if the broken commit hasn't been pushed yet) before
-  pushing — **never** bypass hooks with `--no-verify` (see
-  `.github/copilot-instructions.md` "Shift-left quality
-  (principles)").
-- Commit messages should reference the reviewer when natural, e.g.
-  `fix(session): handle null worktree path (review feedback)`.
-- Include the standard Copilot trailer if the agent posting is Copilot
-  CLI; Claude has its own trailer convention.
+  If any of these fail, fix in a follow-up commit on the same branch (or amend if the broken commit hasn't been pushed yet) before pushing — **never** bypass hooks with `--no-verify` (see `.github/copilot-instructions.md` "Shift-left quality (principles)").
+- Commit messages should reference the reviewer when natural, e.g. `fix(session): handle null worktree path (review feedback)`.
+- Include the standard Copilot trailer if the agent posting is Copilot CLI; Claude has its own trailer convention.
 
-Push to the PR branch (never to `main`, never force-push a branch with
-commits from multiple contributors):
+Push to the PR branch (never to `main`, never force-push a branch with commits from multiple contributors):
 
 ```sh
 git push origin "$(git branch --show-current)"
@@ -251,45 +176,31 @@ SHORT_SHA=$(git rev-parse --short HEAD)
 
 ## 6. Reply in-thread (mandatory AI disclaimer)
 
-Every reply the agent posts on behalf of the user **must** start with
-the disclaimer prefix below — no exceptions, including for one-line
-"done" replies. The disclaimer makes it unambiguous to other reviewers
-that an AI agent typed the body, even though the comment is attributed
-to the user's GitHub account.
+Every reply the agent posts on behalf of the user **must** start with the disclaimer prefix below — no exceptions, including for one-line "done" replies. The disclaimer makes it unambiguous to other reviewers that an AI agent typed the body, even though the comment is attributed to the user's GitHub account.
 
 ### Disclaimer format (exact)
 
-```
+```md
 🤖 AI agent reply (acting for @<gh-user>):
 
 <body>
 ```
 
-`<gh-user>` is a placeholder — at posting time, replace it literally
-with the output of `gh api user --jq .login` (the same value captured
-as `$ME` in §2). For example, if `$ME` is `mcaden`, the prefix is
-`🤖 AI agent reply (acting for @mcaden):`. Keep the emoji, the
-parenthetical, the colon, and the blank line. The body follows on the
-next line.
+`<gh-user>` is a placeholder — at posting time, replace it literally with the output of `gh api user --jq .login` (the same value captured as `$ME` in §2). For example, if `$ME` is `mcaden`, the prefix is `🤖 AI agent reply (acting for @mcaden):`. Keep the emoji, the parenthetical, the colon, and the blank line. The body follows on the next line.
 
 ### Body conventions
 
 - Address the reviewer's point directly. Don't restate their comment.
 - For `accept`: state what changed and link the commit:
   `Done in <SHORT_SHA>. <one-line summary of the change>.`
-- For `decline`: lead with the reason, not the disagreement. Cite
-  spec/design docs when relevant (`per DESIGN.md §5.4`).
-- For `question`: answer plainly. If you don't know, say so — don't
-  guess.
-- For `defer`: name the follow-up (`tracked in #NNN`) or say a follow-up
-  will be filed.
-- Never add filler ("Great catch!", "Thanks for the review!"). The
-  reviewer's time is the scarce resource.
+- For `decline`: lead with the reason, not the disagreement. Cite spec/design docs when relevant (`per DESIGN.md §5.4`).
+- For `question`: answer plainly. If you don't know, say so — don't guess.
+- For `defer`: name the follow-up (`tracked in #NNN`) or say a follow-up will be filed.
+- Never add filler ("Great catch!", "Thanks for the review!"). The reviewer's time is the scarce resource.
 
 ### Posting the reply
 
-Reply **inside the existing thread** (not as a new top-level review
-comment) so the conversation stays threaded:
+Reply **inside the existing thread** (not as a new top-level review comment) so the conversation stays threaded:
 
 ```sh
 # $TOP_COMMENT_ID is the databaseId of the *first* comment in the thread
@@ -298,12 +209,9 @@ gh api -X POST \
   -f body="$REPLY_BODY"
 ```
 
-The REST `replies` endpoint requires the integer `databaseId` of the
-top-level comment, not the GraphQL node ID. Get it from the GraphQL
-response in step 3 (`comments.nodes[0].databaseId`).
+The REST `replies` endpoint requires the integer `databaseId` of the top-level comment, not the GraphQL node ID. Get it from the GraphQL response in step 3 (`comments.nodes[0].databaseId`).
 
-If posting via GraphQL is preferred (e.g. when batching), use
-`addPullRequestReviewThreadReply` with the thread's GraphQL node ID:
+If posting via GraphQL is preferred (e.g. when batching), use `addPullRequestReviewThreadReply` with the thread's GraphQL node ID:
 
 ```sh
 gh api graphql -F threadId="$THREAD_ID" -F body="$REPLY_BODY" -f query='
@@ -316,10 +224,7 @@ gh api graphql -F threadId="$THREAD_ID" -F body="$REPLY_BODY" -f query='
 
 ## 7. Resolve threads — only when code changed
 
-After the reply posts successfully, resolve **only** threads classified
-as `accept`. For everything else — `decline`, `question`, `defer`,
-`already-done`, `outdated` — leave the thread open. The human
-author/reviewer decides when those are settled.
+After the reply posts successfully, resolve **only** threads classified as `accept`. For everything else — `decline`, `question`, `defer`, `already-done`, `outdated` — leave the thread open. The human author/reviewer decides when those are settled.
 
 ```sh
 gh api graphql -F threadId="$THREAD_ID" -f query='
@@ -330,10 +235,7 @@ gh api graphql -F threadId="$THREAD_ID" -f query='
   }'
 ```
 
-If the mutation returns `isResolved: false`, the thread was *not*
-resolved (commonly because the actor lacks write permission or the
-thread was already resolved). Don't retry; surface the failure in the
-final summary.
+If the mutation returns `isResolved: false`, the thread was *not* resolved (commonly because the actor lacks write permission or the thread was already resolved). Don't retry; surface the failure in the final summary.
 
 To unresolve (rare — only if the agent mistakenly resolved):
 
@@ -352,46 +254,31 @@ For each unresolved thread, in this order:
 
 1. **Triage** (§4) — pick a class.
 2. **Implement** (§5) — only if class is `accept`. Stage + commit.
-3. **Quality gate** — lint/test/clippy locally; fix or revert before
-   pushing.
+3. **Quality gate** — lint/test/clippy locally; fix or revert before pushing.
 4. **Push** — once per batch, after all `accept` changes for the PR are
    committed (avoids one push per thread).
 5. **Reply** (§6) — disclaimer + body + commit ref.
 6. **Resolve** (§7) — only `accept`.
 
-Doing all the implementation work *before* any replies means: (a) the
-reply can cite a real, pushed SHA; (b) if the quality gate fails, no
-replies have been posted yet, so nothing to retract.
+Doing all the implementation work *before* any replies means: (a) the reply can cite a real, pushed SHA; (b) if the quality gate fails, no replies have been posted yet, so nothing to retract.
 
 ### Partial-failure recovery (post-push)
 
-Once push succeeds, treat each thread's reply (and its conditional
-resolve) as an **independent** unit. If any single reply API call fails:
+Once push succeeds, treat each thread's reply (and its conditional resolve) as an **independent** unit. If any single reply API call fails:
 
 1. **Stop** further reply/resolve mutations for the rest of the batch.
 2. Record which threads were already replied/resolved and which weren't.
-3. Surface the failure in the §9 summary with the unprocessed thread
-   IDs explicitly listed so the user can finish manually or rerun.
+3. Surface the failure in the §9 summary with the unprocessed thread IDs explicitly listed so the user can finish manually or rerun.
 
-On a **rerun** of this skill against the same PR, before posting any
-new reply: re-fetch threads (§3) and check the **last comment** of
-each target thread for an existing AI reply that already cites the
-current `$SHORT_SHA`. If found, skip — replying again would duplicate.
-The check is identical to the self-loop guard in §10 (author + prefix
-match) but additionally requires the SHA in the body to match.
+On a **rerun** of this skill against the same PR, before posting any new reply: re-fetch threads (§3) and check the **last comment** of each target thread for an existing AI reply that already cites the current `$SHORT_SHA`. If found, skip — replying again would duplicate. The check is identical to the self-loop guard in §10 (author + prefix match) but additionally requires the SHA in the body to match.
 
-Note: on a rerun, threads the agent already addressed in a prior run
-will show as `isOutdated: true`. **Do not re-classify them as
-`outdated` from the §4 table** — the rerun's job is to finish posting
-replies/resolves for work already done, using the original `accept`
-classification (which you can recover from the existing AI reply's
-body referencing a prior `$SHORT_SHA`).
+Note: on a rerun, threads the agent already addressed in a prior run will show as `isOutdated: true`. **Do not re-classify them as `outdated` from the §4 table** — the rerun's job is to finish posting replies/resolves for work already done, using the original `accept` classification (which you can recover from the existing AI reply's body referencing a prior `$SHORT_SHA`).
 
 ## 9. Final summary to the user
 
 When the batch is done, print a compact table to the user:
 
-```
+```md
 PR #N — addressed M of K open threads
 
   ✓ thread 1 (src/foo.ts:42)  accept    fixed in abc1234, resolved
@@ -401,44 +288,21 @@ PR #N — addressed M of K open threads
   ⚠ thread 5 (src/zap.ts:99)  outdated  replied (already stale before this run — left for human)
 ```
 
-Always tell the user which threads were *not* resolved and why, so they
-can do the final pass.
+Always tell the user which threads were *not* resolved and why, so they can do the final pass.
 
 ## 10. Edge cases
 
-- **No PR for current branch**: `gh pr view` exits non-zero. Ask the
-  user which PR to address — don't open a new one.
-- **Pending/draft reviews**: comments inside a `PENDING` review aren't
-  visible to others yet. Skip them; they'll show up once submitted.
-- **Agent's own previous AI replies (self-loop guard)**: when deciding
-  whether to reply again, look at the thread's **last** comment and
-  require **both** of:
-  - `comments.nodes[-1].author.login == $ME` (the comment was posted by
-    the same gh account the agent is using), **and**
-  - `comments.nodes[-1].body` starts with the literal disclaimer
-    prefix `🤖 AI agent reply (acting for @` (the username and
-    closing `):` vary per agent, so match the fixed leading
-    substring — looser matches like just `🤖 AI agent reply` will
-    catch unrelated quotes).
+- **No PR for current branch**: `gh pr view` exits non-zero. Ask the user which PR to address — don't open a new one.
+- **Pending/draft reviews**: comments inside a `PENDING` review aren't visible to others yet. Skip them; they'll show up once submitted.
+- **Agent's own previous AI replies (self-loop guard)**: when deciding whether to reply again, look at the thread's **last** comment and require **both** of:
+  - `comments.nodes[-1].author.login == $ME` (the comment was posted by the same gh account the agent is using), **and**
+  - `comments.nodes[-1].body` starts with the literal disclaimer prefix `🤖 AI agent reply (acting for @` (the username and closing `):` vary per agent, so match the fixed leading substring — looser matches like just `🤖 AI agent reply` will catch unrelated quotes).
 
-  If both hold and **no human has replied since** that AI reply, treat
-  the thread as already addressed and skip — never reply to your own
-  reply in a loop. Author-only matching is not enough either: a
-  human-attributed comment from the same gh account that doesn't
-  carry the disclaimer should still be treated as a real reply.
-- **Suggestion blocks** (` ```suggestion ` ): there is no REST/GraphQL
-  endpoint for applying a suggestion programmatically — that's a
-  GitHub UI feature only. If accepting, read the suggestion from the
-  comment body, edit the file to match, and commit normally. The
-  reply (per §6) should still cite the resulting `$SHORT_SHA`.
-- **Force-push needed** (e.g. amending): only if the PR is the agent's
-  own and not yet under review by humans, and only with the user's
-  explicit OK. Default is to add a new commit.
-- **Rate limits**: `gh api` will surface a 403 with `X-RateLimit-*`
-  headers. Stop and report — don't sleep-and-retry blindly.
-- **Permission errors on resolve**: external contributors' agents can
-  reply but not resolve threads they don't own. Surface this as a
-  warning in the final summary; don't treat it as a failure.
+  If both hold and **no human has replied since** that AI reply, treat the thread as already addressed and skip — never reply to your own reply in a loop. Author-only matching is not enough either: a human-attributed comment from the same gh account that doesn't carry the disclaimer should still be treated as a real reply.
+- **Suggestion blocks** (` ```suggestion ` ): there is no REST/GraphQL endpoint for applying a suggestion programmatically — that's a GitHub UI feature only. If accepting, read the suggestion from the comment body, edit the file to match, and commit normally. The reply (per §6) should still cite the resulting `$SHORT_SHA`.
+- **Force-push needed** (e.g. amending): only if the PR is the agent's own and not yet under review by humans, and only with the user's explicit OK. Default is to add a new commit.
+- **Rate limits**: `gh api` will surface a 403 with `X-RateLimit-*` headers. Stop and report — don't sleep-and-retry blindly.
+- **Permission errors on resolve**: external contributors' agents can reply but not resolve threads they don't own. Surface this as a warning in the final summary; don't treat it as a failure.
 
 ## 11. What this skill does *not* do
 

--- a/.github/skills/pr-comments/SKILL.md
+++ b/.github/skills/pr-comments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-comments
-description: Procedural reference for addressing GitHub PR review comments end-to-end — discover open review threads, triage each one, implement accepted changes, push, reply in-thread with the required AI-agent disclaimer, and resolve only the threads where code actually changed. Invoke when the user asks to "address PR comments", "respond to review", "handle PR feedback", or names a specific PR/comment to act on. Covers exact `gh api` / `gh api graphql` invocations for listing threads, posting replies, and resolving threads, plus the rules for what *not* to auto-resolve. The load-bearing *principles* (always disclose AI authorship, never resolve threads the agent didn't act on, never push to `main`, never `--no-verify`) are restated here so the skill is self-contained.
+description: Procedural reference for addressing GitHub PR review comments end-to-end — discover open review threads, triage each one, implement accepted changes, push, reply in-thread with the required AI-agent disclaimer, and resolve only the threads where code actually changed. Invoke when the user asks to "address PR comments", "respond to review", "handle PR feedback", or names a specific PR/comment to act on. Covers exact `gh api` / `gh api graphql` invocations for listing threads, posting replies, and resolving threads, plus the rules for what *not* to auto-resolve. The load-bearing *principles* (always disclose AI authorship, never resolve threads the agent didn't act on, never push to `main`, never force-push a branch with commits from multiple contributors, never `--no-verify`) are restated here so the skill is self-contained.
 ---
 
 # Address PR review comments — procedural reference
@@ -46,6 +46,15 @@ gh api user --jq .login                       # current login (used in disclaime
 
 If `gh auth status` shows logged out, stop and ask the user to run
 `gh auth login` — do not try to authenticate on their behalf.
+
+### Guardrails by category
+
+- Branch safety: never push to `main`; never force-push a branch with
+  commits from multiple contributors.
+- Quality gate: never bypass hooks with `--no-verify`; run the required
+  lint/test/format checks before finalizing.
+- Thread hygiene: always reply in-thread with the required disclaimer;
+  resolve only `accept` threads where code changed.
 
 > **Shell note**: examples below use POSIX shell syntax (`VAR=$(...)`,
 > single-quoted multi-line `-f query='...'` blocks). On Windows
@@ -162,17 +171,27 @@ For each unresolved thread, classify it before touching code:
 | **already-done** | Code already does what's asked (e.g. on a different line) | Reply pointing to current code → **do not resolve** |
 | **outdated** | Thread was *already* `isOutdated: true` at triage time and the concern no longer applies | Reply explaining what changed → **do not resolve** (always leave for the human; the agent has no reliable way to attest *why* the line went stale before the agent ran) |
 
-**Never silently change the classification mid-flow.** If you start
-implementing an `accept` and discover the suggestion is wrong, stop,
-revert, and reclassify as `decline` with a reply explaining what you
-found.
+Decision flow (use this order each time):
 
-### Timing rule: classifications are sticky from triage
+1. If you agree and can implement now, choose `accept`.
+2. Otherwise choose one reply-only class:
+  `decline`, `question`, `defer`, `already-done`, or `outdated`.
+3. Apply the action rule:
+  `accept` => implement + reply + resolve.
+  reply-only class => reply only, leave open.
+
+**Do not silently change a classification within the same run.** If you
+start implementing an `accept` and discover the suggestion is wrong,
+stop, revert, and explicitly reclassify as `decline` with a reply
+explaining what you found.
+
+### Timing rule: classifications are sticky from triage (single run)
 
 Classify each thread **once**, at triage time (step §4), using the
 discovery snapshot from §3. Carry that classification — and the
 captured `thread.id` — through implement → push → reply → resolve.
-**Do not re-fetch and re-classify** between push and resolve.
+**Do not re-fetch and re-classify** between push and resolve in the
+same run.
 
 This matters because GitHub flips `isOutdated` to `true` as soon as
 your push moves the line a thread anchors to — which is exactly what
@@ -216,8 +235,8 @@ outdated.
 - Include the standard Copilot trailer if the agent posting is Copilot
   CLI; Claude has its own trailer convention.
 
-Push to the PR branch (never to `main`, never force-push a shared
-branch):
+Push to the PR branch (never to `main`, never force-push a branch with
+commits from multiple contributors):
 
 ```sh
 git push origin "$(git branch --show-current)"

--- a/.github/skills/quality-workflow/SKILL.md
+++ b/.github/skills/quality-workflow/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: quality-workflow
-description: Arborist's procedural quality reference — exact build/lint/test commands, inner-loop watcher setup, Husky pre-commit/pre-push configuration, test architecture rules, and end-of-feature performance/memory smoke tests. Invoke when scaffolding the repo, configuring git hooks, setting up editor watchers, looking up an exact `npm`/`cargo` command, writing or restructuring tests, or verifying a feature is done before merge. The load-bearing *principles* (test-first, determinism, "what done means", pitfalls) live in `.github/copilot-instructions.md` and are always in context — this skill is the procedural lookup that complements them.
+description: Arborist's procedural quality reference. Use it as a lookup for one task at a time: command reference, watcher setup, Husky hooks, test architecture, or end-of-feature smoke tests. Invoke when scaffolding the repo, configuring git hooks, setting up editor watchers, looking up an exact `npm`/`cargo` command, writing or restructuring tests, or verifying a feature is done before merge. The load-bearing *principles* (test-first, determinism, "what done means", pitfalls) live in `.github/copilot-instructions.md` and are always in context — this skill provides the concrete commands and setup details.
 ---
 
 # Quality workflow — procedural reference
 
-Companion to the **Shift-left quality** principles in `.github/copilot-instructions.md`. Those principles are always loaded; this file holds the commands and configuration detail you only need when actively setting things up or looking something up.
+Companion to the **Shift-left quality** principles in `.github/copilot-instructions.md`. Those principles are always loaded; this file is a lookup. Read only the section needed for the current task instead of processing the whole document.
 
 ## 1. Build, run, lint, test — command reference
 
@@ -47,7 +47,7 @@ cargo watch -x 'test --workspace'         # tests
 
 ## 3. Pre-commit / pre-push hooks (Husky + lint-staged)
 
-Hooks live under `.husky/`. Bypassing with `--no-verify` is allowed only for WIP branches that won't be merged; never on `main`.
+Hooks live under `.husky/`. Bypassing with `--no-verify` is allowed only for branches explicitly marked as WIP and not intended for merging into `main`.
 
 - **pre-commit**:
   - `lint-staged` runs `eslint --fix` + Prettier on staged JS/TS


### PR DESCRIPTION
This pull request updates procedural documentation to clarify and strengthen safety and quality guardrails for both code contributions and PR review workflows. The changes emphasize stricter controls on process management, code commenting practices, branch safety, and test requirements, as well as improved clarity in procedural instructions.

**Documentation and Process Guardrails:**

* Updated `.github/copilot-instructions.md` to clarify that running dev processes (`npm run tauri:dev`, `cargo run -p arborist`) should only be done if the user explicitly requests it during the current session, and not for general testing—reinforcing safety around user processes.
* Added a new section on code comments, emphasizing that comments should explain intent and trade-offs (the "why"), not restate the code ("what"), and that spec changes should be documented in the spec, not in code comments.
* Refined mergeability criteria to remove the requirement that the app must be manually launched and tested by the user for every change, focusing instead on test coverage and code quality rules.

**PR Review Workflow and Branch Safety:**

* Strengthened the PR review skill documentation to explicitly prohibit force-pushing branches with commits from multiple contributors and clarified that `--no-verify` should never be used, adding a new "Guardrails by category" section for quick reference. [[1]](diffhunk://#diff-9f5d62dffe26e4867cf760f69a604fd025b5e64172956351d9bdc41b8d5b60eaL3-R3) [[2]](diffhunk://#diff-9f5d62dffe26e4867cf760f69a604fd025b5e64172956351d9bdc41b8d5b60eaR50-R58) [[3]](diffhunk://#diff-9f5d62dffe26e4867cf760f69a604fd025b5e64172956351d9bdc41b8d5b60eaL219-R239)
* Improved the PR comment classification and resolution flow to require explicit, sticky classifications per run, and clarified the process for changing a classification if implementation reveals new information.

**Quality Workflow Clarifications:**

* Updated the quality workflow skill to clarify that bypassing pre-commit hooks with `--no-verify` is allowed only for branches explicitly marked as WIP and not intended for merging into `main`.
* Revised the quality workflow description to encourage using the document as a focused lookup for specific tasks rather than reading it end-to-end, improving usability.