### PR TITLE
[env-simplification] Remove ARBORIST_* environment variables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Rust backend owns all PTYs and persistent state; the React frontend communicates
 - **`PtySpawner` trait** — production uses `PortablePtySpawner`; tests inject `FakePtySpawner`
 - **`GitRunner` trait** — production uses `RealGitRunner`; tests inject canned porcelain output
 - **`tauri-bridge.mock.ts`** — frontend tests mock the entire bridge module via `vi.mock('@/lib/tauri-bridge', ...)`
-- **`arborist-test-child` binary** — PTY integration tests use this instead of real `claude`/`copilot`; env vars `ARBORIST_CLI_OVERRIDE_CLAUDE` / `ARBORIST_CLI_OVERRIDE_COPILOT` redirect compose output to it
+- **`arborist-test-child` binary** — PTY integration tests use this instead of real `claude`/`copilot`. Tests redirect compose output to it via `AppConfig.ai_launch_commands.claude/copilot` (Rust integration tests set the field directly through `PartialAppConfig`; the Linux e2e harness uses the boot CLI flags `--ai-launch-claude=<path>` / `--ai-launch-copilot=<path>`)
 
 ### Tool-specific CLI rules (easy to get wrong)
 

--- a/dev/docs/DESIGN.md
+++ b/dev/docs/DESIGN.md
@@ -1020,14 +1020,12 @@ All commands are gated by Tauri capability declarations in `capabilities/main.js
 | `subsession_relaunch` | `{ id }` | `SubSession` | Re-spawn a sub-session under the same id, refreshing `composedCommand` from the current def. See §5.7.7. Errors: `NotFound` (def deleted), `InvalidArgument` (def disabled or parent closing), `WorktreeMissing`, `PtySpawnFailed`/`AppSpawnFailed`/`ToolMissing`. |
 | `subsession_icon` | `{ id }` | `string \| null` | Best-effort fetch of the OS application icon for an `application`-kind sub-session, returned as a `data:image/png;base64,…` URI. Returns `null` (not an error) for terminal sub-sessions, exited PIDs, unsupported platforms, and lookup misses; the frontend falls back to a generic emoji on `null`. Backed by `IconCache` (keyed by canonical exe path; never re-extracts the same exe). Extraction runs on `tokio::task::spawn_blocking`. Per-platform: Windows uses `SHGetFileInfoW` + `DrawIconEx`; macOS shells out to `plutil` + `sips` against the `.app` bundle; Linux walks `~/.local/share/applications` + `/usr/share/applications` for a matching `.desktop` file and resolves `Icon=` against standard `hicolor` PNG paths (no SVG, no full XDG theme resolution). |
 
-> **Test-only seam.** The Rust backend consults two env vars,
-> `ARBORIST_CLI_OVERRIDE_CLAUDE` and `ARBORIST_CLI_OVERRIDE_COPILOT`, when composing
-> a session's command. If set, the value replaces the bare `claude` / `copilot`
-> program token (already shell-quoted). Production never sets these; they exist
-> only so integration tests can drive the full lifecycle against a deterministic
-> child process. The override path is encoded verbatim into the persisted
-> `composedCommand`, so restarting the session with the env var unset will spawn
-> the literal path (not fall back to `claude`/`copilot`). See
+> **Test-only seam.** The integration tests and Linux e2e harness override
+> the `claude` / `copilot` program tokens through the user-facing
+> `AppConfig.ai_launch_commands` config field — there is no environment-variable
+> seam. For e2e, `--ai-launch-claude=<path>` and `--ai-launch-copilot=<path>`
+> CLI flags (parsed in `boot::parse_cli_args`) seed the same config field at
+> boot. Production users get the same plumbing via the Settings dialog. See
 > `compose::cli_program_for_tool`.
 
 ### Events (Rust → Frontend)

--- a/dev/docs/TESTING.md
+++ b/dev/docs/TESTING.md
@@ -107,21 +107,21 @@ To poke at it manually:
 cargo run -p arborist --features test-helpers --bin arborist-test-child
 ```
 
-## 4. Test-only env-var seam: CLI program override
+## 4. Test-only seam: CLI program override
 
-`compose::cli_program_for_tool` consults two env vars when composing a
-session's command:
+`compose::cli_program_for_tool` honours the user-facing
+`AppConfig.ai_launch_commands` field as a verbatim shell-snippet override of
+the bare `claude` / `copilot` program token. Tests use the same plumbing real
+users get via the Settings dialog — there is no environment-variable seam.
 
-| Variable                          | Effect                                                          |
-| --------------------------------- | --------------------------------------------------------------- |
-| `ARBORIST_CLI_OVERRIDE_CLAUDE`       | Replaces the bare `claude` token in the composed command.       |
-| `ARBORIST_CLI_OVERRIDE_COPILOT`      | Replaces the bare `copilot` token in the composed command.      |
+| Surface                                             | Mechanism                                                                                |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `session_lifecycle_real.rs` (Rust integration test) | `store.save_config({ ai_launch_commands: { claude: <test-child path> } })` before create |
+| Linux e2e (`AppImage` under tauri-driver)           | `--ai-launch-claude=<path>` / `--ai-launch-copilot=<path>` CLI flags (see `boot.rs`)     |
 
-Production never sets these. They exist so `session_lifecycle_real.rs`
-can drive the full lifecycle against `arborist-test-child`. The override
-path is encoded verbatim into the persisted `composedCommand`; restarting
-without the env var still spawns the literal path (it does **not** fall
-back to `claude` / `copilot`). This is documented in `DESIGN.md` §6 too.
+The override path is encoded verbatim into the persisted `composedCommand`;
+restarting still spawns the literal path (it does **not** fall back to
+`claude` / `copilot`). This is documented in `DESIGN.md` §6 too.
 
 ## 5. Test-writing rules
 

--- a/dev/e2e/linux/Dockerfile
+++ b/dev/e2e/linux/Dockerfile
@@ -166,8 +166,6 @@ COPY dev/e2e/linux/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Environment for hermetic testing
-ENV ARBORIST_CLI_OVERRIDE_CLAUDE=/usr/local/bin/arborist-test-child
-ENV ARBORIST_CLI_OVERRIDE_COPILOT=/usr/local/bin/arborist-test-child
 ENV DISPLAY=:99
 ENV RUST_LOG=arborist_lib=info
 ENV WEBKIT_DISABLE_COMPOSITING_MODE=1

--- a/dev/e2e/linux/README.md
+++ b/dev/e2e/linux/README.md
@@ -48,8 +48,8 @@ pnpm e2e:linux:shell
 
 ### Hermetic CLI testing
 
-No real `claude` or `copilot` CLIs are installed. The env vars `ARBORIST_CLI_OVERRIDE_CLAUDE`
-and `ARBORIST_CLI_OVERRIDE_COPILOT` point at `arborist-test-child`, which provides a
+No real `claude` or `copilot` CLIs are installed. The boot CLI flags `--ai-launch-claude`
+and `--ai-launch-copilot` (set by `wdio.conf.ts`) point at `arborist-test-child`, which provides a
 deterministic line-based protocol (`ARBORIST-TEST-CHILD READY`, `quit`, `exit N`, `flood K`,
 `unicode`, and echo).
 

--- a/dev/e2e/linux/docker-compose.yml
+++ b/dev/e2e/linux/docker-compose.yml
@@ -31,8 +31,6 @@ services:
       # nested-mount problem that fails on Docker Desktop's 9P filesystem.
       - ./specs:/specs:ro
     environment:
-      - ARBORIST_CLI_OVERRIDE_CLAUDE=/usr/local/bin/arborist-test-child
-      - ARBORIST_CLI_OVERRIDE_COPILOT=/usr/local/bin/arborist-test-child
       - RUST_LOG=arborist_lib=info
       - WEBKIT_DISABLE_COMPOSITING_MODE=1
     tmpfs:
@@ -88,8 +86,6 @@ services:
       - ./specs:/specs:rw
       - ../../..:/src:ro
     environment:
-      - ARBORIST_CLI_OVERRIDE_CLAUDE=/usr/local/bin/arborist-test-child
-      - ARBORIST_CLI_OVERRIDE_COPILOT=/usr/local/bin/arborist-test-child
       - RUST_LOG=arborist_lib=debug
       - WEBKIT_DISABLE_COMPOSITING_MODE=1
     tmpfs:

