### PR TITLE
[pr-prefix] docs: require [worktree] prefix on PR titles

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,8 @@ Read both before proposing implementation work. When the codebase is scaffolded,
 
 This repo has a remote at `origin` -> `https://github.com/mcaden/arborist.git`. Agents may commit, push feature branches, and open pull requests. Do not push directly to `main` and do not force-push shared branches; land changes through PRs.
 
+**PR title convention.** Always prefix PR titles with the worktree name in square brackets, falling back to the branch name when no worktree name is available: `[<worktree-or-branch>] <summary>`. The worktree name is the basename of the current worktree directory (e.g., a worktree at `.worktrees/pr-prefix` yields `[pr-prefix]`). Apply this to every `gh pr create` invocation.
+
 ## Dogfooding safety — don't kill the host
 
 This repo is dogfooded: the user typically runs the **host** `arborist.exe` (or `arborist` on macOS/Linux) and you, the agent, are executing inside one of its PTY sessions. Killing the host crashes the user's editor and every sibling session, including yours. **A previous agent killed the host this way — do not repeat it.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,11 @@ Rust backend owns all PTYs and persistent state; the React frontend communicates
 - Event names use `://` namespace (e.g., `session://output`); payloads are always named-field structs.
 - Path alias `@/*` → `src/*`; no deep relative imports.
 
+## Pull requests
+
+- **PR title prefix.** Always prefix PR titles with the worktree name in square brackets, falling back to the branch name when no worktree is in use: `[<worktree-or-branch>] <summary>`. The worktree name is the basename of the current worktree directory (e.g., `.worktrees/pr-prefix` → `[pr-prefix]`). Apply this to every `gh pr create` invocation.
+- Do not push directly to `main` and do not force-push shared branches; land changes through PRs.
+
 ## Skills (read on demand)
 
 Claude does not auto-discover skill files. When a task matches one of these, **read the linked file before acting**:


### PR DESCRIPTION
Adds a PR title convention to `.github/copilot-instructions.md` and `CLAUDE.md`: PR titles must be prefixed with the worktree name in square brackets (branch name as fallback), e.g. `[pr-prefix] <summary>`. The worktree name is the basename of the current worktree directory.

Docs-only change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>