### PR TITLE
Further refine instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -118,7 +118,7 @@ Match DESIGN.md §7. One concern per file (`pty_pool.rs`, `config_store.rs`, `co
 - Newtype wrappers for IDs (`SessionId(Uuid)`, `InstructionSetId(String)`) — prevents passing the wrong ID into the wrong function.
 
 ### Testing
-Rust-specific principles (procedural detail — test layout, fixtures, virtual-time setup — lives in the `quality-workflow` skill):
+Rust-specific principles (procedural detail — test layout, fixtures, virtual-time setup — lives in the `quality-workflow-gate` skill):
 - Pure logic (label dedup, command composition, path validation) is unit-tested.
 - PTY pool gets integration tests that don't depend on `claude`/`copilot` being installed.
 - `cargo fmt` + `cargo clippy -- -D warnings` must be clean.
@@ -168,7 +168,7 @@ Rust-specific principles (procedural detail — test layout, fixtures, virtual-t
 - Dark mode via `class` strategy; the root `<html>` class is set from system preference at boot.
 
 ### Testing
-Frontend-specific principles (procedural detail in the `quality-workflow` skill):
+Frontend-specific principles (procedural detail in the `quality-workflow-gate` skill):
 - Vitest + React Testing Library. Test behavior, not implementation (no shallow rendering, no snapshot-as-assertion).
 - Mock the `tauri-bridge` module wholesale — never call real `invoke()` from a unit test.
 
@@ -182,7 +182,7 @@ Frontend-specific principles (procedural detail in the `quality-workflow` skill)
 
 **Catch problems on the keystroke, not in CI.** The feedback ladder runs fastest → slowest: editor type/lint on save → unit-test watch → pre-commit hook → pre-push hook → CI. Run the editor and watcher loops continuously while coding; never bypass hooks with `--no-verify` on `main`.
 
-For exact commands, watcher setup, Husky configuration, test layout, and end-of-feature smoke tests, **invoke the `quality-workflow` skill**.
+For exact commands, watcher setup, Husky configuration, test layout, and end-of-feature smoke tests, **invoke the `quality-workflow-gate` skill**.
 
 ## Addressing PR review comments
 

--- a/.github/skills/pr-comments/SKILL.md
+++ b/.github/skills/pr-comments/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pr-comments
 description: Procedural reference for addressing GitHub PR review comments end-to-end — discover open review threads, triage each one, implement accepted changes, push, reply in-thread with the required AI-agent disclaimer, and resolve only the threads where code actually changed. Invoke when the user asks to "address PR comments", "respond to review", "handle PR feedback", or names a specific PR/comment to act on. Covers exact `gh api` / `gh api graphql` invocations for listing threads, posting replies, and resolving threads, plus the rules for what *not* to auto-resolve. The load-bearing *principles* (always disclose AI authorship, never resolve threads the agent didn't act on, never push to `main`, never force-push a branch with commits from multiple contributors, never `--no-verify`) are restated here so the skill is self-contained.
+license: MIT
 ---
 
 # Address PR review comments — procedural reference
@@ -147,7 +148,7 @@ The `outdated` triage class is therefore narrow on purpose: it only applies to t
 ## 5. Implement accepted changes
 
 - One logical change per commit when practical; group only when changes are genuinely interdependent.
-- Run the local quality gate **before pushing** (the recipe in §8 has it as step 3, after the commit, so the staged-file lint that runs in the pre-commit hook can do its job first). The exact set lives in the `quality-workflow` skill, but for self-containment the required commands are:
+- Run the local quality gate **before pushing** (the recipe in §8 has it as step 3, after the commit, so the staged-file lint that runs in the pre-commit hook can do its job first). The exact set lives in the `quality-workflow-gate` skill, but for self-containment the required commands are:
 
   ```sh
   npm run lint

--- a/.github/skills/quality-workflow-gate/SKILL.md
+++ b/.github/skills/quality-workflow-gate/SKILL.md
@@ -1,6 +1,7 @@
 ---
-name: quality-workflow
-description: Arborist's procedural quality reference. Use it as a lookup for one task at a time: command reference, watcher setup, Husky hooks, test architecture, or end-of-feature smoke tests. Invoke when scaffolding the repo, configuring git hooks, setting up editor watchers, looking up an exact `npm`/`cargo` command, writing or restructuring tests, or verifying a feature is done before merge. The load-bearing *principles* (test-first, determinism, "what done means", pitfalls) live in `.github/copilot-instructions.md` and are always in context — this skill provides the concrete commands and setup details.
+name: quality-workflow-gate
+description: Procedural reference for quality. Use it as a lookup for one task at a time for command reference, watcher setup, Husky hooks, test architecture, or end-of-feature smoke tests. Invoke when scaffolding the repo, configuring git hooks, setting up editor watchers, looking up an exact `npm`/`cargo` command, writing or restructuring tests, or verifying a feature is done before merge. The load-bearing *principles* (test-first, determinism, "what done means", pitfalls) live in `.github/copilot-instructions.md` and are always in context — this skill provides the concrete commands and setup details.
+license: MIT
 ---
 
 # Quality workflow — procedural reference

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,4 +143,4 @@ Rust backend owns all PTYs and persistent state; the React frontend communicates
 Claude does not auto-discover skill files. When a task matches one of these, **read the linked file before acting**:
 
 - **Addressing PR review comments / responding to PR feedback** → read `.github/skills/pr-comments/SKILL.md`. Covers the exact `gh api` / GraphQL calls for listing review threads, replying in-thread (with the **mandatory `🤖 AI agent reply (acting for @<gh-user>):` disclaimer prefix**, where `<gh-user>` is replaced literally with the output of `gh api user --jq .login`), and the resolve-only-when-code-changed policy.
-- **Build / lint / test command lookup, Husky hooks, test architecture** → read `.github/skills/quality-workflow/SKILL.md`.
+- **Build / lint / test command lookup, Husky hooks, test architecture** → read `.github/skills/quality-workflow-gate/SKILL.md`.

--- a/dev/docs/DEVELOPMENT.md
+++ b/dev/docs/DEVELOPMENT.md
@@ -92,13 +92,13 @@ arborist/
 │   └── ai/                      # agent-authored artefacts (plan, review, smoke results)
 └── .github/
     ├── copilot-instructions.md  # engineering principles loaded into every agent run
-    └── skills/quality-workflow/SKILL.md   # procedural lookup
+    └── skills/quality-workflow-gate/SKILL.md   # procedural lookup
 ```
 
 ## 4. Day-to-day commands
 
 The full command reference also lives in
-[`.github/skills/quality-workflow/SKILL.md`](../../.github/skills/quality-workflow/SKILL.md);
+[`.github/skills/quality-workflow-gate/SKILL.md`](../../.github/skills/quality-workflow-gate/SKILL.md);
 keep both pages in sync.
 
 ### Run the app

--- a/dev/docs/README.md
+++ b/dev/docs/README.md
@@ -19,7 +19,7 @@ Authoritative documentation for the Arborist desktop app.
 - [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md) —
   load-bearing engineering principles (test-first, determinism, "what done
   means", common pitfalls).
-- [`.github/skills/quality-workflow/SKILL.md`](../../.github/skills/quality-workflow/SKILL.md)
+- [`.github/skills/quality-workflow-gate/SKILL.md`](../../.github/skills/quality-workflow-gate/SKILL.md)
   — exact build / lint / test commands and end-of-feature smoke procedures.
 - [`dev/ai/`](../ai/) — agent-authored artefacts: implementation plan,
   smoke-test results, and review reports.


### PR DESCRIPTION
This pull request renames the `quality-workflow` skill to `quality-workflow-gate` throughout the repository, updates all references accordingly, and adds missing license metadata for skill files. These changes ensure consistency in procedural documentation and skill invocation, and clarify licensing for internal documentation.

**Skill renaming and reference updates:**

* Renamed `.github/skills/quality-workflow/SKILL.md` to `.github/skills/quality-workflow-gate/SKILL.md`, updated the `name` and `description` fields, and added a `license: MIT` field. All references in documentation and procedural files now point to the new skill name and path. [[1]](diffhunk://#diff-16d85c573b9eabe0a6dbe2270c0897fdc9d3f2b7c87caad7939b3ec8f7a650c1L2-R4) [[2]](diffhunk://#diff-c0368b2f21598cf83728c4f33c1dd7910d5c5f8866a5494b376fcf04a3c87ceaL95-R101) [[3]](diffhunk://#diff-ff5e2f9801a18984d055f1243d57767c07b9b956cfa84c6295bf8910b893d70cL22-R22) [[4]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L146-R146)
* Updated all procedural and instructional references in `.github/copilot-instructions.md` and `.github/skills/pr-comments/SKILL.md` to use `quality-workflow-gate` instead of `quality-workflow`. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L121-R121) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L171-R171) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L185-R185) [[4]](diffhunk://#diff-9f5d62dffe26e4867cf760f69a604fd025b5e64172956351d9bdc41b8d5b60eaL150-R151)

**Metadata updates:**

* Added `license: MIT` to `.github/skills/pr-comments/SKILL.md` and `.github/skills/quality-workflow-gate/SKILL.md` for clearer documentation licensing. [[1]](diffhunk://#diff-9f5d62dffe26e4867cf760f69a604fd025b5e64172956351d9bdc41b8d5b60eaR4) [[2]](diffhunk://#diff-16d85c573b9eabe0a6dbe2270c0897fdc9d3f2b7c87caad7939b3ec8f7a650c1L2-R4)