--- a/dev/e2e/linux/entrypoint.sh
+++ b/dev/e2e/linux/entrypoint.sh
@@ -46,7 +46,7 @@ start_dbus() {
 
 setup_home() {
   # Use a fresh ephemeral HOME so each run starts clean (no leftover config)
-  export HOME="${ARBORIST_E2E_HOME:-/tmp/arborist-home}"
+  export HOME="${E2E_HOME:-/tmp/arborist-home}"
   mkdir -p "$HOME"
   echo "[entrypoint] HOME=$HOME"
 }
@@ -57,18 +57,18 @@ setup_home() {
 # legacy config → native picker`, and only the first arm is non-interactive).
 # wdio.conf.ts passes this path via tauri:options.args = ["--workspace", …].
 setup_test_workspace() {
-  export ARBORIST_TEST_WORKSPACE="${ARBORIST_TEST_WORKSPACE:-/tmp/arborist-test-workspace}"
-  if [ ! -d "$ARBORIST_TEST_WORKSPACE/.git" ]; then
-    rm -rf "$ARBORIST_TEST_WORKSPACE"
-    mkdir -p "$ARBORIST_TEST_WORKSPACE"
-    git -C "$ARBORIST_TEST_WORKSPACE" init -q -b main
-    git -C "$ARBORIST_TEST_WORKSPACE" config user.email "e2e@arborist.local"
-    git -C "$ARBORIST_TEST_WORKSPACE" config user.name "Arborist E2E"
-    echo "# Arborist e2e test workspace" > "$ARBORIST_TEST_WORKSPACE/README.md"
-    git -C "$ARBORIST_TEST_WORKSPACE" add README.md
-    git -C "$ARBORIST_TEST_WORKSPACE" commit -q -m "initial commit"
+  export E2E_TEST_WORKSPACE="${E2E_TEST_WORKSPACE:-/tmp/arborist-test-workspace}"
+  if [ ! -d "$E2E_TEST_WORKSPACE/.git" ]; then
+    rm -rf "$E2E_TEST_WORKSPACE"
+    mkdir -p "$E2E_TEST_WORKSPACE"
+    git -C "$E2E_TEST_WORKSPACE" init -q -b main
+    git -C "$E2E_TEST_WORKSPACE" config user.email "e2e@arborist.local"
+    git -C "$E2E_TEST_WORKSPACE" config user.name "Arborist E2E"
+    echo "# Arborist e2e test workspace" > "$E2E_TEST_WORKSPACE/README.md"
+    git -C "$E2E_TEST_WORKSPACE" add README.md
+    git -C "$E2E_TEST_WORKSPACE" commit -q -m "initial commit"
   fi
-  echo "[entrypoint] ARBORIST_TEST_WORKSPACE=$ARBORIST_TEST_WORKSPACE"
+  echo "[entrypoint] E2E_TEST_WORKSPACE=$E2E_TEST_WORKSPACE"
 }
 
 # ---- modes ------------------------------------------------------------------
@@ -126,7 +126,7 @@ run_shell() {
   echo "[entrypoint] AppImage extracted at /opt/arborist/"
   echo "[entrypoint] tauri-driver is at /usr/local/bin/tauri-driver"
   echo "[entrypoint] arborist-test-child is at /usr/local/bin/arborist-test-child"
-  echo "[entrypoint] Test workspace: $ARBORIST_TEST_WORKSPACE"
+  echo "[entrypoint] Test workspace: $E2E_TEST_WORKSPACE"
   echo ""
   exec bash "$@"
 }

--- a/dev/e2e/linux/specs/wdio.conf.ts
+++ b/dev/e2e/linux/specs/wdio.conf.ts
@@ -17,7 +17,12 @@ const APP_BINARY = "/opt/arborist/AppRun";
 // Without --workspace, arborist's boot resolution falls through to the native
 // folder picker and blocks forever in headless mode (the WebView is never
 // created → tauri-driver/WebKitWebDriver session POST hangs until timeout).
-const TEST_WORKSPACE = process.env.ARBORIST_TEST_WORKSPACE ?? "/tmp/arborist-test-workspace";
+const TEST_WORKSPACE = process.env.E2E_TEST_WORKSPACE ?? "/tmp/arborist-test-workspace";
+// Path to the deterministic stand-in for `claude` / `copilot` shipped by the
+// Dockerfile. Passed to arborist via `--ai-launch-claude` / `--ai-launch-copilot`
+// so the bare `claude` / `copilot` program tokens in the composed PTY command
+// resolve to this binary instead of requiring the real CLIs to be installed.
+const TEST_CHILD = "/usr/local/bin/arborist-test-child";
 const DRIVER_PORT = 4444;
 const DRIVER_STARTUP_TIMEOUT_MS = 10_000;
 const DRIVER_POLL_INTERVAL_MS = 100;
@@ -59,7 +64,12 @@ export const config: WebdriverIO.Config = {
       maxInstances: 1,
       "tauri:options": {
         application: APP_BINARY,
-        args: ["--workspace", TEST_WORKSPACE],
+        args: [
+          "--workspace",
+          TEST_WORKSPACE,
+          `--ai-launch-claude=${TEST_CHILD}`,
+          `--ai-launch-copilot=${TEST_CHILD}`,
+        ],
       },
     },
   ],

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -2,15 +2,14 @@
 // Run `tauri dev` on a per-worktree dev-server port so multiple branches /
 // worktrees can be developed in parallel without colliding on port 1420.
 //
-// Port resolution:
-//   1. `ARBORIST_DEV_PORT` env var (explicit override).
-//   2. Otherwise a deterministic hash of the current working directory in
-//      the range [PORT_MIN, PORT_MIN + PORT_RANGE).
+// Port resolution: a deterministic hash of the current working directory in
+// the range [PORT_MIN, PORT_MIN + PORT_RANGE).
 //
-// The chosen port is exported to the child process so:
-//   - `vite.config.ts` picks it up for the dev server.
-//   - This script overrides Tauri's `build.devUrl` via `--config` so the
-//     desktop shell loads the matching URL.
+// The chosen port is propagated to the child process via an override
+// `tauri.conf.json` written to a temp dir:
+//   - `build.beforeDevCommand` runs vite with `--port=<port>` so the frontend
+//     binds to the right port (no env var required).
+//   - `build.devUrl` is set to the matching URL so the desktop shell loads it.
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
@@ -20,37 +19,27 @@ import { fileURLToPath } from 'node:url';
 
 const PORT_MIN = 1420;
 const PORT_RANGE = 100;
-const PORT_MAX = 65535;
-
-function failInvalidPortOverride(override) {
-  console.error(`[arborist] ARBORIST_DEV_PORT must be an integer between 1 and ${PORT_MAX}; received "${override}"`);
-  process.exit(1);
-}
 
 function pickPort() {
-  const override = process.env.ARBORIST_DEV_PORT;
-  if (override !== undefined && override !== '') {
-    if (!/^\d+$/.test(override)) {
-      failInvalidPortOverride(override);
-    }
-    const port = Number(override);
-    if (!Number.isInteger(port) || port < 1 || port > PORT_MAX) {
-      failInvalidPortOverride(override);
-    }
-    return port;
-  }
   const hash = createHash('sha1').update(process.cwd()).digest();
   return PORT_MIN + (hash.readUInt16BE(0) % PORT_RANGE);
 }
 
 const port = pickPort();
-process.env.ARBORIST_DEV_PORT = String(port);
 
 // Write the override to a temp JSON file rather than passing it inline; on
 // Windows the shell strips quotes from inline JSON args, breaking parsing.
 const dir = mkdtempSync(join(tmpdir(), 'arborist-dev-'));
 const overridePath = join(dir, 'tauri.conf.override.json');
-writeFileSync(overridePath, JSON.stringify({ build: { devUrl: `http://localhost:${port}` } }));
+writeFileSync(
+  overridePath,
+  JSON.stringify({
+    build: {
+      beforeDevCommand: `pnpm exec vite --port=${port} --strictPort`,
+      devUrl: `http://localhost:${port}`,
+    },
+  }),
+);
 
 let cleanedUp = false;
 function cleanup() {

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -35,7 +35,7 @@ writeFileSync(
   overridePath,
   JSON.stringify({
     build: {
-      beforeDevCommand: `pnpm exec vite --port=${port} --strictPort`,
+      beforeDevCommand: `pnpm run vite -- --port=${port} --strictPort`,
       devUrl: `http://localhost:${port}`,
     },
   }),

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::process::Command;
 
 /// Build a `git` Command with repo-selection environment variables stripped.
@@ -5,9 +6,9 @@ use std::process::Command;
 /// build.rs runs as a child of `cargo`, which under a husky pre-push hook
 /// inherits `GIT_DIR`/`GIT_WORK_TREE`/etc. from the outer `git push`. Without
 /// stripping them, our branch detection would report the *outer* repo's
-/// branch and bake the wrong value into `ARBORIST_BUILD_BRANCH`. Mirrors
-/// `git::git_command()` (kept duplicated because build scripts can't depend
-/// on the crate being built).
+/// branch and bake the wrong value into the generated `build_branch.txt`.
+/// Mirrors `git::git_command()` (kept duplicated because build scripts can't
+/// depend on the crate being built).
 fn git_command() -> Command {
     let mut cmd = Command::new("git");
     for var in [
@@ -34,11 +35,11 @@ fn git_command() -> Command {
 ///
 /// Returns an empty string if none succeed or the branch is detached / `HEAD`.
 ///
-/// Note: there is intentionally no `ARBORIST_BUILD_BRANCH` override input.
-/// CI vars + git already cover every legitimate case, and an env-var input
-/// would silently leak into PTY children spawned by the running app (which
-/// inherit the build/dev shell's env), baking the wrong branch into any
-/// nested `tauri:dev` invocation.
+/// Note: there is intentionally no env-var override input. CI vars + git
+/// already cover every legitimate case, and an env-var input would silently
+/// leak into PTY children spawned by the running app (which inherit the
+/// build/dev shell's env), baking the wrong branch into any nested
+/// `tauri:dev` invocation.
 fn detect_branch() -> String {
     for var in ["GITHUB_HEAD_REF", "GITHUB_REF_NAME"] {
         if let Ok(v) = std::env::var(var) {
@@ -79,11 +80,16 @@ fn sanitize_branch(raw: &str) -> String {
 
 fn main() {
     let branch = sanitize_branch(&detect_branch());
-    println!("cargo:rustc-env=ARBORIST_BUILD_BRANCH={branch}");
 
-    // Re-run when CI env vars change. We deliberately do NOT
-    // `rerun-if-env-changed=ARBORIST_BUILD_BRANCH` — that variable is no
-    // longer an input (see `detect_branch` doc comment).
+    // Bake the branch into a generated file under OUT_DIR; lib.rs reads it via
+    // `include_str!`. We deliberately avoid `cargo:rustc-env=` (which would
+    // require an `env!()` read at compile time) so the entire codebase is free
+    // of project-specific environment variables.
+    let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").expect("cargo provides OUT_DIR"));
+    let branch_file = out_dir.join("build_branch.txt");
+    std::fs::write(&branch_file, &branch).expect("write build_branch.txt");
+
+    // Re-run when CI env vars change.
     println!("cargo:rerun-if-env-changed=GITHUB_HEAD_REF");
     println!("cargo:rerun-if-env-changed=GITHUB_REF_NAME");
 

--- a/src-tauri/src/app_launcher.rs
+++ b/src-tauri/src/app_launcher.rs
@@ -247,7 +247,6 @@ impl AppSpawner for RealAppSpawner {
 
         let mut command = build_shell_command(trimmed);
         command.current_dir(cwd).stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
-        strip_arborist_env(&mut command);
         configure_detach(&mut command);
 
         let child = command.spawn().map_err(|e| Error::AppSpawnFailed(format!("spawn `{trimmed}`: {e}")))?;
@@ -304,23 +303,6 @@ fn which_in_path(tool: &str) -> Option<PathBuf> {
         }
     }
     None
-}
-
-/// Returns `true` when `key` starts with `ARBORIST_` (case-insensitive).
-fn is_arborist_env_key(key: &std::ffi::OsStr) -> bool {
-    const PREFIX: &[u8] = b"ARBORIST_";
-    let bytes = key.as_encoded_bytes();
-    bytes.len() >= PREFIX.len() && bytes[..PREFIX.len()].eq_ignore_ascii_case(PREFIX)
-}
-
-/// Strip `ARBORIST_*` env vars from the spawned command so they don't leak
-/// into children (e.g. VSCode terminals inheriting `ARBORIST_DEV_PORT`).
-/// Mirror of `pty_pool::strip_arborist_env` adapted for `std::process::Command`.
-fn strip_arborist_env(command: &mut std::process::Command) {
-    let keys: Vec<_> = std::env::vars_os().filter(|(k, _)| is_arborist_env_key(k)).map(|(k, _)| k).collect();
-    for k in keys {
-        command.env_remove(&k);
-    }
 }
 
 #[cfg(target_os = "windows")]
@@ -1838,71 +1820,5 @@ mod tests {
         let res = pool.request_window_close(&id, &focuser);
         assert!(matches!(res, Err(Error::NotFound(_))));
         assert!(focuser.close_calls().is_empty());
-    }
-
-    // ── strip_arborist_env / is_arborist_env_key tests ──────────────
-
-    #[test]
-    fn is_arborist_env_key_matches_prefixed_keys() {
-        assert!(is_arborist_env_key(std::ffi::OsStr::new("ARBORIST_DEV_PORT")));
-        assert!(is_arborist_env_key(std::ffi::OsStr::new("ARBORIST_BUILD_BRANCH")));
-    }
-
-    #[test]
-    fn is_arborist_env_key_is_case_insensitive() {
-        assert!(is_arborist_env_key(std::ffi::OsStr::new("arborist_dev_port")));
-        assert!(is_arborist_env_key(std::ffi::OsStr::new("Arborist_Build_Branch")));
-    }
-
-    #[test]
-    fn is_arborist_env_key_rejects_non_prefixed() {
-        assert!(!is_arborist_env_key(std::ffi::OsStr::new("PATH")));
-        assert!(!is_arborist_env_key(std::ffi::OsStr::new("MY_ARBORIST_VAR")));
-        assert!(!is_arborist_env_key(std::ffi::OsStr::new("ARBORISH_DEV")));
-    }
-
-    #[test]
-    fn is_arborist_env_key_handles_short_or_empty_keys() {
-        assert!(!is_arborist_env_key(std::ffi::OsStr::new("")));
-        assert!(!is_arborist_env_key(std::ffi::OsStr::new("AR")));
-        assert!(!is_arborist_env_key(std::ffi::OsStr::new("ARBORIST")));
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn strip_arborist_env_removes_prefixed_keys_from_command() {
-        // Exercise the full strip_arborist_env path with a real env var and std::process::Command.
-        struct EnvGuard(&'static str);
-        impl Drop for EnvGuard {
-            fn drop(&mut self) {
-                std::env::remove_var(self.0);
-            }
-        }
-
-        let key = "ARBORIST_TEST_APP_LAUNCHER_STRIP_B7E2";
-        let _guard = EnvGuard(key);
-        std::env::set_var(key, "leak-me");
-
-        // Spawn a child that prints whether the key is set.
-        #[cfg(target_os = "windows")]
-        let mut cmd = {
-            let mut c = std::process::Command::new("cmd");
-            c.args(["/c", &format!("if defined {key} (echo FOUND) else (echo ABSENT)")]);
-            c
-        };
-        #[cfg(not(target_os = "windows"))]
-        let mut cmd = {
-            let mut c = std::process::Command::new("sh");
-            c.args(["-c", &format!("if [ -n \"${{{key}}}\" ]; then echo FOUND; else echo ABSENT; fi")]);
-            c
-        };
-
-        strip_arborist_env(&mut cmd);
-        let output = cmd.output().expect("failed to spawn child");
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        assert!(
-            stdout.contains("ABSENT"),
-            "expected ARBORIST_* key to be stripped from child env, got: {stdout}"
-        );
     }
 }

--- a/src-tauri/src/boot.rs
+++ b/src-tauri/src/boot.rs
@@ -118,19 +118,27 @@ pub enum BootSource {
     Picker,
 }
 
-/// Parsed CLI arguments. Today only `--workspace <path>` / `--workspace=<path>`. Unknown args are ignored (forward-compat).
+/// Parsed CLI arguments. Today: `--workspace <path>` / `--workspace=<path>`, and the test-seam launch overrides
+/// `--ai-launch-claude=<cmd>` / `--ai-launch-copilot=<cmd>` (both also accept the space-separated form). Unknown args are ignored (forward-compat).
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct CliArgs {
     pub workspace: Option<PathBuf>,
+    /// Override for the `claude` program token. Seeds `AppConfig.ai_launch_commands.claude` at boot. Used by Linux e2e to point at
+    /// `arborist-test-child` without environment variables.
+    pub ai_launch_claude: Option<String>,
+    /// Sibling of [`Self::ai_launch_claude`] for the `copilot` program token.
+    pub ai_launch_copilot: Option<String>,
 }
 
-/// Parse `--workspace <path>` / `--workspace=<path>` from an arbitrary argv (the binary name at index 0 is skipped).
+/// Parse `--workspace <path>` / `--workspace=<path>` and `--ai-launch-claude=<cmd>` / `--ai-launch-copilot=<cmd>` from an arbitrary argv (the binary
+/// name at index 0 is skipped).
 ///
 /// Errors:
 /// * Missing value after `--workspace` (last arg, or next arg starts with
 ///   `--`).
 /// * Duplicate `--workspace` (specified more than once).
 /// * Empty value (e.g. `--workspace=`).
+/// * Same conditions for the `--ai-launch-*` variants.
 pub fn parse_cli_args<I, S>(argv: I) -> Result<CliArgs, BootError>
 where
     I: IntoIterator<Item = S>,
@@ -144,13 +152,14 @@ where
         let s = match arg.to_str() {
             Some(s) => s.to_string(),
             None => {
-                // Symmetry with the space-separated form below: if the arg *looks* like `--workspace=<bytes>` (or bare `--workspace`) but the value
-                // isn't valid UTF-8, surface a clean error rather than silently dropping the flag and falling back to the picker. We use
-                // `to_string_lossy` for the prefix probe — `\u{FFFD}` can't appear inside a literal `--workspace` token, so the lossy form is safe to
-                // inspect.
+                // Symmetry with the space-separated form below: if the arg *looks* like one of the recognised flags but the value isn't valid UTF-8,
+                // surface a clean error rather than silently dropping the flag and falling back to the picker. We use `to_string_lossy` for the
+                // prefix probe — `\u{FFFD}` can't appear inside a literal flag name, so the lossy form is safe to inspect.
                 let lossy = arg.to_string_lossy();
-                if lossy == "--workspace" || lossy.starts_with("--workspace=") {
-                    return Err(BootError::Cli("--workspace value is not valid UTF-8".into()));
+                for flag in ["--workspace", "--ai-launch-claude", "--ai-launch-copilot"] {
+                    if lossy == flag || lossy.starts_with(&format!("{flag}=")) {
+                        return Err(BootError::Cli(format!("{flag} value is not valid UTF-8")));
+                    }
                 }
                 continue;
             }
@@ -175,10 +184,37 @@ where
                 return Err(BootError::Cli("--workspace specified more than once".into()));
             }
             out.workspace = Some(PathBuf::from(next_str));
+        } else if let Some(value) = s.strip_prefix("--ai-launch-claude=") {
+            assign_ai_launch(&mut out.ai_launch_claude, "--ai-launch-claude", value)?;
+        } else if s == "--ai-launch-claude" {
+            let next = args.next().ok_or_else(|| BootError::Cli("--ai-launch-claude requires a value".into()))?;
+            let next_str = next
+                .to_str()
+                .ok_or_else(|| BootError::Cli("--ai-launch-claude value is not valid UTF-8".into()))?;
+            assign_ai_launch(&mut out.ai_launch_claude, "--ai-launch-claude", next_str)?;
+        } else if let Some(value) = s.strip_prefix("--ai-launch-copilot=") {
+            assign_ai_launch(&mut out.ai_launch_copilot, "--ai-launch-copilot", value)?;
+        } else if s == "--ai-launch-copilot" {
+            let next = args.next().ok_or_else(|| BootError::Cli("--ai-launch-copilot requires a value".into()))?;
+            let next_str = next
+                .to_str()
+                .ok_or_else(|| BootError::Cli("--ai-launch-copilot value is not valid UTF-8".into()))?;
+            assign_ai_launch(&mut out.ai_launch_copilot, "--ai-launch-copilot", next_str)?;
         }
         // unknown args ignored
     }
     Ok(out)
+}
+
+fn assign_ai_launch(slot: &mut Option<String>, flag: &str, value: &str) -> Result<(), BootError> {
+    if value.is_empty() {
+        return Err(BootError::Cli(format!("{flag}= requires a value")));
+    }
+    if slot.is_some() {
+        return Err(BootError::Cli(format!("{flag} specified more than once")));
+    }
+    *slot = Some(value.to_owned());
+    Ok(())
 }
 
 /// Where the per-branch hint file lives. Mirrors the storage layout: canonical builds keep it at `<app_data_dir>/last-workspace.json`, branch builds
@@ -820,6 +856,7 @@ mod tests {
         .unwrap();
         let args = CliArgs {
             workspace: Some(ws_cli.clone()),
+            ..Default::default()
         };
         let resolved = resolve_boot_workspace(&args, td.path(), "main", &YesRunner).unwrap();
         assert_eq!(resolved, Some((dunce::canonicalize(&ws_cli).unwrap(), BootSource::Cli)));
@@ -871,6 +908,7 @@ mod tests {
         let td = TempDir::new().unwrap();
         let args = CliArgs {
             workspace: Some(td.path().join("does-not-exist")),
+            ..Default::default()
         };
         let err = resolve_boot_workspace(&args, td.path(), "main", &YesRunner).unwrap_err();
         match err {
@@ -886,7 +924,10 @@ mod tests {
         let td = TempDir::new().unwrap();
         let ws = td.path().join("not-a-repo");
         std::fs::create_dir_all(&ws).unwrap();
-        let args = CliArgs { workspace: Some(ws.clone()) };
+        let args = CliArgs {
+            workspace: Some(ws.clone()),
+            ..Default::default()
+        };
         let err = resolve_boot_workspace(&args, td.path(), "main", &NoRunner).unwrap_err();
         match err {
             BootError::NotARepository { workspace, origin, .. } => {
@@ -1071,7 +1112,10 @@ mod tests {
         std::fs::create_dir_all(&ws).unwrap();
         std::fs::create_dir_all(ws.join(".git")).unwrap();
 
-        let args = CliArgs { workspace: Some(ws.clone()) };
+        let args = CliArgs {
+            workspace: Some(ws.clone()),
+            ..Default::default()
+        };
         let binding = boot_select_workspace(&args, &app_data, "main", &YesRunner)
             .unwrap()
             .expect("should bind, not cancel");
@@ -1108,7 +1152,10 @@ mod tests {
         std::fs::create_dir_all(layout.workspace_dir()).unwrap();
         std::fs::create_dir_all(layout.settings_path()).unwrap();
 
-        let args = CliArgs { workspace: Some(ws.clone()) };
+        let args = CliArgs {
+            workspace: Some(ws.clone()),
+            ..Default::default()
+        };
         let err = boot_select_workspace(&args, &app_data, "main", &YesRunner).expect_err("boot must abort on persist failure");
 
         match err {

--- a/src-tauri/src/boot.rs
+++ b/src-tauri/src/boot.rs
@@ -213,13 +213,14 @@ where
 }
 
 fn assign_ai_launch(slot: &mut Option<String>, flag: &str, value: &str) -> Result<(), BootError> {
-    if value.is_empty() {
-        return Err(BootError::Cli(format!("{flag}= requires a value")));
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(BootError::Cli(format!("{flag} requires a non-empty value")));
     }
     if slot.is_some() {
         return Err(BootError::Cli(format!("{flag} specified more than once")));
     }
-    *slot = Some(value.to_owned());
+    *slot = Some(trimmed.to_owned());
     Ok(())
 }
 
@@ -841,7 +842,7 @@ mod tests {
     fn parse_cli_args_ai_launch_claude_empty_equals_value_errors() {
         let err = parse_cli_args(["arborist", "--ai-launch-claude="]).unwrap_err();
         match err {
-            BootError::Cli(msg) => assert!(msg.contains("--ai-launch-claude") && msg.contains("requires a value")),
+            BootError::Cli(msg) => assert!(msg.contains("--ai-launch-claude") && msg.contains("non-empty")),
             other => panic!("expected BootError::Cli, got {other:?}"),
         }
     }
@@ -850,9 +851,40 @@ mod tests {
     fn parse_cli_args_ai_launch_copilot_empty_equals_value_errors() {
         let err = parse_cli_args(["arborist", "--ai-launch-copilot="]).unwrap_err();
         match err {
-            BootError::Cli(msg) => assert!(msg.contains("--ai-launch-copilot") && msg.contains("requires a value")),
+            BootError::Cli(msg) => assert!(msg.contains("--ai-launch-copilot") && msg.contains("non-empty")),
             other => panic!("expected BootError::Cli, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_cli_args_ai_launch_claude_whitespace_only_value_errors() {
+        // `--ai-launch-claude="   "` (whitespace-only, non-empty string) must
+        // be rejected — otherwise `compose::cli_program_for_tool` would later
+        // trim the override down to empty and silently fall back to the bare
+        // `claude` token, making the CLI flag look like it worked.
+        let err = parse_cli_args(["arborist", "--ai-launch-claude=   "]).unwrap_err();
+        match err {
+            BootError::Cli(msg) => assert!(msg.contains("--ai-launch-claude") && msg.contains("non-empty")),
+            other => panic!("expected BootError::Cli, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_cli_args_ai_launch_copilot_whitespace_only_value_errors() {
+        let err = parse_cli_args(["arborist", "--ai-launch-copilot=\t \t"]).unwrap_err();
+        match err {
+            BootError::Cli(msg) => assert!(msg.contains("--ai-launch-copilot") && msg.contains("non-empty")),
+            other => panic!("expected BootError::Cli, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_cli_args_ai_launch_claude_trims_value() {
+        // A value with surrounding whitespace is accepted but stored trimmed,
+        // so it matches what `compose::cli_program_for_tool` will splice into
+        // the composed shell command.
+        let args = parse_cli_args(["arborist", "--ai-launch-claude=  /usr/local/bin/test-child  "]).unwrap();
+        assert_eq!(args.ai_launch_claude.as_deref(), Some("/usr/local/bin/test-child"));
     }
 
     #[test]

--- a/src-tauri/src/boot.rs
+++ b/src-tauri/src/boot.rs
@@ -191,6 +191,9 @@ where
             let next_str = next
                 .to_str()
                 .ok_or_else(|| BootError::Cli("--ai-launch-claude value is not valid UTF-8".into()))?;
+            if next_str.is_empty() || next_str.starts_with("--") {
+                return Err(BootError::Cli("--ai-launch-claude requires a value (got flag-like value)".into()));
+            }
             assign_ai_launch(&mut out.ai_launch_claude, "--ai-launch-claude", next_str)?;
         } else if let Some(value) = s.strip_prefix("--ai-launch-copilot=") {
             assign_ai_launch(&mut out.ai_launch_copilot, "--ai-launch-copilot", value)?;
@@ -199,6 +202,9 @@ where
             let next_str = next
                 .to_str()
                 .ok_or_else(|| BootError::Cli("--ai-launch-copilot value is not valid UTF-8".into()))?;
+            if next_str.is_empty() || next_str.starts_with("--") {
+                return Err(BootError::Cli("--ai-launch-copilot requires a value (got flag-like value)".into()));
+            }
             assign_ai_launch(&mut out.ai_launch_copilot, "--ai-launch-copilot", next_str)?;
         }
         // unknown args ignored
@@ -762,6 +768,125 @@ mod tests {
             BootError::Cli(msg) => assert!(msg.contains("--workspace value is not valid UTF-8")),
             other => panic!("expected BootError::Cli, got {other:?}"),
         }
+    }
+
+    // ----- --ai-launch-claude / --ai-launch-copilot --------------------
+
+    #[test]
+    fn parse_cli_args_ai_launch_claude_equals_form() {
+        let args = parse_cli_args(["arborist", "--ai-launch-claude=/usr/local/bin/test-child"]).unwrap();
+        assert_eq!(args.ai_launch_claude.as_deref(), Some("/usr/local/bin/test-child"));
+        assert!(args.ai_launch_copilot.is_none());
+    }
+
+    #[test]
+    fn parse_cli_args_ai_launch_claude_space_separated() {
+        let args = parse_cli_args(["arborist", "--ai-launch-claude", "/usr/local/bin/test-child"]).unwrap();
+        assert_eq!(args.ai_launch_claude.as_deref(), Some("/usr/local/bin/test-child"));
+    }
+
+    #[test]
+    fn parse_cli_args_ai_launch_copilot_equals_form() {
+        let args = parse_cli_args(["arborist", "--ai-launch-copilot=/usr/local/bin/test-child"]).unwrap();
+        assert_eq!(args.ai_launch_copilot.as_deref(), Some("/usr/local/bin/test-child"));
+        assert!(args.ai_launch_claude.is_none());
+    }
+
+    #[test]
+    fn parse_cli_args_ai_launch_copilot_space_separated() {
+        let args = parse_cli_args(["arborist", "--ai-launch-copilot", "/usr/local/bin/test-child"]).unwrap();
+        assert_eq!(args.ai_launch_copilot.as_deref(), Some("/usr/local/bin/test-child"));
+    }
+
+    #[test]
+    fn parse_cli_args_ai_launch_claude_missing_value_errors() {
+        let err = parse_cli_args(["arborist", "--ai-launch-claude"]).unwrap_err();
+        match err {
+            BootError::Cli(msg) => assert!(msg.contains("--ai-launch-claude requires a value")),
+            other => panic!("expected BootError::Cli, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_cli_args_ai_launch_copilot_missing_value_errors() {
+        let err = parse_cli_args(["arborist", "--ai-launch-copilot"]).unwrap_err();
+        match err {
+            BootError::Cli(msg) => assert!(msg.contains("--ai-launch-copilot requires a value")),
+            other => panic!("expected BootError::Cli, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_cli_args_ai_launch_claude_flag_like_value_errors() {
+        // Regression: bare `--ai-launch-claude --workspace /ws` must NOT silently
+        // assign `--workspace` as the launch command and then fail to parse the
+        // workspace path. Mirror the strict behaviour we apply to `--workspace`.
+        let err = parse_cli_args(["arborist", "--ai-launch-claude", "--workspace", "/ws"]).unwrap_err();
+        match err {
+            BootError::Cli(msg) => assert!(msg.contains("--ai-launch-claude") && msg.contains("flag-like")),
+            other => panic!("expected BootError::Cli, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_cli_args_ai_launch_copilot_flag_like_value_errors() {
+        let err = parse_cli_args(["arborist", "--ai-launch-copilot", "--workspace", "/ws"]).unwrap_err();
+        match err {
+            BootError::Cli(msg) => assert!(msg.contains("--ai-launch-copilot") && msg.contains("flag-like")),
+            other => panic!("expected BootError::Cli, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_cli_args_ai_launch_claude_empty_equals_value_errors() {
+        let err = parse_cli_args(["arborist", "--ai-launch-claude="]).unwrap_err();
+        match err {
+            BootError::Cli(msg) => assert!(msg.contains("--ai-launch-claude") && msg.contains("requires a value")),
+            other => panic!("expected BootError::Cli, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_cli_args_ai_launch_copilot_empty_equals_value_errors() {
+        let err = parse_cli_args(["arborist", "--ai-launch-copilot="]).unwrap_err();
+        match err {
+            BootError::Cli(msg) => assert!(msg.contains("--ai-launch-copilot") && msg.contains("requires a value")),
+            other => panic!("expected BootError::Cli, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_cli_args_ai_launch_claude_duplicate_errors() {
+        let err = parse_cli_args(["arborist", "--ai-launch-claude=/a", "--ai-launch-claude", "/b"]).unwrap_err();
+        match err {
+            BootError::Cli(msg) => assert!(msg.contains("--ai-launch-claude specified more than once")),
+            other => panic!("expected BootError::Cli, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_cli_args_ai_launch_copilot_duplicate_errors() {
+        let err = parse_cli_args(["arborist", "--ai-launch-copilot=/a", "--ai-launch-copilot=/b"]).unwrap_err();
+        match err {
+            BootError::Cli(msg) => assert!(msg.contains("--ai-launch-copilot specified more than once")),
+            other => panic!("expected BootError::Cli, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_cli_args_ai_launch_both_with_workspace() {
+        // Realistic Linux e2e invocation: --workspace alongside both AI launch overrides.
+        let args = parse_cli_args([
+            "arborist",
+            "--workspace",
+            "/tmp/ws",
+            "--ai-launch-claude=/usr/local/bin/test-child",
+            "--ai-launch-copilot=/usr/local/bin/test-child",
+        ])
+        .unwrap();
+        assert_eq!(args.workspace.as_deref(), Some(Path::new("/tmp/ws")));
+        assert_eq!(args.ai_launch_claude.as_deref(), Some("/usr/local/bin/test-child"));
+        assert_eq!(args.ai_launch_copilot.as_deref(), Some("/usr/local/bin/test-child"));
     }
 
     // ----- hint_file_path ----------------------------------------------

--- a/src-tauri/src/compose.rs
+++ b/src-tauri/src/compose.rs
@@ -434,7 +434,7 @@ fn worktree_context_block(label: &str, worktree_path: &Path) -> String {
 }
 
 fn build_claude(inputs: &ComposeInputs<'_>, quoter: Quoter) -> (String, Vec<TempFileSpec>) {
-    let program = cli_program_for_tool(Tool::Claude, inputs.cli_launch_command, quoter);
+    let program = cli_program_for_tool(Tool::Claude, inputs.cli_launch_command);
 
     // No user instruction set: launch plain `claude`. The agent still auto-discovers `CLAUDE.md` from its `cwd` (the worktree). Skipping
     // `--system-prompt` keeps the launch surface minimal and lets the agent derive its location from `pwd`/`git` without us having to fabricate a
@@ -464,22 +464,14 @@ fn build_claude(inputs: &ComposeInputs<'_>, quoter: Quoter) -> (String, Vec<Temp
     )
 }
 
-fn build_copilot(inputs: &ComposeInputs<'_>, quoter: Quoter) -> (String, Vec<TempFileSpec>) {
+fn build_copilot(inputs: &ComposeInputs<'_>, _quoter: Quoter) -> (String, Vec<TempFileSpec>) {
     // Modern `copilot` (the standalone GitHub Copilot CLI) starts in interactive mode by default. The legacy `--interactive <string>` flag was
     // removed and now triggers a "too many arguments" usage error from the CLI itself. We therefore spawn `copilot` with no arguments and rely on its
     // `cwd`-based discovery of `.github/copilot-instructions.md` for repository guidance — the PTY pool already passes the worktree as `cwd`. The
     // worktree context block (label + path) is intentionally dropped here; the agent can derive its location from `pwd`/`git` if it needs to.
-    let cli_cmd = cli_program_for_tool(Tool::Copilot, inputs.cli_launch_command, quoter);
+    let cli_cmd = cli_program_for_tool(Tool::Copilot, inputs.cli_launch_command);
     (cli_cmd, Vec::new())
 }
-
-/// Environment variable consulted by [`cli_program_for_tool`] to override the `claude` executable. **Test-only seam** — production code never sets
-/// this, but integration tests point it at `arborist-test-child` so they can drive the full Tauri command/event surface end-to-end without a real
-/// Claude install. Documented here so the override path is auditable.
-pub const CLAUDE_OVERRIDE_ENV: &str = "ARBORIST_CLI_OVERRIDE_CLAUDE";
-
-/// Sibling of [`CLAUDE_OVERRIDE_ENV`] for the `copilot` executable.
-pub const COPILOT_OVERRIDE_ENV: &str = "ARBORIST_CLI_OVERRIDE_COPILOT";
 
 /// Resolve the program token for `tool`. Precedence (highest first):
 ///
@@ -488,31 +480,14 @@ pub const COPILOT_OVERRIDE_ENV: &str = "ARBORIST_CLI_OVERRIDE_COPILOT";
 ///    authored by the user — not a single argument — so callers can add flags
 ///    like `--model sonnet` directly. Persisted by the Settings dialog into
 ///    `AppConfig.ai_launch_commands`.
-/// 2. **Test-seam env var** (`ARBORIST_CLI_OVERRIDE_*`): set by integration
-///    tests to point at `arborist-test-child`. Returned **shell-quoted** so
-///    paths with spaces still work.
-/// 3. **Default**: the bare CLI name (`claude` / `copilot`).
-///
-/// The override path is invisible to the persisted `composed_command` once the env var is unset, so do not rely on the env-var path across restarts.
-fn cli_program_for_tool(tool: Tool, config_override: Option<&str>, quoter: Quoter) -> String {
-    // 1. Config override (verbatim).
+/// 2. **Default**: the bare CLI name (`claude` / `copilot`).
+fn cli_program_for_tool(tool: Tool, config_override: Option<&str>) -> String {
     if let Some(s) = config_override {
         let trimmed = s.trim();
         if !trimmed.is_empty() {
             return trimmed.to_owned();
         }
     }
-    // 2. Test-seam env override (quoted).
-    let var = match tool {
-        Tool::Claude => CLAUDE_OVERRIDE_ENV,
-        Tool::Copilot => COPILOT_OVERRIDE_ENV,
-    };
-    if let Ok(path) = std::env::var(var) {
-        if !path.is_empty() {
-            return quoter(&path);
-        }
-    }
-    // 3. Default.
     match tool {
         Tool::Claude => "claude".to_owned(),
         Tool::Copilot => "copilot".to_owned(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -271,6 +271,26 @@ pub fn run() {
             ));
             app.manage(sub_ctx.clone());
 
+            // Apply `--ai-launch-claude` / `--ai-launch-copilot` overrides if supplied. Persisted into the workspace's config so users / the e2e
+            // harness can replace the bare `claude` / `copilot` program tokens without setting any environment variable.
+            //
+            // Done *before* the startup icon backfill below so the backfill sees the final config — if a future change makes any icon-relevant
+            // field depend on `ai_launch_commands` (e.g. resolving the launcher's exe to extract its OS icon), the warm-cache pass will pick it up
+            // on first boot rather than waiting until next startup.
+            if cli_args.ai_launch_claude.is_some() || cli_args.ai_launch_copilot.is_some() {
+                let store = ctx_for_backfill.store();
+                let patch = types::PartialAppConfig {
+                    ai_launch_commands: Some(types::PartialAiLaunchCommands {
+                        claude: cli_args.ai_launch_claude.clone(),
+                        copilot: cli_args.ai_launch_copilot.clone(),
+                    }),
+                    ..Default::default()
+                };
+                if let Err(err) = store.save_config(patch) {
+                    tracing::warn!(%err, "failed to apply --ai-launch-* CLI overrides to config");
+                }
+            }
+
             // Best-effort: warm the persisted icon cache for every sidebar entry now, so the first render after startup doesn't show emoji-then-icon
             // flicker. Failures are non-fatal — the frontend already has a graceful fallback (the bundled SVG / emoji glyph).
             //
@@ -290,22 +310,6 @@ pub fn run() {
                     );
                 } else {
                     tracing::debug!("startup icon backfill: cache populated");
-                }
-            }
-
-            // Apply `--ai-launch-claude` / `--ai-launch-copilot` overrides if supplied. Persisted into the workspace's config so users / the e2e
-            // harness can replace the bare `claude` / `copilot` program tokens without setting any environment variable.
-            if cli_args.ai_launch_claude.is_some() || cli_args.ai_launch_copilot.is_some() {
-                let store = ctx_for_backfill.store();
-                let patch = types::PartialAppConfig {
-                    ai_launch_commands: Some(types::PartialAiLaunchCommands {
-                        claude: cli_args.ai_launch_claude.clone(),
-                        copilot: cli_args.ai_launch_copilot.clone(),
-                    }),
-                    ..Default::default()
-                };
-                if let Err(err) = store.save_config(patch) {
-                    tracing::warn!(%err, "failed to apply --ai-launch-* CLI overrides to config");
                 }
             }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -110,8 +110,10 @@ fn workspace_basename(path: &std::path::Path) -> Option<String> {
     }
 }
 
-/// Branch this binary was built from, captured at compile time by `build.rs`.
-pub(crate) const BUILD_BRANCH: &str = env!("ARBORIST_BUILD_BRANCH");
+/// Branch this binary was built from, captured at compile time by `build.rs`
+/// and embedded via a generated file under `OUT_DIR` (no environment variable
+/// involved on either side).
+pub(crate) const BUILD_BRANCH: &str = include_str!(concat!(env!("OUT_DIR"), "/build_branch.txt"));
 
 pub mod boot;
 pub mod seed;
@@ -288,6 +290,22 @@ pub fn run() {
                     );
                 } else {
                     tracing::debug!("startup icon backfill: cache populated");
+                }
+            }
+
+            // Apply `--ai-launch-claude` / `--ai-launch-copilot` overrides if supplied. Persisted into the workspace's config so users / the e2e
+            // harness can replace the bare `claude` / `copilot` program tokens without setting any environment variable.
+            if cli_args.ai_launch_claude.is_some() || cli_args.ai_launch_copilot.is_some() {
+                let store = ctx_for_backfill.store();
+                let patch = types::PartialAppConfig {
+                    ai_launch_commands: Some(types::PartialAiLaunchCommands {
+                        claude: cli_args.ai_launch_claude.clone(),
+                        copilot: cli_args.ai_launch_copilot.clone(),
+                    }),
+                    ..Default::default()
+                };
+                if let Err(err) = store.save_config(patch) {
+                    tracing::warn!(%err, "failed to apply --ai-launch-* CLI overrides to config");
                 }
             }
 

--- a/src-tauri/src/pty_pool.rs
+++ b/src-tauri/src/pty_pool.rs
@@ -150,42 +150,6 @@ pub trait PtyKiller: Send + Sync {
 // --------------------------------------------------------------------------- Production spawner (portable-pty)
 // ---------------------------------------------------------------------------
 
-/// The reserved env-var namespace prefix for Arborist's own build/dev tooling.
-const ARBORIST_ENV_PREFIX: &str = "ARBORIST_";
-
-/// Strip every `ARBORIST_*` env var from the inherited environment of `builder`.
-///
-/// `portable_pty::CommandBuilder` snapshots the current process env at construction; `env_remove` records an unset that overrides those entries when
-/// the child is spawned. We enumerate `keys` and remove anything beginning with the `ARBORIST_` prefix — that namespace is reserved for Arborist's
-/// own build/dev tooling (e.g. `ARBORIST_BUILD_BRANCH` from build.rs, `ARBORIST_DEV_PORT` from `scripts/tauri-dev.mjs`) and must never leak into the
-/// user shells we spawn.
-///
-/// Prefix matching is **case-insensitive** (ASCII): on Windows env-var names are themselves case-insensitive, so a stray `Arborist_Dev_Port` set by
-/// an outer shell is the same variable as `ARBORIST_DEV_PORT` and must be stripped too. On Unix the names are technically distinct but the prefix is
-/// by convention reserved regardless of case, so this is also defensible (and safer than surprising callers with platform-divergent behaviour).
-///
-/// We compare on raw `OsStr` bytes (`as_encoded_bytes()`) rather than `to_str()` so non-UTF-8 keys (legal on Unix) whose leading bytes match
-/// `ARBORIST_` are still stripped — `to_str()` would return `None` and silently leak them.
-fn strip_arborist_env_keys<I, K>(builder: &mut CommandBuilder, keys: I)
-where
-    I: IntoIterator<Item = K>,
-    K: AsRef<std::ffi::OsStr>,
-{
-    let prefix_bytes = ARBORIST_ENV_PREFIX.as_bytes();
-    for k in keys {
-        let key_bytes = k.as_ref().as_encoded_bytes();
-        if key_bytes.len() >= prefix_bytes.len() && key_bytes[..prefix_bytes.len()].eq_ignore_ascii_case(prefix_bytes) {
-            builder.env_remove(k.as_ref());
-        }
-    }
-}
-
-/// Production wrapper: feed the current process env into
-/// [`strip_arborist_env_keys`].
-fn strip_arborist_env(builder: &mut CommandBuilder) {
-    strip_arborist_env_keys(builder, std::env::vars_os().map(|(k, _)| k));
-}
-
 /// Production [`PtySpawner`] backed by `portable_pty::native_pty_system()`.
 pub struct PortablePtySpawner;
 
@@ -215,11 +179,6 @@ impl PtySpawner for PortablePtySpawner {
         }
         // DESIGN §5.6: cwd is the discrete worktree path — never spliced into the command string.
         builder.cwd(cwd);
-        // Strip Arborist build/dev tooling env vars from the inherited environment so they don't leak into PTY children. The running app inherits its
-        // launching shell's env, and any `ARBORIST_*` var set there (e.g. `ARBORIST_BUILD_BRANCH`, `ARBORIST_DEV_PORT` set by
-        // `scripts/tauri-dev.mjs`) would otherwise propagate to user shells and to nested `tauri:dev` invocations launched from a session, baking the
-        // wrong values into those builds. These vars are only meaningful at Arborist's own build/launch time.
-        strip_arborist_env(&mut builder);
         // Per-session env additions. The child still inherits the parent process's env (we never call `env_clear`); these are overrides/additions
         // only — see `compose::env_for_tool`.
         for (k, v) in &cmd.env {
@@ -1037,128 +996,5 @@ mod tests {
         assert!(!is_possible_partial(&[0xFF])); // invalid lead
         assert!(!is_possible_partial(&[0x80])); // continuation
         assert!(!is_possible_partial(&[]));
-    }
-
-    /// Build a probe builder seeded with the supplied env, then strip `ARBORIST_*` keys and return the remaining keys. Mirrors production by feeding
-    /// the strip helper an iterator of owned `OsString`s — the same shape `std::env::vars_os()` produces.
-    fn keys_after_strip(seed: &[(&str, &str)], strip_keys: &[&str]) -> Vec<String> {
-        let mut b = CommandBuilder::new("/bin/true");
-        // Replace the auto-inherited env with a known-good set so the assertion isn't perturbed by the actual host environment.
-        b.env_clear();
-        for (k, v) in seed {
-            b.env(*k, *v);
-        }
-        let owned: Vec<std::ffi::OsString> = strip_keys.iter().map(|s| (*s).into()).collect();
-        strip_arborist_env_keys(&mut b, owned);
-        b.iter_full_env_as_str().map(|(k, _)| k.to_string()).collect()
-    }
-
-    #[test]
-    fn strip_arborist_env_removes_prefixed_keys() {
-        let keys = keys_after_strip(
-            &[
-                ("PATH", "/usr/bin"),
-                ("ARBORIST_BUILD_BRANCH", "main"),
-                ("ARBORIST_DEV_PORT", "1494"),
-                ("HOME", "/home/u"),
-            ],
-            &["PATH", "ARBORIST_BUILD_BRANCH", "ARBORIST_DEV_PORT", "HOME"],
-        );
-        assert!(keys.iter().any(|k| k == "PATH"));
-        assert!(keys.iter().any(|k| k == "HOME"));
-        assert!(!keys.iter().any(|k| k.to_ascii_uppercase().starts_with("ARBORIST_")));
-    }
-
-    #[test]
-    fn strip_arborist_env_preserves_lookalike_keys() {
-        // Names that *contain* but don't *start with* the prefix must survive.
-        let keys = keys_after_strip(&[("MY_ARBORIST_VAR", "x"), ("ARBORISH_DEV", "x")], &["MY_ARBORIST_VAR", "ARBORISH_DEV"]);
-        assert!(keys.iter().any(|k| k == "MY_ARBORIST_VAR"));
-        assert!(keys.iter().any(|k| k == "ARBORISH_DEV"));
-    }
-
-    #[test]
-    fn strip_arborist_env_is_case_insensitive() {
-        // On Windows env-var names are case-insensitive, so any casing of the prefix is the same variable and must be stripped. Unix matches the same
-        // behaviour for namespace-hygiene consistency.
-        let keys = keys_after_strip(
-            &[
-                ("Arborist_Build_Branch", "main"),
-                ("arborist_dev_port", "1494"),
-                ("ARBORIST_FOO", "x"),
-                ("PATH", "/usr/bin"),
-            ],
-            &["Arborist_Build_Branch", "arborist_dev_port", "ARBORIST_FOO", "PATH"],
-        );
-        assert_eq!(keys, vec!["PATH".to_string()]);
-    }
-
-    #[test]
-    fn strip_arborist_env_ignores_short_or_empty_keys() {
-        // Keys shorter than the prefix can't match; ensure the length guard doesn't underflow / panic.
-        let keys = keys_after_strip(&[("AR", "x"), ("A", "y")], &["AR", "A"]);
-        assert!(keys.iter().any(|k| k == "AR"));
-        assert!(keys.iter().any(|k| k == "A"));
-    }
-
-    #[test]
-    fn strip_arborist_env_is_noop_when_no_match() {
-        let before = keys_after_strip(&[("PATH", "/usr/bin")], &["PATH"]);
-        assert_eq!(before, vec!["PATH".to_string()]);
-    }
-
-    #[test]
-    #[serial_test::serial(env)]
-    fn strip_arborist_env_production_path_strips_real_env_var() {
-        // Exercise the production wrapper that reads `std::env::vars_os()`, ensuring the OsString-based iteration path actually removes a matching
-        // key from the resulting CommandBuilder. Use a unique-per-test key so concurrent tests can't false-positive (std::env mutations are
-        // process-global). Marked `#[serial(env)]` so the test suite serializes any other env-mutating tests against this one —
-        // `std::env::set_var`/`remove_var` are process-global and inherently racy with concurrent reads.
-        struct EnvProbe(&'static str);
-        impl Drop for EnvProbe {
-            fn drop(&mut self) {
-                std::env::remove_var(self.0);
-            }
-        }
-
-        let key = "ARBORIST_TEST_PROBE_PRODUCTION_PATH_8C4A";
-        let _guard = EnvProbe(key);
-        std::env::set_var(key, "1");
-        let mut b = CommandBuilder::new("/bin/true");
-        // Don't env_clear here — we need the inherited env to include our key.
-        strip_arborist_env(&mut b);
-        let remaining: Vec<String> = b.iter_full_env_as_str().map(|(k, _)| k.to_string()).collect();
-        assert!(
-            !remaining.iter().any(|k| k == key),
-            "production strip_arborist_env failed to remove {key} via vars_os(); remaining keys with ARBORIST prefix: {:?}",
-            remaining
-                .iter()
-                .filter(|k| k.to_ascii_uppercase().starts_with("ARBORIST_"))
-                .collect::<Vec<_>>()
-        );
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn strip_arborist_env_strips_non_utf8_keys() {
-        // Env-var names on Unix are arbitrary `OsStr` byte sequences, not guaranteed UTF-8. A key whose leading bytes are `ARBORIST_` but whose
-        // trailing bytes are non-UTF-8 must still be stripped — the earlier `to_str()`-gated impl would silently leak such keys.
-        use std::ffi::OsString;
-        use std::os::unix::ffi::OsStringExt;
-
-        // "ARBORIST_" + invalid UTF-8 byte (0xFF is never valid UTF-8).
-        let mut bytes = b"ARBORIST_".to_vec();
-        bytes.push(0xFF);
-        bytes.extend_from_slice(b"_TAIL");
-        let bad: OsString = OsString::from_vec(bytes);
-
-        let mut b = CommandBuilder::new("/bin/true");
-        b.env_clear();
-        b.env(&bad, "leak-me");
-        // Sanity: the bad key starts in the env before the strip.
-        assert!(b.get_env(&bad).is_some(), "test setup: env not seeded");
-
-        strip_arborist_env_keys(&mut b, vec![bad.clone()]);
-        assert!(b.get_env(&bad).is_none(), "non-UTF-8 ARBORIST_* key was not stripped");
     }
 }

--- a/src-tauri/tests/session_lifecycle_real.rs
+++ b/src-tauri/tests/session_lifecycle_real.rs
@@ -1,7 +1,7 @@
 //! Phase 7 happy-path integration test against the **real** PortablePtySpawner.
 //!
-//! We override the `claude` program token with the test-only env-var seam (`ARBORIST_CLI_OVERRIDE_CLAUDE`) and point it at `arborist-test-child`, the
-//! deterministic child shipped alongside the PTY-pool tests. This proves the end-to-end flow — compose → temp file → portable-pty spawn → output
+//! We override the `claude` program token by populating `AppConfig.ai_launch_commands.claude` with the path to `arborist-test-child` (the
+//! deterministic child shipped alongside the PTY-pool tests). This proves the end-to-end flow — compose → temp file → portable-pty spawn → output
 //! drain → status persistence — works with no fakes anywhere except the CLI itself.
 //!
 //! **Unix-only.** On Windows, `shell_quote_cmd` always wraps its input in `"…"`. Combined with the temp-file path argument's own quoting, the
@@ -17,11 +17,11 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use arborist_lib::commands::session::{session_close_impl, session_create_impl, session_input_impl, AppContext};
-use arborist_lib::compose::CLAUDE_OVERRIDE_ENV;
 use arborist_lib::config_store::ConfigStore;
 use arborist_lib::pty_pool::{PortablePtySpawner, PtyPool, PtySink};
 use arborist_lib::types::{
-    InstructionSetId, PartialAppConfig, PartialDefaultInstructionSets, SessionCreateArgs, SessionId, SessionInputArgs, SessionStatus, Tool,
+    InstructionSetId, PartialAiLaunchCommands, PartialAppConfig, PartialDefaultInstructionSets, SessionCreateArgs, SessionId, SessionInputArgs,
+    SessionStatus, Tool,
 };
 use tempfile::TempDir;
 
@@ -59,13 +59,6 @@ fn wait_until<F: FnMut() -> bool>(mut f: F, dur: Duration) -> bool {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn real_spawner_drives_create_input_close_round_trip() {
-    // Tests can race via process-global env vars, but `cargo test` runs tests in this binary on the same process. We only have one test in this file,
-    // and the env var stays set for its duration — fine. SAFETY: setting an env var at the start of a single-test binary is race-free because nothing
-    // else reads it concurrently.
-    unsafe {
-        std::env::set_var(CLAUDE_OVERRIDE_ENV, TEST_CHILD);
-    }
-
     let config_dir = TempDir::new().unwrap();
     let instructions_dir = TempDir::new().unwrap();
     let worktree = TempDir::new().unwrap();
@@ -79,6 +72,12 @@ async fn real_spawner_drives_create_input_close_round_trip() {
             instruction_sets_dir: Some(instructions_dir.path().to_path_buf()),
             default_instruction_sets: Some(PartialDefaultInstructionSets {
                 claude: Some(instruction_id.clone()),
+                copilot: None,
+            }),
+            // Replace the bare `claude` program token with the deterministic test child via the user-config override path
+            // (`AppConfig.ai_launch_commands.claude`). This is the same plumbing real users get via the Settings dialog.
+            ai_launch_commands: Some(PartialAiLaunchCommands {
+                claude: Some(TEST_CHILD.to_owned()),
                 copilot: None,
             }),
             ..Default::default()
@@ -129,9 +128,4 @@ async fn real_spawner_drives_create_input_close_round_trip() {
     // Close. The pool kills the child and removes the persisted record; tearDown should be clean within a couple of seconds even on Windows.
     session_close_impl(&ctx, view.id, false).await.unwrap();
     assert!(!ctx.pool.contains(&view.id));
-
-    // Restore parity for any later tests sharing this process. The test binary will exit immediately, so this is just hygiene.
-    unsafe {
-        std::env::remove_var(CLAUDE_OVERRIDE_ENV);
-    }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,15 +3,11 @@ import react from '@vitejs/plugin-react';
 import { fileURLToPath, URL } from 'node:url';
 import { relative, isAbsolute } from 'node:path';
 
-function devPort(): number {
-  const raw = process.env.ARBORIST_DEV_PORT;
-  // Same validation rule as scripts/tauri-dev.mjs: integer in [1, 65535].
-  // Reject `Number()`-coerced forms like "1e3" or " 42 " so both entrypoints
-  // agree on what counts as a valid override.
-  if (!raw || !/^\d+$/.test(raw)) return 1420;
-  const n = Number(raw);
-  return n >= 1 && n <= 65535 ? n : 1420;
-}
+// Default dev port. The actual per-worktree port is supplied by
+// `scripts/tauri-dev.mjs` via vite's `--port=<n>` CLI flag (see Vite's
+// preview/server options) — kept out of this config so the codebase carries
+// no project-specific environment variables.
+const DEFAULT_DEV_PORT = 1420;
 
 const projectRoot = fileURLToPath(new URL('.', import.meta.url));
 
@@ -40,7 +36,7 @@ export default defineConfig({
   },
   clearScreen: false,
   server: {
-    port: devPort(),
+    port: DEFAULT_DEV_PORT,
     strictPort: true,
     watch: {
       // Arborist creates linked git worktrees under `<workspaceRoot>/.worktrees/<name>/`.


### PR DESCRIPTION
Closes #62.

Replaces five `ARBORIST_*` env-var-based mechanisms with non-env-var equivalents and deletes the env-stripping logic from the PTY/app spawn paths.

## Changes

| Old env var | Replacement |
|---|---|
| `ARBORIST_BUILD_BRANCH` | `build.rs` writes branch to `OUT_DIR/build_branch.txt`; `lib.rs` reads it via `include_str!` (no `cargo:rustc-env=`) |
| `ARBORIST_DEV_PORT` | `scripts/tauri-dev.mjs` injects `beforeDevCommand: pnpm exec vite --port=<n> --strictPort` into a temp tauri override; `vite.config.ts` uses a static default |
| `ARBORIST_CLI_OVERRIDE_CLAUDE` / `ARBORIST_CLI_OVERRIDE_COPILOT` | New boot CLI flags `--ai-launch-claude=<path>` / `--ai-launch-copilot=<path>` (parsed in `boot::parse_cli_args`) seed `AppConfig.ai_launch_commands` at boot. Rust integration tests set `PartialAiLaunchCommands` directly via `save_config`. |
| `ARBORIST_TEST_WORKSPACE` / `ARBORIST_E2E_HOME` | Renamed to `E2E_TEST_WORKSPACE` / `E2E_HOME` (Linux e2e harness only — no longer in the project namespace) |

### Deleted

- `pty_pool::strip_arborist_env` + helpers + spawn-time call site + 6 tests
- `app_launcher::strip_arborist_env` + helpers + spawn-time call site + 5 tests
- `compose::CLAUDE_OVERRIDE_ENV` / `COPILOT_OVERRIDE_ENV`; `cli_program_for_tool` simplifies to `(Tool, Option<&str>) -> String`

### Docs

`DESIGN.md`, `TESTING.md`, `CLAUDE.md`, and `dev/e2e/linux/README.md` updated to describe the new `--ai-launch-*` CLI seam.

## Verification

- `grep -ri ARBORIST_ .` returns zero matches across the repo.
- `pnpm run lint` ✓
- `pnpm test --run` ✓ (567 tests)
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets --features test-helpers -- -D warnings` ✓
- `cargo test --workspace --features test-helpers` ✓

Linux e2e harness changes are not runnable on this Windows host; relying on CI for that gate.