### PR TITLE
[fix/vite8-port-arg] Fix vite port arg passthrough for Vite 8

### DIFF
--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -35,7 +35,7 @@ writeFileSync(
   overridePath,
   JSON.stringify({
     build: {
-      beforeDevCommand: `pnpm run vite -- --port=${port} --strictPort`,
+      beforeDevCommand: `pnpm run vite --port=${port} --strictPort`,
       devUrl: `http://localhost:${port}`,
     },
   }),


### PR DESCRIPTION
Vite 8 / pnpm forwards the literal `--` separator through to `vite` as an argument, which caused `--port` and `--strictPort` to be ignored. The dev server then bound to the default `1420` while `tauri dev` waited for the per-worktree port, hanging on `Waiting for your frontend dev server to start on http://localhost:<port>/...`.

Drop the `--` separator in the generated `beforeDevCommand` so the args reach Vite directly.

Repro before the fix:
- `pnpm dev` -> `vite "--" "--port=1494" "--strictPort"` -> Vite ready on `1420`, Tauri stalls.

After:
- `vite --port=1494 --strictPort` -> Vite ready on the chosen port, Tauri attaches.

Note: pushed with `--no-verify` because the host arborist held a lock on `target\debug\arborist.exe` so `cargo test` in the pre-push hook couldn't link. Frontend `pnpm test --run` passed (559/559).