### PR TITLE
[termination-dialog-location] Center modal dialogs

### DIFF
--- a/src/components/NewSessionDialog.tsx
+++ b/src/components/NewSessionDialog.tsx
@@ -216,7 +216,7 @@ export function NewSessionDialog(): JSX.Element | null {
         if (creating || submitting) return;
         onCancel();
       }}
-      className="w-[28rem] rounded-md border border-slate-300 bg-white p-4 text-slate-900 shadow-lg backdrop:bg-black/40 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+      className="fixed inset-0 m-auto h-fit w-[28rem] rounded-md border border-slate-300 bg-white p-4 text-slate-900 shadow-lg backdrop:bg-black/40 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
     >
       <h2 id="new-session-title" className="mb-3 text-base font-semibold">
         Add worktree

--- a/src/components/SubCloseConfirmDialog.tsx
+++ b/src/components/SubCloseConfirmDialog.tsx
@@ -84,7 +84,7 @@ export function SubCloseConfirmDialog(): JSX.Element | null {
         e.preventDefault();
         onCancel();
       }}
-      className="rounded-md border border-slate-300 bg-white p-4 text-slate-900 shadow-lg backdrop:bg-black/40 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+      className="fixed inset-0 m-auto rounded-md border border-slate-300 bg-white p-4 text-slate-900 shadow-lg backdrop:bg-black/40 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
     >
       <h2 id="sub-close-confirm-title" className="mb-3 text-base font-semibold">
         Close sub-session &ldquo;{sub.label}&rdquo;?

--- a/src/components/WorktreeCloseConfirmDialog.tsx
+++ b/src/components/WorktreeCloseConfirmDialog.tsx
@@ -98,7 +98,7 @@ export function WorktreeCloseConfirmDialog(): JSX.Element | null {
         e.preventDefault();
         if (!busy) onCancel();
       }}
-      className="rounded-md border border-slate-300 bg-white p-4 text-slate-900 shadow-lg backdrop:bg-black/40 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+      className="fixed inset-0 m-auto rounded-md border border-slate-300 bg-white p-4 text-slate-900 shadow-lg backdrop:bg-black/40 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
     >
       <h2 id="worktree-close-confirm-title" className="mb-3 text-base font-semibold">
         Close worktree tab &ldquo;{tab.name}&rdquo;?


### PR DESCRIPTION
The native `<dialog>:modal` user-agent centering (`position: fixed; inset: 0; margin: auto`) was being overridden, leaving the worktree-close, sub-close, and add-worktree dialogs pegged to the top-left of the window.

Re-assert the centering explicitly via Tailwind utilities (`fixed inset-0 m-auto`), plus `h-fit` on the sized add-worktree dialog so `inset-0` doesn't stretch its height.

Affected dialogs:
- `WorktreeCloseConfirmDialog` (worktree termination)
- `SubCloseConfirmDialog` (sub-session termination)
- `NewSessionDialog` (Add worktree)