### PR TITLE
feat: include workspace name and braces around branch in window title (#56)

### DIFF
--- a/dev/docs/CONFIGURATION.md
+++ b/dev/docs/CONFIGURATION.md
@@ -55,7 +55,7 @@ graph TD
 
 The **branch axis** is keyed off the build-time `BUILD_BRANCH` (see
 `build.rs`); for a `main` (or untagged) build the `branches/<…>/` segment
-collapses, mirroring the title-bar's `window_title_for_branch` rule. The
+collapses, mirroring the title-bar's `window_title` rule. The
 **workspace axis** is keyed off a deterministic hash of the canonicalised
 workspace root path. Two parallel Arborist instances bound to different
 pairs therefore touch disjoint files, and the `.lock` file inside each

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1508,7 +1508,20 @@ pub async fn workspace_switch_impl(
         .path()
         .app_data_dir()
         .map_err(|e| AppError::new("Io", format!("app_data_dir: {e}")))?;
-    workspace_switch_impl_inner(ctx, &app_data_dir, crate::BUILD_BRANCH, new_path).await
+    let result = workspace_switch_impl_inner(ctx, &app_data_dir, crate::BUILD_BRANCH, new_path).await?;
+
+    // Refresh the OS window title so the new workspace name is visible (issue #56). Read the *currently bound* workspace from `ctx.workspace` rather
+    // than `result.workspace_root`, so if two switches race and resume out of order after the inner barrier releases, the title still ends up
+    // matching the workspace the runtime is actually bound to. Best-effort: failures only affect the title, not the switch result.
+    if let Some(window) = app_handle.get_webview_window("main") {
+        let current_root = ctx.workspace.read().expect("workspace lock poisoned").workspace_root.clone();
+        let title = crate::window_title(crate::BUILD_BRANCH, current_root.as_deref());
+        if let Err(err) = window.set_title(&title) {
+            tracing::warn!(%err, "failed to update main window title after workspace switch");
+        }
+    }
+
+    Ok(result)
 }
 
 /// Testable inner of [`workspace_switch_impl`]. See module-level docs on the public wrapper for the full pipeline. Split out so unit tests can drive

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1510,14 +1510,25 @@ pub async fn workspace_switch_impl(
         .map_err(|e| AppError::new("Io", format!("app_data_dir: {e}")))?;
     let result = workspace_switch_impl_inner(ctx, &app_data_dir, crate::BUILD_BRANCH, new_path).await?;
 
-    // Refresh the OS window title so the new workspace name is visible (issue #56). Read the *currently bound* workspace from `ctx.workspace` rather
-    // than `result.workspace_root`, so if two switches race and resume out of order after the inner barrier releases, the title still ends up
-    // matching the workspace the runtime is actually bound to. Best-effort: failures only affect the title, not the switch result.
+    // Refresh the OS window title so the new workspace name is visible (issue #56). To make this deterministic across rapid back-to-back switches we
+    // hold the `ctx.workspace` READ guard across the `set_title` call rather than read-clone-drop-then-set: the inner's commit takes
+    // `ctx.workspace.write()`, which cannot acquire while any reader is active, so no newer scope can be committed between our `window_title`
+    // computation and the OS title-set. A delayed wrapper therefore can never overwrite a newer correct title with a stale value. The hold spans one
+    // synchronous OS call (`SetWindowTextW` / `NSWindow.title=` / `gtk_window_set_title`) — none re-enter into Arborist workspace code, so there is
+    // no deadlock surface. Lock-poisoning is treated as best-effort: log and skip rather than crash the whole process for a non-essential title
+    // refresh (matches the pattern in `commands::mod.rs` PtySink callbacks).
     if let Some(window) = app_handle.get_webview_window("main") {
-        let current_root = ctx.workspace.read().expect("workspace lock poisoned").workspace_root.clone();
-        let title = crate::window_title(crate::BUILD_BRANCH, current_root.as_deref());
-        if let Err(err) = window.set_title(&title) {
-            tracing::warn!(%err, "failed to update main window title after workspace switch");
+        match ctx.workspace.read() {
+            Ok(guard) => {
+                let title = crate::window_title(crate::BUILD_BRANCH, guard.workspace_root.as_deref());
+                if let Err(err) = window.set_title(&title) {
+                    tracing::warn!(%err, "failed to update main window title after workspace switch");
+                }
+                drop(guard);
+            }
+            Err(_) => {
+                tracing::warn!("workspace lock poisoned; skipping title refresh after workspace switch");
+            }
         }
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,16 +69,42 @@ pub fn init_tracing(log_dir: Option<&std::path::Path>) -> Option<WorkerGuard> {
     }
 }
 
-/// Compute the main window title for a given build branch.
+/// Compute the main window title for a given build branch and (optionally) bound workspace.
 ///
-/// On `main` (or when no branch could be detected) the title is just `"Arborist"`. On any other branch the title becomes `"Arborist - <branch>"` so
-/// it is obvious which build is running.
-pub(crate) fn window_title_for_branch(branch: &str) -> String {
-    let trimmed = branch.trim();
-    if trimmed.is_empty() || trimmed == "main" {
-        "Arborist".to_string()
+/// Format (issue #56):
+/// * canonical build, no workspace → `Arborist`
+/// * canonical build, workspace bound → `Arborist - <workspace>`
+/// * feature build, no workspace → `Arborist {<branch>}`
+/// * feature build, workspace bound → `Arborist - <workspace> {<branch>}`
+///
+/// "Canonical" matches [`store_layout::is_canonical_build`] (empty branch or the literal `"main"`) so the title-bar story and the storage-scoping
+/// story stay aligned to one rule. The branch in the title is the **build-time** `BUILD_BRANCH` — same axis as storage scoping — not the workspace's
+/// currently-checked-out branch. The workspace name is the path's trailing component (see [`workspace_basename`]).
+pub(crate) fn window_title(branch: &str, workspace_root: Option<&std::path::Path>) -> String {
+    let trimmed_branch = branch.trim();
+    let workspace_name = workspace_root.and_then(workspace_basename);
+
+    let mut title = String::from("Arborist");
+    if let Some(ws) = workspace_name {
+        title.push_str(" - ");
+        title.push_str(&ws);
+    }
+    if !store_layout::is_canonical_build(branch) {
+        title.push_str(" {");
+        title.push_str(trimmed_branch);
+        title.push('}');
+    }
+    title
+}
+
+/// Display name for a workspace path: the trailing path component, lossily stringified. Returns `None` when the path has no usable component (e.g.
+/// a filesystem root like `/` or `C:\`), so callers can decide to omit the workspace segment entirely rather than print an empty name.
+fn workspace_basename(path: &std::path::Path) -> Option<String> {
+    let name = path.file_name()?.to_string_lossy().into_owned();
+    if name.is_empty() {
+        None
     } else {
-        format!("Arborist - {trimmed}")
+        Some(name)
     }
 }
 
@@ -108,9 +134,11 @@ pub fn run() {
             tracing::info!("Arborist starting up");
 
             // If this build came from a branch other than `main`, surface the branch name in the window title bar so it's obvious which build is
-            // running.
+            // running. We set the title twice: once here with no workspace bound (covers the brief startup window before `boot_select_workspace`
+            // returns), and again after the workspace binding succeeds with the bound `workspace_root` so the workspace name is included
+            // (issue #56).
             if let Some(window) = app.get_webview_window("main") {
-                let title = window_title_for_branch(BUILD_BRANCH);
+                let title = window_title(BUILD_BRANCH, None);
                 if let Err(err) = window.set_title(&title) {
                     tracing::warn!(%err, "failed to set main window title");
                 }
@@ -187,6 +215,15 @@ pub fn run() {
             // Boot succeeded — hand the WorkerGuard off to Tauri's managed state so logs continue to flush for the lifetime of the running app.
             if let Some(guard) = log_guard {
                 app.manage(LogGuard(guard));
+            }
+
+            // Re-set the window title now that we know which workspace we bound (issue #56). The earlier set above used `None` so users see the build
+            // branch immediately; this update adds the workspace name. Best-effort: a failure here only affects the title, not the boot.
+            if let Some(window) = app.get_webview_window("main") {
+                let title = window_title(BUILD_BRANCH, Some(&binding.workspace_root));
+                if let Err(err) = window.set_title(&title) {
+                    tracing::warn!(%err, "failed to update main window title after workspace bind");
+                }
             }
 
             // Build the production AppContext: portable-pty spawner, the workspace-bound ConfigStore (held behind RwLock so phase 7 workspace_switch
@@ -287,6 +324,7 @@ pub fn run() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
 
     #[test]
     fn init_tracing_is_idempotent() {
@@ -295,20 +333,87 @@ mod tests {
         init_tracing(None);
     }
 
+    // ----- window_title — full matrix of (canonical-build × workspace-bound). Issue #56.
+
     #[test]
-    fn title_on_main_is_plain() {
-        assert_eq!(window_title_for_branch("main"), "Arborist");
+    fn title_canonical_build_no_workspace_is_plain() {
+        assert_eq!(window_title("main", None), "Arborist");
+        assert_eq!(window_title("", None), "Arborist");
+        assert_eq!(window_title("   ", None), "Arborist");
     }
 
     #[test]
-    fn title_on_empty_branch_is_plain() {
-        assert_eq!(window_title_for_branch(""), "Arborist");
-        assert_eq!(window_title_for_branch("   "), "Arborist");
+    fn title_canonical_build_with_workspace_appends_dash_workspace() {
+        assert_eq!(window_title("main", Some(Path::new("/Users/dev/projects/grove"))), "Arborist - grove");
+        assert_eq!(window_title("", Some(Path::new("/Users/dev/projects/grove"))), "Arborist - grove");
     }
 
     #[test]
-    fn title_on_feature_branch_includes_name() {
-        assert_eq!(window_title_for_branch("feature/x"), "Arborist - feature/x");
-        assert_eq!(window_title_for_branch("  branch-name  "), "Arborist - branch-name");
+    fn title_feature_build_no_workspace_wraps_branch_in_braces() {
+        assert_eq!(window_title("feature/x", None), "Arborist {feature/x}");
+        assert_eq!(window_title("branch-name", None), "Arborist {branch-name}");
+    }
+
+    #[test]
+    fn title_feature_build_with_workspace_includes_both() {
+        assert_eq!(
+            window_title("my-feature-branch", Some(Path::new("/Users/dev/projects/my-workspace"))),
+            "Arborist - my-workspace {my-feature-branch}",
+        );
+    }
+
+    #[test]
+    fn title_trims_branch_whitespace_in_braces() {
+        assert_eq!(
+            window_title("  feature/x  ", Some(Path::new("/Users/dev/projects/grove"))),
+            "Arborist - grove {feature/x}",
+        );
+        assert_eq!(window_title("  branch-name  ", None), "Arborist {branch-name}");
+    }
+
+    // ----- workspace_basename edge cases.
+
+    #[cfg(unix)]
+    #[test]
+    fn workspace_basename_unix_returns_trailing_component() {
+        assert_eq!(workspace_basename(Path::new("/Users/dev/projects/grove")), Some("grove".to_string()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workspace_basename_unix_handles_trailing_separator() {
+        // Path::file_name skips the trailing separator and returns the real basename.
+        assert_eq!(workspace_basename(Path::new("/Users/dev/projects/grove/")), Some("grove".to_string()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workspace_basename_unix_returns_none_for_root() {
+        assert_eq!(workspace_basename(Path::new("/")), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn workspace_basename_windows_returns_trailing_component() {
+        assert_eq!(workspace_basename(Path::new(r"C:\repos\grove")), Some("grove".to_string()));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn workspace_basename_windows_handles_trailing_separator() {
+        assert_eq!(workspace_basename(Path::new(r"C:\repos\grove\")), Some("grove".to_string()));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn workspace_basename_windows_returns_none_for_drive_root() {
+        assert_eq!(workspace_basename(Path::new(r"C:\")), None);
+    }
+
+    #[test]
+    fn workspace_basename_preserves_unicode() {
+        // file_name + to_string_lossy preserves valid UTF-8 unchanged.
+        let path = std::env::temp_dir().join("プロジェクト");
+        assert_eq!(workspace_basename(&path).as_deref(), Some("プロジェクト"));
     }
 }

--- a/src-tauri/src/store_layout.rs
+++ b/src-tauri/src/store_layout.rs
@@ -28,7 +28,7 @@
 //! ```
 //!
 //! The "canonical" build (empty `BUILD_BRANCH` or the literal `"main"`) collapses the `branches/<branch>/` segment so existing installs see no path
-//! change at the branch axis. The same collapse rule is already used by the title bar — see [`crate::window_title_for_branch`].
+//! change at the branch axis. The same collapse rule is already used by the title bar — see [`crate::window_title`].
 //!
 //! All functions in this module are pure and deterministic: they do not touch the filesystem. Disk I/O (lock acquisition, seeding, atomic writes)
 //! lives in the modules that consume these paths.
@@ -104,7 +104,7 @@ impl std::fmt::Display for CanonicalPath {
 /// Returns `true` if `branch` represents the canonical (top-level) build.
 ///
 /// Both an empty string (no git info / detached HEAD / shallow clone) and the literal `"main"` collapse to the canonical layout. This mirrors
-/// [`crate::window_title_for_branch`] so the title-bar story and the
+/// [`crate::window_title`] so the title-bar story and the
 /// storage-key story stay aligned.
 #[must_use]
 pub fn is_canonical_build(branch: &str) -> bool {


### PR DESCRIPTION
Closes #56.

Format change for the OS-native main window title:

| Build       | Workspace bound | Title                              |
| ----------- | --------------- | ---------------------------------- |
| canonical   | no              | `Arborist`                       |
| canonical   | yes             | `Arborist - <workspace>`         |
| feature     | no              | `Arborist {<branch>}`            |
| feature     | yes             | `Arborist - <workspace> {<branch>}` |

The curly braces visually isolate the build branch from surrounding text, and the workspace basename makes it clear which workspace the window belongs to when multiple Arborist instances are open in parallel.

### Scope note on color

The issue describes coloring the branch orange and the workspace name in the same color as `Arborist`. The current title bar is the OS-native window title bar, which does not support colored text. Per the implementation discussion, this PR updates the title text only; the colored styling is left for a future custom in-app title bar.

### Implementation

- `window_title_for_branch` is replaced by `window_title(branch, workspace_root: Option<&Path>)`. The canonical-build collapse now reuses `store_layout::is_canonical_build` so the title-bar story and the storage-scoping story stay coupled to one rule.
- `workspace_basename` returns `Path::file_name` lossily stringified; filesystem roots return `None` so the workspace segment is omitted rather than printed empty.
- The title is set three times across the binding lifetime:
  1. Start of `run::setup` with `workspace=None` (covers the brief startup window before workspace bind).
  2. After `boot_select_workspace` succeeds, with `Some(&binding.workspace_root)`.
  3. After every successful `workspace_switch`. The wrapper reads the currently-bound workspace from `ctx.workspace` rather than the returned `WorkspaceSwitchResult.workspace_root` so out-of-order resumption of queued switches still leaves the title matching the runtime's actual binding.

### Tests

11 new pure-fn unit tests cover:

- The full 2x2 matrix of (canonical/feature build x bound/unbound workspace).
- Whitespace trimming in the branch component.
- `workspace_basename` edge cases: trailing separator, filesystem root (Unix and Windows gated), Unicode preservation.

Verification: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `npm run lint`, `npm test -- --run` all green locally.

> 🤖 This pull request was prepared by Copilot CLI.