### PR TITLE
feat(sidebar): use Nerd Font codicons for AI status indicators (#64)

### DIFF
--- a/src/components/SidebarTab.tsx
+++ b/src/components/SidebarTab.tsx
@@ -286,8 +286,11 @@ function SessionStatusIndicator({
 }
 
 function statusIconClasses(status: DisplayStatus): string {
-  // Uniform geometry; only color and animation vary by state.
-  const base = 'h-3.5 w-3.5 shrink-0';
+  // Uniform geometry; only color and animation vary by state. The icon
+  // is now a Nerd Font codicon glyph (see `StatusIcon.tsx`), so size is
+  // controlled by `text-*` (font-size) rather than `h-* w-*` — the
+  // glyph's box is pinned to 1em × 1em inside the component.
+  const base = 'text-base shrink-0';
   switch (status) {
     case 'starting':
       return `${base} animate-spin text-sky-500`;

--- a/src/components/StatusIcon.test.tsx
+++ b/src/components/StatusIcon.test.tsx
@@ -5,11 +5,24 @@ import { StatusIcon } from './StatusIcon';
 import type { DisplayStatus } from '@/store/session-store';
 
 describe('StatusIcon', () => {
-  const cases: Array<Exclude<DisplayStatus, 'idle'>> = ['starting', 'working', 'awaiting', 'attention', 'exited', 'error'];
+  // Every non-idle DisplayStatus variant must have a glyph; the test ids
+  // below are kebab-case (the camelCase enum values are normalised in
+  // `StatusIcon.tsx`'s `STATUS_TESTID_SUFFIX` map).
+  const cases: ReadonlyArray<{ status: Exclude<DisplayStatus, 'idle'>; testIdSuffix: string }> = [
+    { status: 'starting', testIdSuffix: 'starting' },
+    { status: 'working', testIdSuffix: 'working' },
+    { status: 'awaiting', testIdSuffix: 'awaiting' },
+    { status: 'attention', testIdSuffix: 'attention' },
+    { status: 'awaitingPermission', testIdSuffix: 'awaiting-permission' },
+    { status: 'runningTool', testIdSuffix: 'running-tool' },
+    { status: 'thinking', testIdSuffix: 'thinking' },
+    { status: 'exited', testIdSuffix: 'exited' },
+    { status: 'error', testIdSuffix: 'error' },
+  ];
 
-  it.each(cases)('renders the %s glyph with a stable testid', (status) => {
+  it.each(cases)('renders the $status glyph with a stable testid', ({ status, testIdSuffix }) => {
     render(<StatusIcon status={status} />);
-    expect(screen.getByTestId(`status-icon-${status}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`status-icon-${testIdSuffix}`)).toBeInTheDocument();
   });
 
   it('renders nothing for idle (quiescent sessions stay quiet)', () => {
@@ -17,16 +30,60 @@ describe('StatusIcon', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('forwards the className to the rendered svg', () => {
-    render(<StatusIcon status="working" className="text-emerald-500" />);
-    const svg = screen.getByTestId('status-icon-working');
-    expect(svg).toHaveClass('text-emerald-500');
+  it.each(cases)('emits a single-codepoint Nerd Font codicon glyph for $status', ({ status, testIdSuffix }) => {
+    render(<StatusIcon status={status} />);
+    const text = screen.getByTestId(`status-icon-${testIdSuffix}`).textContent ?? '';
+    // Single codepoint: surrogate-pair-aware so accidental swaps to a
+    // higher-plane glyph (e.g. material-design icons U+F0001+) still
+    // count as one codepoint.
+    expect([...text]).toHaveLength(1);
+    const codepoint = text.codePointAt(0);
+    expect(codepoint).toBeDefined();
+    // Codicons live in the U+EA60–U+EC1E PUA range. Asserting the range
+    // catches accidental fall-back to ASCII (e.g. typing the literal
+    // character instead of the escape) and warns if a future edit pulls
+    // a glyph from the wrong Nerd Font block.
+    expect(codepoint!).toBeGreaterThanOrEqual(0xea60);
+    expect(codepoint!).toBeLessThanOrEqual(0xec1e);
   });
 
-  it('emits the title as an accessible <title> element for tooltips', () => {
+  it('emits a distinct glyph per non-idle status (no collisions)', () => {
+    const seen = new Map<string, DisplayStatus>();
+    for (const { status, testIdSuffix } of cases) {
+      const { unmount } = render(<StatusIcon status={status} />);
+      const text = screen.getByTestId(`status-icon-${testIdSuffix}`).textContent ?? '';
+      expect(seen.has(text), `glyph for "${status}" collides with "${seen.get(text) ?? ''}"`).toBe(false);
+      seen.set(text, status);
+      unmount();
+    }
+  });
+
+  it('forwards the className to the rendered element', () => {
+    render(<StatusIcon status="working" className="text-emerald-500" />);
+    const el = screen.getByTestId('status-icon-working');
+    expect(el).toHaveClass('text-emerald-500');
+  });
+
+  it('pins the glyph box to a 1em square so the icon column does not shift on state changes', () => {
+    render(<StatusIcon status="working" />);
+    const el = screen.getByTestId('status-icon-working');
+    // `inline-block w-[1em] text-center leading-none` is what keeps the
+    // unread-overlay dot anchored — assert each piece so accidental
+    // removal of a class is caught here, not in a manual visual check.
+    expect(el).toHaveClass('inline-block');
+    expect(el).toHaveClass('w-[1em]');
+    expect(el).toHaveClass('text-center');
+    expect(el).toHaveClass('leading-none');
+  });
+
+  it('pins the glyph to the proportional Nerd Font family even inside a font-mono ancestor', () => {
+    render(<StatusIcon status="working" />);
+    expect(screen.getByTestId('status-icon-working')).toHaveClass('font-sans');
+  });
+
+  it('emits the title as a native title attribute for hover tooltips', () => {
     render(<StatusIcon status="awaiting" title="Awaiting input" />);
-    const svg = screen.getByTestId('status-icon-awaiting');
-    expect(svg.querySelector('title')?.textContent).toBe('Awaiting input');
+    expect(screen.getByTestId('status-icon-awaiting')).toHaveAttribute('title', 'Awaiting input');
   });
 
   it('hides the icon from assistive tech when no title is supplied', () => {
@@ -34,17 +91,17 @@ describe('StatusIcon', () => {
     // sidebar tab itself is the labelled element, so an unlabelled icon
     // should be silently decorative.
     render(<StatusIcon status="working" />);
-    const svg = screen.getByTestId('status-icon-working');
-    expect(svg).toHaveAttribute('aria-hidden', 'true');
-    expect(svg).not.toHaveAttribute('aria-label');
-    expect(svg).not.toHaveAttribute('role');
+    const el = screen.getByTestId('status-icon-working');
+    expect(el).toHaveAttribute('aria-hidden', 'true');
+    expect(el).not.toHaveAttribute('aria-label');
+    expect(el).not.toHaveAttribute('role');
   });
 
   it('promotes to role=img and exposes aria-label when titled', () => {
     render(<StatusIcon status="working" title="Working" />);
-    const svg = screen.getByTestId('status-icon-working');
-    expect(svg).toHaveAttribute('aria-label', 'Working');
-    expect(svg).toHaveAttribute('role', 'img');
-    expect(svg).not.toHaveAttribute('aria-hidden');
+    const el = screen.getByTestId('status-icon-working');
+    expect(el).toHaveAttribute('aria-label', 'Working');
+    expect(el).toHaveAttribute('role', 'img');
+    expect(el).not.toHaveAttribute('aria-hidden');
   });
 });

--- a/src/components/StatusIcon.test.tsx
+++ b/src/components/StatusIcon.test.tsx
@@ -76,9 +76,14 @@ describe('StatusIcon', () => {
     expect(el).toHaveClass('leading-none');
   });
 
-  it('pins the glyph to the proportional Nerd Font family even inside a font-mono ancestor', () => {
+  it('pins the glyph to the dedicated CaskaydiaCove NF icon family (not the body sans stack)', () => {
+    // `font-icon` is a Tailwind family containing only `CaskaydiaCove NF`
+    // (no system fallback) — see `tailwind.config.js`. Asserting it
+    // explicitly catches accidental regressions back to `font-sans`,
+    // whose stack reorganisation could silently swap to a font that
+    // lacks the codicon PUA glyphs.
     render(<StatusIcon status="working" />);
-    expect(screen.getByTestId('status-icon-working')).toHaveClass('font-sans');
+    expect(screen.getByTestId('status-icon-working')).toHaveClass('font-icon');
   });
 
   it('emits the title as a native title attribute for hover tooltips', () => {
@@ -101,6 +106,37 @@ describe('StatusIcon', () => {
     render(<StatusIcon status="working" title="Working" />);
     const el = screen.getByTestId('status-icon-working');
     expect(el).toHaveAttribute('aria-label', 'Working');
+    expect(el).toHaveAttribute('role', 'img');
+    expect(el).not.toHaveAttribute('aria-hidden');
+  });
+
+  it('treats an empty-string title as decorative (no contradictory aria signals)', () => {
+    // `??` does not coerce empty strings to undefined, so the previous
+    // `aria-label={title ?? undefined}` paired with `aria-hidden={title ? … : true}`
+    // emitted both `aria-label=""` and `aria-hidden="true"` for `title=""`,
+    // which screen readers warn on. Treat empty as absent.
+    render(<StatusIcon status="working" title="" />);
+    const el = screen.getByTestId('status-icon-working');
+    expect(el).toHaveAttribute('aria-hidden', 'true');
+    expect(el).not.toHaveAttribute('aria-label');
+    expect(el).not.toHaveAttribute('role');
+    expect(el).not.toHaveAttribute('title');
+  });
+
+  it('treats a whitespace-only title as decorative', () => {
+    render(<StatusIcon status="working" title="   " />);
+    const el = screen.getByTestId('status-icon-working');
+    expect(el).toHaveAttribute('aria-hidden', 'true');
+    expect(el).not.toHaveAttribute('aria-label');
+    expect(el).not.toHaveAttribute('role');
+    expect(el).not.toHaveAttribute('title');
+  });
+
+  it('trims surrounding whitespace from a meaningful title', () => {
+    render(<StatusIcon status="working" title="  Working  " />);
+    const el = screen.getByTestId('status-icon-working');
+    expect(el).toHaveAttribute('aria-label', 'Working');
+    expect(el).toHaveAttribute('title', 'Working');
     expect(el).toHaveAttribute('role', 'img');
     expect(el).not.toHaveAttribute('aria-hidden');
   });

--- a/src/components/StatusIcon.test.tsx
+++ b/src/components/StatusIcon.test.tsx
@@ -7,7 +7,7 @@ import type { DisplayStatus } from '@/store/session-store';
 describe('StatusIcon', () => {
   // Every non-idle DisplayStatus variant must have a glyph; the test ids
   // below are kebab-case (the camelCase enum values are normalised in
-  // `StatusIcon.tsx`'s `STATUS_TESTID_SUFFIX` map).
+  // `StatusIcon.tsx`'s `STATUS_META` entries via their `testIdSuffix` values).
   const cases: ReadonlyArray<{ status: Exclude<DisplayStatus, 'idle'>; testIdSuffix: string }> = [
     { status: 'starting', testIdSuffix: 'starting' },
     { status: 'working', testIdSuffix: 'working' },

--- a/src/components/StatusIcon.tsx
+++ b/src/components/StatusIcon.tsx
@@ -21,50 +21,54 @@ import type { DisplayStatus } from '@/store/session-store';
 interface StatusIconProps {
   status: DisplayStatus;
   className?: string;
-  /** Set as the native `title` attribute for hover-tooltip + assistive-tech label. */
+  /** Set as the native `title` attribute for hover-tooltip + assistive-tech label. Empty / whitespace-only strings are treated as absent. */
   title?: string;
 }
 
-// Codepoints lifted from the Nerd Fonts v3 `glyphnames.json` catalogue.
-// Keep the comments in sync with the upstream `nf-cod-…` name so a
-// future maintainer can re-derive the codepoint from the cheatsheet.
-const STATUS_GLYPHS: Record<Exclude<DisplayStatus, 'idle'>, string> = {
-  starting: '\ueb19', // nf-cod-loading — partial-ring spinner (pairs with animate-spin)
-  working: '\uec10', // nf-cod-sparkle — "model is generating"
-  awaiting: '\uea6b', // nf-cod-comment — speech bubble: agent is parked at its prompt
-  attention: '\ueaa2', // nf-cod-bell — matches OSC 9 / OSC 777 / standalone BEL semantics
-  awaitingPermission: '\uea75', // nf-cod-lock — agent is blocked on a permission decision
-  runningTool: '\ueb6d', // nf-cod-tools — agent invoked a tool
-  thinking: '\uea7c', // nf-cod-ellipsis — assistant turn in flight (pairs with animate-pulse)
-  exited: '\uead7', // nf-cod-debug_stop — terminal-state filled square
-  error: '\uea87', // nf-cod-error — circle with bang
-};
+interface StatusMeta {
+  /** Single-codepoint Nerd Font codicon glyph (U+EA60–U+EC1E PUA range). */
+  glyph: string;
+  /** Stable kebab-case suffix appended to `status-icon-` for the test id. */
+  testIdSuffix: string;
+}
 
-// Stable kebab-case suffix for the test id. Predates the camelCase
-// `awaitingPermission` / `runningTool` enum names — kept verbatim so any
-// existing or external assertion against the previous testid keeps
-// working after the SVG → glyph swap.
-const STATUS_TESTID_SUFFIX: Record<Exclude<DisplayStatus, 'idle'>, string> = {
-  starting: 'starting',
-  working: 'working',
-  awaiting: 'awaiting',
-  attention: 'attention',
-  awaitingPermission: 'awaiting-permission',
-  runningTool: 'running-tool',
-  thinking: 'thinking',
-  exited: 'exited',
-  error: 'error',
-};
+// Single source of truth for per-status presentation. Co-locating the
+// glyph and the test-id suffix in one map prevents the two from drifting
+// when a future `DisplayStatus` variant is added or renamed (TypeScript
+// catches missing keys, but only when the maps stay typed against the
+// same union — having one map removes the parallel-update footgun).
+//
+// `satisfies` keeps the per-key literal types narrow (so callers can
+// rely on `STATUS_META.starting.glyph` being the actual codepoint
+// string, not just `string`) while still enforcing exhaustiveness.
+//
+// The kebab-case test-id suffixes for the camelCase `awaitingPermission`
+// and `runningTool` cases predate this swap; preserved verbatim so any
+// existing assertion against the previous testid keeps working.
+const STATUS_META = {
+  starting: { glyph: '\ueb19', testIdSuffix: 'starting' }, // nf-cod-loading — partial-ring spinner (pairs with animate-spin)
+  working: { glyph: '\uec10', testIdSuffix: 'working' }, // nf-cod-sparkle — "model is generating"
+  awaiting: { glyph: '\uea6b', testIdSuffix: 'awaiting' }, // nf-cod-comment — speech bubble: agent is parked at its prompt
+  attention: { glyph: '\ueaa2', testIdSuffix: 'attention' }, // nf-cod-bell — matches OSC 9 / OSC 777 / standalone BEL semantics
+  awaitingPermission: { glyph: '\uea75', testIdSuffix: 'awaiting-permission' }, // nf-cod-lock — agent is blocked on a permission decision
+  runningTool: { glyph: '\ueb6d', testIdSuffix: 'running-tool' }, // nf-cod-tools — agent invoked a tool
+  thinking: { glyph: '\uea7c', testIdSuffix: 'thinking' }, // nf-cod-ellipsis — assistant turn in flight (pairs with animate-pulse)
+  exited: { glyph: '\uead7', testIdSuffix: 'exited' }, // nf-cod-debug_stop — terminal-state filled square
+  error: { glyph: '\uea87', testIdSuffix: 'error' }, // nf-cod-error — circle with bang
+} as const satisfies Record<Exclude<DisplayStatus, 'idle'>, StatusMeta>;
 
 // `inline-block w-[1em] text-center` pins the glyph's box to a square
 // the size of the current font, so layout stays stable when the active
 // state — and therefore the codepoint — changes. `leading-none` strips
 // the inherited line-box so the box's reported height equals its
 // font-size; the unread-overlay dot in `SidebarTab` anchors off this
-// box and would jitter otherwise. `font-sans` pins the glyph to the
-// bundled `CaskaydiaCove NF` family even when the icon is rendered
-// inside a `font-mono` ancestor (e.g. terminal-adjacent surfaces).
-const BASE_CLASSES = 'inline-block w-[1em] text-center font-sans leading-none';
+// box and would jitter otherwise. `font-icon` is a dedicated Tailwind
+// family that contains only `'CaskaydiaCove NF'` — explicitly decoupled
+// from the `sans` stack so reorganising the body font can't break icon
+// rendering, and intentionally without a generic fallback so a missing
+// glyph renders as tofu instead of silently picking up a system-font
+// substitute that lacks the codicon PUA codepoints.
+const BASE_CLASSES = 'inline-block w-[1em] text-center font-icon leading-none';
 
 export function StatusIcon({ status, className, title }: StatusIconProps): JSX.Element | null {
   // `idle` intentionally renders nothing — a quiescent session shouldn't
@@ -72,8 +76,19 @@ export function StatusIcon({ status, className, title }: StatusIconProps): JSX.E
   // than reserving space for an absent glyph.
   if (status === 'idle') return null;
 
-  const glyph = STATUS_GLYPHS[status];
-  const testId = `status-icon-${STATUS_TESTID_SUFFIX[status]}`;
+  const { glyph, testIdSuffix } = STATUS_META[status];
+  const testId = `status-icon-${testIdSuffix}`;
+
+  // Treat empty- and whitespace-only `title` strings as "no title"
+  // rather than as a meaningful tooltip. Without this normalisation,
+  // `title=""` produces a contradictory pair of a11y signals — `??`
+  // preserves the empty string for `aria-label`, while `title ? …`
+  // treats it as falsy and still emits `aria-hidden="true"`. Trimming
+  // also rules out whitespace-only labels, which are never a useful
+  // tooltip in practice.
+  const trimmedTitle = title?.trim();
+  const hasTitle = trimmedTitle !== undefined && trimmedTitle.length > 0;
+  const labelTitle = hasTitle ? trimmedTitle : undefined;
 
   return (
     <span
@@ -81,11 +96,12 @@ export function StatusIcon({ status, className, title }: StatusIconProps): JSX.E
       // Provide an a11y label only when the caller supplied a meaningful
       // tooltip; otherwise hide from assistive tech entirely (the parent
       // tab already announces the session). Mixing aria-label with
-      // aria-hidden=true is a contradiction screen readers will warn on.
-      aria-label={title ?? undefined}
-      aria-hidden={title ? undefined : true}
-      role={title ? 'img' : undefined}
-      title={title}
+      // aria-hidden=true is a contradiction screen readers will warn on,
+      // so route everything through the same `hasTitle` boolean.
+      aria-label={labelTitle}
+      aria-hidden={hasTitle ? undefined : true}
+      role={hasTitle ? 'img' : undefined}
+      title={labelTitle}
       data-testid={testId}
     >
       {glyph}

--- a/src/components/StatusIcon.tsx
+++ b/src/components/StatusIcon.tsx
@@ -1,21 +1,70 @@
-// Inline SVG status glyphs for the sidebar. Replaces the colored-dot
-// indicators that lived in `SidebarTab` with one icon per
-// [`DisplayStatus`]. Kept as inline SVGs (no icon-library dependency)
-// to match the convention established by `ToolIcon.tsx`.
+// Status indicator glyphs for the sidebar — one Nerd Font codicon per
+// [`DisplayStatus`] so the right-hand status column reads as fast as a
+// row of text. Replaces the inline SVGs that lived here previously,
+// piggy-backing on the bundled `CaskaydiaCove NF` font (added in #61)
+// so we don't ship a second icon library.
 //
-// Each icon paints from `currentColor` so Tailwind text-color classes
-// recolour them; the per-state color is owned by the caller and is set
-// via the `className` prop. Sizes are uniform (h-3.5 w-3.5 by default
-// at the call site) so swapping states does not nudge layout.
+// Codicons live in the U+EA60–U+EC1E PUA range and are guaranteed to be
+// present in any Nerd Font v3.x build. See
+// https://www.nerdfonts.com/cheat-sheet for the upstream catalogue;
+// each glyph below cites the upstream `nf-cod-…` name as a lookup key
+// for future swaps.
+//
+// The component renders a plain `<span>`. The caller owns sizing
+// (`text-*`), colour (`text-{colour}-{shade}`) and animation
+// (`animate-{spin,pulse}`) classes via the `className` prop. We pin the
+// glyph's box to `1em × 1em` so the surrounding layout doesn't shift
+// when the state — and therefore the glyph — changes.
 
 import type { DisplayStatus } from '@/store/session-store';
 
 interface StatusIconProps {
   status: DisplayStatus;
   className?: string;
-  /** Set as `<title>` for hover-tooltip + assistive-tech label. */
+  /** Set as the native `title` attribute for hover-tooltip + assistive-tech label. */
   title?: string;
 }
+
+// Codepoints lifted from the Nerd Fonts v3 `glyphnames.json` catalogue.
+// Keep the comments in sync with the upstream `nf-cod-…` name so a
+// future maintainer can re-derive the codepoint from the cheatsheet.
+const STATUS_GLYPHS: Record<Exclude<DisplayStatus, 'idle'>, string> = {
+  starting: '\ueb19', // nf-cod-loading — partial-ring spinner (pairs with animate-spin)
+  working: '\uec10', // nf-cod-sparkle — "model is generating"
+  awaiting: '\uea6b', // nf-cod-comment — speech bubble: agent is parked at its prompt
+  attention: '\ueaa2', // nf-cod-bell — matches OSC 9 / OSC 777 / standalone BEL semantics
+  awaitingPermission: '\uea75', // nf-cod-lock — agent is blocked on a permission decision
+  runningTool: '\ueb6d', // nf-cod-tools — agent invoked a tool
+  thinking: '\uea7c', // nf-cod-ellipsis — assistant turn in flight (pairs with animate-pulse)
+  exited: '\uead7', // nf-cod-debug_stop — terminal-state filled square
+  error: '\uea87', // nf-cod-error — circle with bang
+};
+
+// Stable kebab-case suffix for the test id. Predates the camelCase
+// `awaitingPermission` / `runningTool` enum names — kept verbatim so any
+// existing or external assertion against the previous testid keeps
+// working after the SVG → glyph swap.
+const STATUS_TESTID_SUFFIX: Record<Exclude<DisplayStatus, 'idle'>, string> = {
+  starting: 'starting',
+  working: 'working',
+  awaiting: 'awaiting',
+  attention: 'attention',
+  awaitingPermission: 'awaiting-permission',
+  runningTool: 'running-tool',
+  thinking: 'thinking',
+  exited: 'exited',
+  error: 'error',
+};
+
+// `inline-block w-[1em] text-center` pins the glyph's box to a square
+// the size of the current font, so layout stays stable when the active
+// state — and therefore the codepoint — changes. `leading-none` strips
+// the inherited line-box so the box's reported height equals its
+// font-size; the unread-overlay dot in `SidebarTab` anchors off this
+// box and would jitter otherwise. `font-sans` pins the glyph to the
+// bundled `CaskaydiaCove NF` family even when the icon is rendered
+// inside a `font-mono` ancestor (e.g. terminal-adjacent surfaces).
+const BASE_CLASSES = 'inline-block w-[1em] text-center font-sans leading-none';
 
 export function StatusIcon({ status, className, title }: StatusIconProps): JSX.Element | null {
   // `idle` intentionally renders nothing — a quiescent session shouldn't
@@ -23,127 +72,23 @@ export function StatusIcon({ status, className, title }: StatusIconProps): JSX.E
   // than reserving space for an absent glyph.
   if (status === 'idle') return null;
 
-  const common = {
-    xmlns: 'http://www.w3.org/2000/svg',
-    viewBox: '0 0 24 24',
-    fill: 'none',
-    stroke: 'currentColor',
-    strokeWidth: 2,
-    strokeLinecap: 'round' as const,
-    strokeLinejoin: 'round' as const,
-    // Provide an a11y label only when the caller supplied a meaningful
-    // tooltip; otherwise hide from assistive tech entirely (the parent
-    // tab already announces the session). Mixing aria-label with
-    // aria-hidden=true is a contradiction screen readers will warn on.
-    'aria-label': title ?? undefined,
-    'aria-hidden': title ? undefined : true,
-    role: title ? ('img' as const) : undefined,
-    className,
-  };
+  const glyph = STATUS_GLYPHS[status];
+  const testId = `status-icon-${STATUS_TESTID_SUFFIX[status]}`;
 
-  switch (status) {
-    case 'starting':
-      // Three-quarter ring with the gap pointing up-right; pairs with
-      // an `animate-spin` class supplied by the caller for the spinner
-      // effect.
-      return (
-        <svg {...common} data-testid="status-icon-starting">
-          {title ? <title>{title}</title> : null}
-          <path d="M12 3 a9 9 0 1 1 -9 9" />
-        </svg>
-      );
-
-    case 'working':
-      // Sparkles — evokes "the model is generating".
-      return (
-        <svg {...common} data-testid="status-icon-working">
-          {title ? <title>{title}</title> : null}
-          <path d="M12 3 l1.6 4.4 L18 9 l-4.4 1.6 L12 15 l-1.6-4.4 L6 9 l4.4-1.6 z" />
-          <path d="M18 14 l0.8 2.2 L21 17 l-2.2 0.8 L18 20 l-0.8-2.2 L15 17 l2.2-0.8 z" />
-        </svg>
-      );
-
-    case 'awaiting':
-      // Speech bubble — "the agent has finished and is waiting for you
-      // to say something".
-      return (
-        <svg {...common} data-testid="status-icon-awaiting">
-          {title ? <title>{title}</title> : null}
-          <path d="M4 5 h16 a1 1 0 0 1 1 1 v10 a1 1 0 0 1 -1 1 h-9 l-4 3 v-3 H4 a1 1 0 0 1 -1 -1 V6 a1 1 0 0 1 1 -1 z" />
-        </svg>
-      );
-
-    case 'attention':
-      // Bell — matches OSC 9 / OSC 777 / standalone BEL semantics.
-      return (
-        <svg {...common} data-testid="status-icon-attention">
-          {title ? <title>{title}</title> : null}
-          <path d="M6 16 V11 a6 6 0 0 1 12 0 v5 l1.5 2 H4.5 z" />
-          <path d="M10 20 a2 2 0 0 0 4 0" />
-        </svg>
-      );
-
-    case 'awaitingPermission':
-      // Padlock — agent is blocked on a permission decision. The amber
-      // colour (set by the caller via className) deliberately matches
-      // `attention` so the user reads "this tab needs me" at a glance.
-      return (
-        <svg {...common} data-testid="status-icon-awaiting-permission">
-          {title ? <title>{title}</title> : null}
-          <rect x="5" y="11" width="14" height="9" rx="2" />
-          <path d="M8 11 V8 a4 4 0 0 1 8 0 v3" />
-        </svg>
-      );
-
-    case 'runningTool':
-      // Wrench — distinct from the sparkle (`working`) and dots
-      // (`thinking`) so a glance at the icon answers "what is the agent
-      // doing right now?".
-      return (
-        <svg {...common} data-testid="status-icon-running-tool">
-          {title ? <title>{title}</title> : null}
-          <path d="M14.7 3.5 a4.5 4.5 0 0 0 5.8 5.8 L13 16.8 l-2.8-2.8 z" />
-          <line x1="9.5" y1="14.5" x2="4.5" y2="19.5" />
-        </svg>
-      );
-
-    case 'thinking':
-      // Three dots — universal "agent is processing". Pairs with an
-      // `animate-pulse` class supplied by the caller.
-      return (
-        <svg {...common} data-testid="status-icon-thinking" fill="currentColor" stroke="none">
-          {title ? <title>{title}</title> : null}
-          <circle cx="6" cy="12" r="1.5" />
-          <circle cx="12" cy="12" r="1.5" />
-          <circle cx="18" cy="12" r="1.5" />
-        </svg>
-      );
-
-    case 'exited':
-      // Filled stop square — terminal-state indicator.
-      return (
-        <svg {...common} fill="currentColor" data-testid="status-icon-exited">
-          {title ? <title>{title}</title> : null}
-          <rect x="6" y="6" width="12" height="12" rx="1.5" />
-        </svg>
-      );
-
-    case 'error':
-      // Triangle with a bang — universal "something went wrong".
-      return (
-        <svg {...common} data-testid="status-icon-error">
-          {title ? <title>{title}</title> : null}
-          <path d="M12 3 L22 20 H2 z" />
-          <line x1="12" y1="10" x2="12" y2="14" />
-          <line x1="12" y1="17" x2="12" y2="17.01" />
-        </svg>
-      );
-
-    default: {
-      // Exhaustive: TS will flag a new DisplayStatus variant here.
-      const _exhaustive: never = status;
-      void _exhaustive;
-      return null;
-    }
-  }
+  return (
+    <span
+      className={className ? `${BASE_CLASSES} ${className}` : BASE_CLASSES}
+      // Provide an a11y label only when the caller supplied a meaningful
+      // tooltip; otherwise hide from assistive tech entirely (the parent
+      // tab already announces the session). Mixing aria-label with
+      // aria-hidden=true is a contradiction screen readers will warn on.
+      aria-label={title ?? undefined}
+      aria-hidden={title ? undefined : true}
+      role={title ? 'img' : undefined}
+      title={title}
+      data-testid={testId}
+    >
+      {glyph}
+    </span>
+  );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,6 +9,13 @@ export default {
       fontFamily: {
         sans: ["'CaskaydiaCove NF'", ...defaultTheme.fontFamily.sans],
         mono: ["'CaskaydiaCove NF Mono'", ...defaultTheme.fontFamily.mono],
+        // Dedicated stack for Nerd Font icon glyphs (e.g. `StatusIcon`).
+        // Pinned to CaskaydiaCove NF only — no generic fallback — so the
+        // icon column either renders the codicon or shows tofu rather
+        // than silently falling back to a system font that lacks the
+        // PUA codepoints. Decoupled from `sans` so reorganising the
+        // body-font stack can't accidentally break icon rendering.
+        icon: ["'CaskaydiaCove NF'"],
       },
     },
   },


### PR DESCRIPTION
Closes #64.

Replaces the hand-rolled inline SVG status icons with Codicon glyphs
from the bundled CaskaydiaCove Nerd Font (added in #61). Each
`DisplayStatus` maps to a single PUA codepoint:

| State                | Glyph                       | Codepoint |
|----------------------|-----------------------------|-----------|
| `starting`           | `nf-cod-loading`            | U+EB19    |
| `working`            | `nf-cod-sparkle`            | U+EC10    |
| `awaiting`           | `nf-cod-comment`            | U+EA6B    |
| `attention`          | `nf-cod-bell`               | U+EAA2    |
| `awaitingPermission` | `nf-cod-lock`               | U+EA75    |
| `runningTool`        | `nf-cod-tools`              | U+EB6D    |
| `thinking`           | `nf-cod-ellipsis`           | U+EA7C    |
| `exited`             | `nf-cod-debug_stop`         | U+EAD7    |
| `error`              | `nf-cod-error`              | U+EA87    |

The component still renders nothing for `idle` (preserves the prior
"no-shout-when-quiescent" behaviour) and keeps the same prop API
(`status`, `className`, `title`) so the `SidebarTab` caller is
untouched apart from swapping `h-3.5 w-3.5` for `text-base` (icon
size is now driven by font-size rather than SVG dimensions).

### Layout stability
Glyph geometry is pinned to a 1em x 1em box (`inline-block w-[1em]
text-center leading-none`) so swapping states does not jitter the
icon column or the unread-overlay dot anchored over it. `font-sans`
guarantees the proportional `CaskaydiaCove NF` family is used even
inside `font-mono` ancestors.

### Test ids preserved
`status-icon-awaiting-permission` and `status-icon-running-tool`
keep their existing kebab-case suffixes via an explicit
`STATUS_TESTID_SUFFIX` map.

### Test coverage
New tests assert: glyph presence per state, single-codepoint shape,
`U+EA60..U+EC1E` codicon-range membership, no glyph collisions
across states, font-family pinning, and the previous a11y / tooltip
contract.

### Verification
- `npm run lint` clean
- `npm test -- --run` -> 485/485 passing
- `npm run build` succeeds

🤖 PR opened by an AI agent acting on behalf of @mcaden.
