### PR TITLE
[resize-sidebar] Resizable left sidebar with hover-revealed drag handle (closes #94)

### DIFF
--- a/src-tauri/src/config_store.rs
+++ b/src-tauri/src/config_store.rs
@@ -477,6 +477,23 @@ fn migrate_copilot_composed_commands(sessions: &mut BTreeMap<SessionId, Session>
 // ---------------------------------------------------------------------------
 
 fn validate_loaded_config(cfg: &mut AppConfig) {
+    // Clamp a hand-edited `sidebar_width_px` into [180, 480]. The patch path in `merge_partial` already clamps frontend-driven writes; this load-time
+    // pass is the self-heal for a user who hand-edited `config.json` directly (the existing custom_processes / instruction-set validation a few lines
+    // down follow the same "normalize on load" pattern).
+    if let Some(width) = cfg.sidebar_width_px {
+        let clamped = width.clamp(crate::types::SIDEBAR_WIDTH_MIN_PX, crate::types::SIDEBAR_WIDTH_MAX_PX);
+        if clamped != width {
+            warn!(
+                code = "InvalidValue",
+                field = "sidebarWidthPx",
+                found = width,
+                clamped = clamped,
+                "sidebarWidthPx was outside [180, 480]; clamped on load",
+            );
+            cfg.sidebar_width_px = Some(clamped);
+        }
+    }
+
     // Canonicalize instructionSetsDir. An empty path = "no directory yet configured" and is left as-is.
     if !cfg.instruction_sets_dir.as_os_str().is_empty() {
         match dunce::canonicalize(&cfg.instruction_sets_dir) {
@@ -2856,6 +2873,41 @@ mod tests {
             ids.contains(&BUILTIN_DEF_ID_VSCODE),
             "fresh install must include {BUILTIN_DEF_ID_VSCODE}, got {ids:?}"
         );
+    }
+
+    #[test]
+    fn load_config_clamps_out_of_range_sidebar_width_px() {
+        // A user hand-edits config.json to set sidebarWidthPx outside [180, 480]. Load should clamp into range rather than preserve the bad value
+        // (and rather than waiting for the next frontend resize to trigger the patch-path clamp in merge_partial).
+        let td = TempDir::new().expect("td");
+        let path = td.path().join("config.json");
+        let raw = serde_json::json!({
+            "configVersion": CONFIG_VERSION_CURRENT,
+            "defaultInstructionSets": { "claude": "", "copilot": "" },
+            "instructionSetsDir": "",
+            "worktreeRoots": [],
+            "lastOpenSessions": [],
+            "tabOrder": [],
+            "sidebarWidthPx": 9000,
+        });
+        fs::write(&path, serde_json::to_string(&raw).expect("ser")).expect("write");
+        let store = ConfigStore::open(td.path()).expect("open");
+        let cfg = store.load_config();
+        assert_eq!(cfg.sidebar_width_px, Some(crate::types::SIDEBAR_WIDTH_MAX_PX));
+
+        // And the under-bound direction.
+        let raw_low = serde_json::json!({
+            "configVersion": CONFIG_VERSION_CURRENT,
+            "defaultInstructionSets": { "claude": "", "copilot": "" },
+            "instructionSetsDir": "",
+            "worktreeRoots": [],
+            "lastOpenSessions": [],
+            "tabOrder": [],
+            "sidebarWidthPx": 1,
+        });
+        fs::write(&path, serde_json::to_string(&raw_low).expect("ser")).expect("write");
+        let cfg_low = store.load_config();
+        assert_eq!(cfg_low.sidebar_width_px, Some(crate::types::SIDEBAR_WIDTH_MIN_PX));
     }
 
     #[test]

--- a/src-tauri/src/config_store.rs
+++ b/src-tauri/src/config_store.rs
@@ -673,6 +673,11 @@ fn merge_partial(cfg: &mut AppConfig, patch: PartialAppConfig) -> Result<(), Err
     if let Some(active) = patch.active_worktree_tab_id {
         cfg.active_worktree_tab_id = active;
     }
+    if let Some(width) = patch.sidebar_width_px {
+        // Clamp here so a hand-edited config / racing frontend cannot land us on an off-screen sidebar. We never reject — `min/max` is a soft policy
+        // that should self-heal, not a fatal validation error like a non-existent path.
+        cfg.sidebar_width_px = Some(width.clamp(crate::types::SIDEBAR_WIDTH_MIN_PX, crate::types::SIDEBAR_WIDTH_MAX_PX));
+    }
     Ok(())
 }
 

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -566,7 +566,17 @@ pub struct AppConfig {
     /// is highlighted on launch. Added in `configVersion = 5`.
     #[serde(default)]
     pub active_worktree_tab_id: Option<WorktreeTabId>,
+    /// User-chosen width of the left sidebar in CSS pixels (Issue #94). `None` means "use the frontend default" (224 px today).
+    /// Clamped to `[SIDEBAR_WIDTH_MIN_PX, SIDEBAR_WIDTH_MAX_PX]` on write so a hand-edited config can't shove the column off-screen.
+    /// Backwards-compatible add: pre-#94 configs lack the field and serde fills it with `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sidebar_width_px: Option<u32>,
 }
+
+/// Lower bound for the resizable sidebar width (CSS px). Narrow enough to still show ~12 chars of label.
+pub const SIDEBAR_WIDTH_MIN_PX: u32 = 180;
+/// Upper bound for the resizable sidebar width (CSS px). Wide enough for full branch names without consuming half the window.
+pub const SIDEBAR_WIDTH_MAX_PX: u32 = 480;
 
 impl Default for AppConfig {
     fn default() -> Self {
@@ -586,6 +596,7 @@ impl Default for AppConfig {
             worktree_tabs: Vec::new(),
             worktree_tab_order: Vec::new(),
             active_worktree_tab_id: None,
+            sidebar_width_px: None,
         }
     }
 }
@@ -654,6 +665,10 @@ pub struct PartialAppConfig {
     /// Tri-state: absent → leave alone; `null` → clear; `"<uuid>"` → set.
     #[serde(default, skip_serializing_if = "Option::is_none", with = "double_option")]
     pub active_worktree_tab_id: Option<Option<WorktreeTabId>>,
+    /// Sidebar width (CSS px). `None` → leave alone; `Some(n)` → set (clamped to [`SIDEBAR_WIDTH_MIN_PX`, `SIDEBAR_WIDTH_MAX_PX`]).
+    /// We don't expose a tri-state "clear" since the frontend always sends a concrete width; reverting to the default just sends `224`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sidebar_width_px: Option<u32>,
 }
 
 /// serde adapter for `Option<Option<T>>`: distinguishes "absent" from "present-but-null". JSON has no native `Some(None)`, so we serialise
@@ -1629,6 +1644,7 @@ mod tests {
             worktree_tabs: vec![],
             worktree_tab_order: vec![],
             active_worktree_tab_id: None,
+            sidebar_width_px: None,
         };
         let fixture = json!({
             "configVersion": 5,
@@ -1761,6 +1777,7 @@ mod tests {
             worktree_tabs: None,
             worktree_tab_order: None,
             active_worktree_tab_id: None,
+            sidebar_width_px: None,
         };
         let fixture = json!({
             "defaultInstructionSets": { "claude": "claude-default" },

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -18,6 +18,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('@/lib/tauri-bridge', async () => await import('@/lib/tauri-bridge.mock'));
 
 import * as bridgeMock from '@/lib/tauri-bridge.mock';
+import { useConfigStore } from '@/store/config-store';
 import { useSessionStore } from '@/store/session-store';
 import { useSubSessionStore } from '@/store/sub-session-store';
 import { useWorktreeTabStore } from '@/store/worktree-tab-store';
@@ -87,6 +88,10 @@ beforeEach(() => {
   });
   useWorktreeTabStore.setState({ tabs: [], activeId: null, pendingClose: undefined, isHydrated: false });
   useSubSessionStore.setState({ subSessions: [], statusMessages: {}, pendingClose: undefined, isHydrated: true });
+  // Reset the config store between tests so prior `sidebarWidthPx` writes don't leak into the next test's mount.
+  useConfigStore.setState({
+    config: { ...useConfigStore.getState().config, sidebarWidthPx: undefined },
+  });
   // jsdom doesn't implement HTMLDialogElement.showModal/close in older
   // versions; provide minimal shims so the worktree close-confirm dialog
   // (and other native <dialog> consumers) can mount.
@@ -480,5 +485,52 @@ describe('Sidebar metrics indicator (Issue #3)', () => {
     // Claude gets its own parallel caveat so users know what 'limit' means.
     expect(title).toMatch(/model nominal max/i);
     expect(title).toMatch(/includes harness overhead/i);
+  });
+
+  // ---------------------------------------------------------------------
+  // Issue #94 — resizable sidebar
+  // ---------------------------------------------------------------------
+
+  describe('sidebar width (Issue #94)', () => {
+    it('falls back to the 224 px default when no persisted width is set', () => {
+      seed([makeView('a')], 'a');
+      render(<Sidebar />);
+      expect(screen.getByTestId('sidebar')).toHaveStyle({ width: '224px' });
+    });
+
+    it('renders the persisted width from config-store on mount', () => {
+      useConfigStore.setState({
+        config: { ...useConfigStore.getState().config, sidebarWidthPx: 320 },
+      });
+      seed([makeView('a')], 'a');
+      render(<Sidebar />);
+      expect(screen.getByTestId('sidebar')).toHaveStyle({ width: '320px' });
+    });
+
+    it('persists a new width via configSet when the user nudges via keyboard', async () => {
+      bridgeMock.configSet.mockResolvedValue({
+        ...useConfigStore.getState().config,
+        sidebarWidthPx: 240,
+      });
+      seed([makeView('a')], 'a');
+      render(<Sidebar />);
+      const handle = screen.getByTestId('sidebar-resize-handle');
+      await act(async () => {
+        fireEvent.keyDown(handle, { key: 'ArrowRight' });
+      });
+      expect(bridgeMock.configSet).toHaveBeenCalledWith({ sidebarWidthPx: 240 });
+    });
+
+    it('skips persistence when the width is already at the persisted value', () => {
+      useConfigStore.setState({
+        config: { ...useConfigStore.getState().config, sidebarWidthPx: 224 },
+      });
+      seed([makeView('a')], 'a');
+      render(<Sidebar />);
+      const handle = screen.getByTestId('sidebar-resize-handle');
+      // Double-click "reset" should be a no-op write because we're already at the default.
+      fireEvent.doubleClick(handle);
+      expect(bridgeMock.configSet).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -88,10 +88,11 @@ beforeEach(() => {
   });
   useWorktreeTabStore.setState({ tabs: [], activeId: null, pendingClose: undefined, isHydrated: false });
   useSubSessionStore.setState({ subSessions: [], statusMessages: {}, pendingClose: undefined, isHydrated: true });
-  // Reset the config store between tests so prior `sidebarWidthPx` writes don't leak into the next test's mount.
-  useConfigStore.setState({
-    config: { ...useConfigStore.getState().config, sidebarWidthPx: undefined },
-  });
+  // Reset the config store between tests so prior `sidebarWidthPx` writes don't leak into the next test's mount. `exactOptionalPropertyTypes`
+  // forbids assigning `sidebarWidthPx: undefined` literally — strip the key by destructuring it out instead.
+  const { sidebarWidthPx: _drop, ...restConfig } = useConfigStore.getState().config;
+  void _drop;
+  useConfigStore.setState({ config: restConfig });
   // jsdom doesn't implement HTMLDialogElement.showModal/close in older
   // versions; provide minimal shims so the worktree close-confirm dialog
   // (and other native <dialog> consumers) can mount.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -301,6 +301,10 @@ export function Sidebar(): JSX.Element {
             await configSet({ sidebarWidthPx: value });
           } catch (err) {
             console.warn(`[sidebar] failed to persist width ${value}: ${formatError(err)}`);
+            // Clear the cached intent on failure so the user can retry the same value. Otherwise the next `commitWidth(value)` would short-circuit
+            // (`clamped === intendedPersistedRef.current`) and the on-disk width would stay out of sync with `liveWidth` until the user picked
+            // *some other* width first.
+            if (intendedPersistedRef.current === value) intendedPersistedRef.current = null;
           }
         }
         inFlightWriteRef.current = null;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -262,24 +262,35 @@ export function Sidebar(): JSX.Element {
   const configSet = useConfigStore((s) => s.set);
   const [liveWidth, setLiveWidth] = useState<number>(() => clampSidebarWidth(persistedWidth ?? SIDEBAR_DEFAULT_WIDTH_PX));
 
-  // Adopt backend-truth width whenever the persisted value changes (hydrate, workspace switch). Skipping this when a drag is in progress would be
-  // ideal, but workspace switches replace the whole sidebar tree anyway so there's no in-flight drag to disturb in practice.
-  useEffect(() => {
-    setLiveWidth(clampSidebarWidth(persistedWidth ?? SIDEBAR_DEFAULT_WIDTH_PX));
-  }, [persistedWidth]);
-
   // Serialize sidebar-width persistence so rapid commits (e.g. holding ArrowLeft for auto-repeat keyboard nudges) can't issue overlapping
   // `configSet` calls that resolve out of order and leave a stale value on disk. We coalesce: the latest requested width is queued in
   // `pendingWidthRef`; while a write is in flight we just update the ref, and the drain loop picks the latest value when the in-flight call
   // resolves. Pointer-up gestures fire only one commit so the fast path is the no-op-already-equal short-circuit below.
   const pendingWidthRef = useRef<number | null>(null);
   const inFlightWriteRef = useRef<Promise<unknown> | null>(null);
+  // Latest *intended* persisted value — what `commitWidth` last asked the backend to store, even if the write hasn't resolved yet. The no-op
+  // short-circuit compares against this rather than the (possibly stale) hydrated `persistedWidth`, so a "drag to 260, drag back to 224 before the
+  // 260 write resolves" sequence still enqueues the revert.
+  const intendedPersistedRef = useRef<number | null>(null);
+
+  // Adopt backend-truth width whenever the persisted value changes (hydrate, workspace switch). Skip while a self-initiated write is in flight or
+  // pending: otherwise the intermediate snapshot from the first write of a serialized drain (e.g. holding ArrowRight) yanks `liveWidth` back to the
+  // previous value, causing visible jitter during keyboard auto-repeat. Once drained, the backend snapshot reflects our intended value (or another
+  // tab / process changed it) and we clear `intendedPersistedRef` so future hydrate snapshots are honored.
+  useEffect(() => {
+    if (inFlightWriteRef.current || pendingWidthRef.current !== null) return;
+    intendedPersistedRef.current = null;
+    setLiveWidth(clampSidebarWidth(persistedWidth ?? SIDEBAR_DEFAULT_WIDTH_PX));
+  }, [persistedWidth]);
 
   const commitWidth = useCallback(
     (next: number) => {
       const clamped = clampSidebarWidth(next);
-      // Only persist when the value actually changed from what's on disk. Saves a config write on no-op drags / Home / End at the bound.
-      if (clamped === (persistedWidth ?? SIDEBAR_DEFAULT_WIDTH_PX)) return;
+      // Compare against the latest *intended* persisted value, falling back to the hydrated snapshot when no write is in flight. Comparing against
+      // the stale `persistedWidth` alone would let a "260 in flight, user reverts to 224" sequence early-return without enqueuing the revert.
+      const target = intendedPersistedRef.current ?? persistedWidth ?? SIDEBAR_DEFAULT_WIDTH_PX;
+      if (clamped === target) return;
+      intendedPersistedRef.current = clamped;
       pendingWidthRef.current = clamped;
       if (inFlightWriteRef.current) return;
       const drain = async (): Promise<void> => {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -30,6 +30,8 @@ import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent }
 import { WorktreeCloseConfirmDialog } from './WorktreeCloseConfirmDialog';
 import { NewSessionButton } from './NewSessionButton';
 import { SettingsDialog } from './SettingsDialog';
+import { SidebarResizeHandle } from './SidebarResizeHandle';
+import { clampSidebarWidth, DEFAULT_WIDTH_PX as SIDEBAR_DEFAULT_WIDTH_PX } from './sidebar-width';
 import { SidebarSubTab } from './SidebarSubTab';
 import { SidebarTab } from './SidebarTab';
 import { SidebarWorktreeTab } from './SidebarWorktreeTab';
@@ -40,6 +42,7 @@ import { WorktreeTabContextMenu } from './WorktreeTabContextMenu';
 import { useSessionActions, useSessions } from '@/store/session-store';
 import { useSubSessionsForWorktreeTab } from '@/store/sub-session-store';
 import { useActiveWorktreeTabId, useWorktreeTabs } from '@/store/worktree-tab-store';
+import { useConfigStore, selectSidebarWidthPx } from '@/store/config-store';
 import { formatError } from '@/lib/tauri-bridge';
 import type { SessionId, WorktreeTabId } from '@/types/arborist';
 
@@ -253,6 +256,30 @@ export function Sidebar(): JSX.Element {
 
   const clampedFocusedIndex = Math.min(focusedIndex, Math.max(0, ids.length - 1));
 
+  // Persisted sidebar width (Issue #94). `undefined` until config hydrates or when the user has never resized — fall back to the legacy default.
+  // Live width during a drag is kept in local state so we don't round-trip through `configSet` (and therefore disk) on every pointermove tick.
+  const persistedWidth = useConfigStore(selectSidebarWidthPx);
+  const configSet = useConfigStore((s) => s.set);
+  const [liveWidth, setLiveWidth] = useState<number>(() => clampSidebarWidth(persistedWidth ?? SIDEBAR_DEFAULT_WIDTH_PX));
+
+  // Adopt backend-truth width whenever the persisted value changes (hydrate, workspace switch). Skipping this when a drag is in progress would be
+  // ideal, but workspace switches replace the whole sidebar tree anyway so there's no in-flight drag to disturb in practice.
+  useEffect(() => {
+    setLiveWidth(clampSidebarWidth(persistedWidth ?? SIDEBAR_DEFAULT_WIDTH_PX));
+  }, [persistedWidth]);
+
+  const commitWidth = useCallback(
+    (next: number) => {
+      const clamped = clampSidebarWidth(next);
+      // Only persist when the value actually changed from what's on disk. Saves a config write on no-op drags / Home / End at the bound.
+      if (clamped === (persistedWidth ?? SIDEBAR_DEFAULT_WIDTH_PX)) return;
+      void configSet({ sidebarWidthPx: clamped }).catch((err) => {
+        console.warn(`[sidebar] failed to persist width ${clamped}: ${formatError(err)}`);
+      });
+    },
+    [configSet, persistedWidth],
+  );
+
   return (
     <aside
       aria-label="Sessions"
@@ -260,7 +287,8 @@ export function Sidebar(): JSX.Element {
       aria-orientation="vertical"
       data-testid="sidebar"
       onKeyDown={onKeyDown}
-      className="flex h-full w-56 shrink-0 flex-col border-r border-slate-200 bg-slate-50 dark:border-slate-800 dark:bg-slate-900"
+      style={{ width: `${liveWidth}px` }}
+      className="relative flex h-full shrink-0 flex-col border-r border-slate-200 bg-slate-50 dark:border-slate-800 dark:bg-slate-900"
     >
       <WorkspaceIndicator />
       <NewSessionButton buttonRef={newSessionButtonRef} />
@@ -339,6 +367,7 @@ export function Sidebar(): JSX.Element {
         />
       )}
       {settingsOpen ? <SettingsDialog onClose={() => setSettingsOpen(false)} initialTab={settingsInitialTab} /> : null}
+      <SidebarResizeHandle width={liveWidth} onWidthChange={setLiveWidth} onCommit={commitWidth} />
     </aside>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -268,14 +268,33 @@ export function Sidebar(): JSX.Element {
     setLiveWidth(clampSidebarWidth(persistedWidth ?? SIDEBAR_DEFAULT_WIDTH_PX));
   }, [persistedWidth]);
 
+  // Serialize sidebar-width persistence so rapid commits (e.g. holding ArrowLeft for auto-repeat keyboard nudges) can't issue overlapping
+  // `configSet` calls that resolve out of order and leave a stale value on disk. We coalesce: the latest requested width is queued in
+  // `pendingWidthRef`; while a write is in flight we just update the ref, and the drain loop picks the latest value when the in-flight call
+  // resolves. Pointer-up gestures fire only one commit so the fast path is the no-op-already-equal short-circuit below.
+  const pendingWidthRef = useRef<number | null>(null);
+  const inFlightWriteRef = useRef<Promise<unknown> | null>(null);
+
   const commitWidth = useCallback(
     (next: number) => {
       const clamped = clampSidebarWidth(next);
       // Only persist when the value actually changed from what's on disk. Saves a config write on no-op drags / Home / End at the bound.
       if (clamped === (persistedWidth ?? SIDEBAR_DEFAULT_WIDTH_PX)) return;
-      void configSet({ sidebarWidthPx: clamped }).catch((err) => {
-        console.warn(`[sidebar] failed to persist width ${clamped}: ${formatError(err)}`);
-      });
+      pendingWidthRef.current = clamped;
+      if (inFlightWriteRef.current) return;
+      const drain = async (): Promise<void> => {
+        while (pendingWidthRef.current !== null) {
+          const value = pendingWidthRef.current;
+          pendingWidthRef.current = null;
+          try {
+            await configSet({ sidebarWidthPx: value });
+          } catch (err) {
+            console.warn(`[sidebar] failed to persist width ${value}: ${formatError(err)}`);
+          }
+        }
+        inFlightWriteRef.current = null;
+      };
+      inFlightWriteRef.current = drain();
     },
     [configSet, persistedWidth],
   );

--- a/src/components/SidebarResizeHandle.test.tsx
+++ b/src/components/SidebarResizeHandle.test.tsx
@@ -1,0 +1,147 @@
+// Issue #94 — resizable left sidebar. We test the handle component in
+// isolation rather than driving it through the full Sidebar so jsdom doesn't
+// have to fake `pointerCapture` against the production tab tree.
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SidebarResizeHandle } from './SidebarResizeHandle';
+import { DEFAULT_WIDTH_PX, MAX_WIDTH_PX, MIN_WIDTH_PX, clampSidebarWidth } from './sidebar-width';
+
+// jsdom doesn't implement pointer capture; stub it on Element so the
+// production code's `setPointerCapture` / `releasePointerCapture` /
+// `hasPointerCapture` calls don't throw.
+const proto = Element.prototype as unknown as {
+  setPointerCapture?: (id: number) => void;
+  releasePointerCapture?: (id: number) => void;
+  hasPointerCapture?: (id: number) => boolean;
+};
+if (typeof proto.setPointerCapture !== 'function') proto.setPointerCapture = () => {};
+if (typeof proto.releasePointerCapture !== 'function') proto.releasePointerCapture = () => {};
+if (typeof proto.hasPointerCapture !== 'function') proto.hasPointerCapture = () => true;
+
+function renderHandle(initial = DEFAULT_WIDTH_PX): {
+  onWidthChange: ReturnType<typeof vi.fn>;
+  onCommit: ReturnType<typeof vi.fn>;
+  handle: HTMLElement;
+} {
+  const onWidthChange = vi.fn();
+  const onCommit = vi.fn();
+  render(<SidebarResizeHandle width={initial} onWidthChange={onWidthChange} onCommit={onCommit} />);
+  return { onWidthChange, onCommit, handle: screen.getByTestId('sidebar-resize-handle') };
+}
+
+describe('clampSidebarWidth', () => {
+  it('clamps below min and above max', () => {
+    expect(clampSidebarWidth(0)).toBe(MIN_WIDTH_PX);
+    expect(clampSidebarWidth(99999)).toBe(MAX_WIDTH_PX);
+  });
+
+  it('rounds non-integer inputs', () => {
+    expect(clampSidebarWidth(224.4)).toBe(224);
+    expect(clampSidebarWidth(224.6)).toBe(225);
+  });
+
+  it('returns the default for non-finite inputs', () => {
+    expect(clampSidebarWidth(Number.NaN)).toBe(DEFAULT_WIDTH_PX);
+    expect(clampSidebarWidth(Number.POSITIVE_INFINITY)).toBe(DEFAULT_WIDTH_PX);
+  });
+});
+
+describe('SidebarResizeHandle', () => {
+  it('exposes the WAI-ARIA separator pattern with live aria-valuenow', () => {
+    const { handle } = renderHandle(260);
+    expect(handle).toHaveAttribute('role', 'separator');
+    expect(handle).toHaveAttribute('aria-orientation', 'vertical');
+    expect(handle).toHaveAttribute('aria-valuemin', String(MIN_WIDTH_PX));
+    expect(handle).toHaveAttribute('aria-valuemax', String(MAX_WIDTH_PX));
+    expect(handle).toHaveAttribute('aria-valuenow', '260');
+    expect(handle).toHaveAttribute('tabindex', '0');
+  });
+
+  it('drags update width live and commit once on pointer up', () => {
+    const { onWidthChange, onCommit, handle } = renderHandle(220);
+    fireEvent.pointerDown(handle, { button: 0, pointerId: 1, clientX: 500 });
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 540 }); // +40 → 260
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 580 }); // +80 → 300
+    expect(onWidthChange).toHaveBeenNthCalledWith(1, 260);
+    expect(onWidthChange).toHaveBeenLastCalledWith(300);
+    expect(onCommit).not.toHaveBeenCalled();
+
+    fireEvent.pointerUp(handle, { pointerId: 1, clientX: 580 });
+    // What we care about: exactly one commit per gesture.
+    expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it('clamps drag delta to the min/max bounds', () => {
+    const { onWidthChange, handle } = renderHandle(DEFAULT_WIDTH_PX);
+    fireEvent.pointerDown(handle, { button: 0, pointerId: 1, clientX: 500 });
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 100 }); // -400 → would be -176, clamps to MIN
+    expect(onWidthChange).toHaveBeenLastCalledWith(MIN_WIDTH_PX);
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 2000 }); // +1500 → clamps to MAX
+    expect(onWidthChange).toHaveBeenLastCalledWith(MAX_WIDTH_PX);
+  });
+
+  it('does not start a drag for non-primary buttons', () => {
+    const { onWidthChange, onCommit, handle } = renderHandle(220);
+    fireEvent.pointerDown(handle, { button: 2, pointerId: 1, clientX: 500 });
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 600 });
+    fireEvent.pointerUp(handle, { pointerId: 1, clientX: 600 });
+    expect(onWidthChange).not.toHaveBeenCalled();
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('cleans up the drag on pointer cancel without leaking state', () => {
+    const { onCommit, handle } = renderHandle(220);
+    fireEvent.pointerDown(handle, { button: 0, pointerId: 1, clientX: 500 });
+    fireEvent.pointerCancel(handle, { pointerId: 1, clientX: 500 });
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(handle).toHaveAttribute('data-dragging', 'false');
+  });
+
+  it.each([
+    ['ArrowLeft', 224, 208],
+    ['ArrowRight', 224, 240],
+    ['Home', 224, MIN_WIDTH_PX],
+    ['End', 224, MAX_WIDTH_PX],
+  ])('keyboard %s nudges width and commits', (key, start, expected) => {
+    const { onWidthChange, onCommit, handle } = renderHandle(start);
+    handle.focus();
+    fireEvent.keyDown(handle, { key });
+    expect(onWidthChange).toHaveBeenCalledWith(expected);
+    expect(onCommit).toHaveBeenCalledWith(expected);
+  });
+
+  it('keyboard nudge at the bound clamps and still commits (Home/End behaviour)', () => {
+    const { onWidthChange, onCommit, handle } = renderHandle(MIN_WIDTH_PX);
+    fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+    // Width was already at MIN, so no live change call; commit fires anyway so the contract is "one commit per keystroke".
+    expect(onWidthChange).not.toHaveBeenCalled();
+    expect(onCommit).toHaveBeenCalledWith(MIN_WIDTH_PX);
+  });
+
+  it('ignores unrelated keys', () => {
+    const { onWidthChange, onCommit, handle } = renderHandle(220);
+    fireEvent.keyDown(handle, { key: 'Enter' });
+    fireEvent.keyDown(handle, { key: ' ' });
+    fireEvent.keyDown(handle, { key: 'a' });
+    expect(onWidthChange).not.toHaveBeenCalled();
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('double-click resets width to the default and commits', () => {
+    const { onWidthChange, onCommit, handle } = renderHandle(400);
+    fireEvent.doubleClick(handle);
+    expect(onWidthChange).toHaveBeenCalledWith(DEFAULT_WIDTH_PX);
+    expect(onCommit).toHaveBeenCalledWith(DEFAULT_WIDTH_PX);
+  });
+
+  it('reflects in-flight drag via data-dragging for the accent line', () => {
+    const { handle } = renderHandle(220);
+    expect(handle).toHaveAttribute('data-dragging', 'false');
+    fireEvent.pointerDown(handle, { button: 0, pointerId: 1, clientX: 500 });
+    expect(handle).toHaveAttribute('data-dragging', 'true');
+    fireEvent.pointerUp(handle, { pointerId: 1, clientX: 500 });
+    expect(handle).toHaveAttribute('data-dragging', 'false');
+  });
+});

--- a/src/components/SidebarResizeHandle.test.tsx
+++ b/src/components/SidebarResizeHandle.test.tsx
@@ -59,7 +59,7 @@ describe('SidebarResizeHandle', () => {
     expect(handle).toHaveAttribute('tabindex', '0');
   });
 
-  it('drags update width live and commit once on pointer up', () => {
+  it('drags update width live and commit the final dragged value on pointer up', () => {
     const { onWidthChange, onCommit, handle } = renderHandle(220);
     fireEvent.pointerDown(handle, { button: 0, pointerId: 1, clientX: 500 });
     fireEvent.pointerMove(handle, { pointerId: 1, clientX: 540 }); // +40 → 260
@@ -69,8 +69,10 @@ describe('SidebarResizeHandle', () => {
     expect(onCommit).not.toHaveBeenCalled();
 
     fireEvent.pointerUp(handle, { pointerId: 1, clientX: 580 });
-    // What we care about: exactly one commit per gesture.
+    // Exactly one commit per gesture, carrying the final dragged value — NOT the pre-drag width. Regression guard for the React-18 batching race
+    // where `pointermove` and `pointerup` can run in the same task without an interleaving re-render, leaving the `width` prop stale.
     expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenLastCalledWith(300);
   });
 
   it('clamps drag delta to the min/max bounds', () => {

--- a/src/components/SidebarResizeHandle.test.tsx
+++ b/src/components/SidebarResizeHandle.test.tsx
@@ -122,11 +122,37 @@ describe('SidebarResizeHandle', () => {
     expect(onCommit).toHaveBeenCalledWith(MIN_WIDTH_PX);
   });
 
-  it('ignores unrelated keys', () => {
+  it('swallows Enter and Space (preventDefault + stopPropagation, no width change)', () => {
+    // Separator has no activation semantics and the parent tablist's onKeyDown reacts to Enter/Space by focusing a tab. Without
+    // explicit swallow here, pressing Enter on a focused handle would jump focus to a session tab — surprising and wrong.
     const { onWidthChange, onCommit, handle } = renderHandle(220);
-    fireEvent.keyDown(handle, { key: 'Enter' });
-    fireEvent.keyDown(handle, { key: ' ' });
-    fireEvent.keyDown(handle, { key: 'a' });
+    for (const key of ['Enter', ' ']) {
+      const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+      const stopPropagation = vi.spyOn(event, 'stopPropagation');
+      handle.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(true);
+      expect(stopPropagation).toHaveBeenCalled();
+    }
+    expect(onWidthChange).not.toHaveBeenCalled();
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('stops propagation for handled keys so the parent tablist does not double-handle Home/End', () => {
+    const { handle } = renderHandle(260);
+    for (const key of ['ArrowLeft', 'ArrowRight', 'Home', 'End']) {
+      const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+      const stopPropagation = vi.spyOn(event, 'stopPropagation');
+      handle.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(true);
+      expect(stopPropagation).toHaveBeenCalled();
+    }
+  });
+
+  it('ignores unrelated keys without preventDefault', () => {
+    const { onWidthChange, onCommit, handle } = renderHandle(220);
+    const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true, cancelable: true });
+    handle.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(false);
     expect(onWidthChange).not.toHaveBeenCalled();
     expect(onCommit).not.toHaveBeenCalled();
   });

--- a/src/components/SidebarResizeHandle.tsx
+++ b/src/components/SidebarResizeHandle.tsx
@@ -107,9 +107,21 @@ export function SidebarResizeHandle({ width, onWidthChange, onCommit }: SidebarR
 
   const onKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>) => {
+      // Always swallow Enter / Space — a separator has no activation semantics, and letting them bubble would trigger the parent tablist's
+      // Enter/Space handler which focuses the currently-selected session tab. The handle is its own focusable widget; pressing Enter on it
+      // should be a no-op rather than surprise the user with a tab-focus jump.
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
       const next = computeKeyboardWidth(e.key, widthRef.current);
       if (next === null) return;
       e.preventDefault();
+      // Stop propagation for handled keys (Arrow*, Home, End) — otherwise the parent tablist's onKeyDown would *also* react to Home/End
+      // and steal focus to the first/last tab while we resize. ArrowLeft/Right don't currently overlap with the parent's handlers, but
+      // stopping them too keeps the contract uniform: "the separator owns its own keys".
+      e.stopPropagation();
       if (next !== widthRef.current) onWidthChange(next);
       onCommit(next);
     },

--- a/src/components/SidebarResizeHandle.tsx
+++ b/src/components/SidebarResizeHandle.tsx
@@ -149,7 +149,7 @@ export function SidebarResizeHandle({ width, onWidthChange, onCommit }: SidebarR
         style={accentStyle}
         // `data-dragging` on the parent forces the accent visible during an active drag so the user keeps a clear reference even
         // when the pointer wanders away from the handle.
-        className="h-full bg-slate-300 opacity-0 transition-opacity group-hover:opacity-100 group-[[data-dragging=true]]:opacity-100 dark:bg-slate-700"
+        className="h-full bg-slate-300 opacity-0 transition-opacity group-hover:opacity-100 group-data-[dragging=true]:opacity-100 dark:bg-slate-700"
       />
     </div>
   );

--- a/src/components/SidebarResizeHandle.tsx
+++ b/src/components/SidebarResizeHandle.tsx
@@ -50,9 +50,14 @@ export function SidebarResizeHandle({ width, onWidthChange, onCommit }: SidebarR
   // Mirror dragging state into React state so the `data-dragging` attribute and the accent-line opacity update on `pointerdown` without
   // waiting for an unrelated re-render. We still keep the `dragRef` for the start coordinates so move handlers don't re-bind on every render.
   const [isDragging, setIsDragging] = useState<boolean>(false);
-  // Mirror the latest width into a ref so the pointermove handler always sees the freshest value without re-binding on every render.
+  // Mirror the latest *prop-driven* width into a ref so pointermove can read the freshest committed value without re-binding on every render.
   const widthRef = useRef<number>(width);
   widthRef.current = width;
+  // Track the last width we computed during the current gesture. We can't read this from `widthRef` because the parent re-render hasn't necessarily
+  // flushed by the time `pointerup` fires — React 18 batches state updates across pointermove/pointerup in the same task. Committing
+  // `widthRef.current` from `finishDrag` would therefore risk snapping back to the *pre-drag* width on fast releases.
+  const lastComputedRef = useRef<number>(width);
+  lastComputedRef.current = width;
 
   const onPointerDown = useCallback((e: PointerEvent<HTMLDivElement>) => {
     if (e.button !== 0) return;
@@ -67,6 +72,10 @@ export function SidebarResizeHandle({ width, onWidthChange, onCommit }: SidebarR
       const drag = dragRef.current;
       if (!drag || drag.pointerId !== e.pointerId) return;
       const next = clampSidebarWidth(drag.startWidth + (e.clientX - drag.startX));
+      // Capture the freshly-computed width *before* notifying the parent. `finishDrag` reads this on pointerup; reading `widthRef.current` there
+      // would race React 18's batched re-renders — pointermove + pointerup can land in the same task with no flush in between, leaving the prop
+      // (and therefore `widthRef`) at the pre-drag value.
+      lastComputedRef.current = next;
       if (next !== widthRef.current) onWidthChange(next);
     },
     [onWidthChange],
@@ -80,7 +89,7 @@ export function SidebarResizeHandle({ width, onWidthChange, onCommit }: SidebarR
       setIsDragging(false);
       if (e.currentTarget.hasPointerCapture(e.pointerId)) e.currentTarget.releasePointerCapture(e.pointerId);
       // Commit even when width is unchanged from drag start — keeps the contract simple (one commit per gesture) and the no-op write is cheap.
-      onCommit(widthRef.current);
+      onCommit(lastComputedRef.current);
     },
     [onCommit],
   );

--- a/src/components/SidebarResizeHandle.tsx
+++ b/src/components/SidebarResizeHandle.tsx
@@ -1,0 +1,141 @@
+// Hover-revealed drag handle for the left sidebar's right edge (Issue #94).
+//
+// Renders an 8 px-wide invisible hit zone overlaid on the sidebar's right
+// edge, with a 1-2 px accent line that fades in on hover or while a drag is
+// in progress. Live width updates go through the `onWidthChange` callback so
+// the parent can mutate its rendered width without re-rendering the whole
+// sidebar tree on every `pointermove`. Persistence (and clamping) happens
+// once on pointer-up via `onCommit`.
+//
+// Accessibility: `role="separator"` + `aria-orientation="vertical"` matches
+// the WAI-ARIA window-splitter pattern. The handle is focusable; ArrowLeft /
+// ArrowRight nudge by `KEYBOARD_STEP_PX` (16 px), Home / End snap to the min
+// / max bounds. Double-click resets to `DEFAULT_WIDTH_PX` (224 px).
+
+import { useCallback, useRef, useState, type CSSProperties, type KeyboardEvent, type PointerEvent } from 'react';
+
+import { clampSidebarWidth, DEFAULT_WIDTH_PX, KEYBOARD_STEP_PX, MAX_WIDTH_PX, MIN_WIDTH_PX } from './sidebar-width';
+
+function computeKeyboardWidth(key: string, current: number): number | null {
+  switch (key) {
+    case 'ArrowLeft':
+      return clampSidebarWidth(current - KEYBOARD_STEP_PX);
+    case 'ArrowRight':
+      return clampSidebarWidth(current + KEYBOARD_STEP_PX);
+    case 'Home':
+      return MIN_WIDTH_PX;
+    case 'End':
+      return MAX_WIDTH_PX;
+    default:
+      return null;
+  }
+}
+
+interface SidebarResizeHandleProps {
+  /** Current rendered width (px). Drives the `aria-valuenow` so screen readers track live drags. */
+  width: number;
+  /** Live update while dragging or after a keyboard nudge — caller mutates its rendered width. */
+  onWidthChange: (next: number) => void;
+  /**
+   * Called when the user finishes a gesture (pointer up, keyboard release, double-click reset). Caller persists the value. Skipped during in-flight
+   * pointer move so we don't hit disk on every tick.
+   */
+  onCommit: (next: number) => void;
+}
+
+export function SidebarResizeHandle({ width, onWidthChange, onCommit }: SidebarResizeHandleProps): JSX.Element {
+  // Drag bookkeeping. `pointerId` doubles as "is a drag in progress?" — we capture the pointer so the user can drag past the handle
+  // without losing it under fast movement, and release on pointer up / cancel.
+  const dragRef = useRef<{ pointerId: number; startX: number; startWidth: number } | null>(null);
+  // Mirror dragging state into React state so the `data-dragging` attribute and the accent-line opacity update on `pointerdown` without
+  // waiting for an unrelated re-render. We still keep the `dragRef` for the start coordinates so move handlers don't re-bind on every render.
+  const [isDragging, setIsDragging] = useState<boolean>(false);
+  // Mirror the latest width into a ref so the pointermove handler always sees the freshest value without re-binding on every render.
+  const widthRef = useRef<number>(width);
+  widthRef.current = width;
+
+  const onPointerDown = useCallback((e: PointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    e.currentTarget.setPointerCapture(e.pointerId);
+    dragRef.current = { pointerId: e.pointerId, startX: e.clientX, startWidth: widthRef.current };
+    setIsDragging(true);
+  }, []);
+
+  const onPointerMove = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag || drag.pointerId !== e.pointerId) return;
+      const next = clampSidebarWidth(drag.startWidth + (e.clientX - drag.startX));
+      if (next !== widthRef.current) onWidthChange(next);
+    },
+    [onWidthChange],
+  );
+
+  const finishDrag = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag || drag.pointerId !== e.pointerId) return;
+      dragRef.current = null;
+      setIsDragging(false);
+      if (e.currentTarget.hasPointerCapture(e.pointerId)) e.currentTarget.releasePointerCapture(e.pointerId);
+      // Commit even when width is unchanged from drag start — keeps the contract simple (one commit per gesture) and the no-op write is cheap.
+      onCommit(widthRef.current);
+    },
+    [onCommit],
+  );
+
+  const onDoubleClick = useCallback(() => {
+    onWidthChange(DEFAULT_WIDTH_PX);
+    onCommit(DEFAULT_WIDTH_PX);
+  }, [onCommit, onWidthChange]);
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      const next = computeKeyboardWidth(e.key, widthRef.current);
+      if (next === null) return;
+      e.preventDefault();
+      if (next !== widthRef.current) onWidthChange(next);
+      onCommit(next);
+    },
+    [onCommit, onWidthChange],
+  );
+
+  const isDraggingNow = isDragging;
+
+  const accentStyle: CSSProperties = {
+    // Width of the visible accent line; the hit zone (parent) stays 8 px wide so the click target is comfortable even when the line is 1 px.
+    width: '1px',
+  };
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize sidebar"
+      aria-valuemin={MIN_WIDTH_PX}
+      aria-valuemax={MAX_WIDTH_PX}
+      aria-valuenow={width}
+      tabIndex={0}
+      data-testid="sidebar-resize-handle"
+      data-dragging={isDraggingNow ? 'true' : 'false'}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={finishDrag}
+      onPointerCancel={finishDrag}
+      onDoubleClick={onDoubleClick}
+      onKeyDown={onKeyDown}
+      // `group` lets the inner accent line react to hover on the larger hit zone. `touch-none` keeps mobile pointer drags from
+      // turning into scrolls. The 8 px width gives a forgiving grab target while the inner line stays visually quiet.
+      className="group absolute right-0 top-0 z-10 flex h-full w-2 translate-x-1/2 cursor-col-resize touch-none items-stretch justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 dark:focus-visible:ring-blue-500"
+    >
+      <div
+        aria-hidden="true"
+        style={accentStyle}
+        // `data-dragging` on the parent forces the accent visible during an active drag so the user keeps a clear reference even
+        // when the pointer wanders away from the handle.
+        className="h-full bg-slate-300 opacity-0 transition-opacity group-hover:opacity-100 group-[[data-dragging=true]]:opacity-100 dark:bg-slate-700"
+      />
+    </div>
+  );
+}

--- a/src/components/SidebarResizeHandle.tsx
+++ b/src/components/SidebarResizeHandle.tsx
@@ -95,6 +95,12 @@ export function SidebarResizeHandle({ width, onWidthChange, onCommit }: SidebarR
   );
 
   const onDoubleClick = useCallback(() => {
+    // Defensive: cancel any in-flight gesture so a trailing pointerup can't overwrite the reset with the last dragged width. In normal DOM event
+    // ordering `dblclick` only fires after two completed pointerup cycles, so `dragRef` should already be null — but releasing pointer capture and
+    // resetting the computed-width ref keeps the invariant unconditional.
+    dragRef.current = null;
+    setIsDragging(false);
+    lastComputedRef.current = DEFAULT_WIDTH_PX;
     onWidthChange(DEFAULT_WIDTH_PX);
     onCommit(DEFAULT_WIDTH_PX);
   }, [onCommit, onWidthChange]);

--- a/src/components/WorktreeDashboard.test.tsx
+++ b/src/components/WorktreeDashboard.test.tsx
@@ -6,7 +6,7 @@ vi.mock('@/lib/tauri-bridge', async () => await import('@/lib/tauri-bridge.mock'
 import * as bridgeMock from '@/lib/tauri-bridge.mock';
 import { useSessionStore } from '@/store/session-store';
 import { useWorktreeTabStore } from '@/store/worktree-tab-store';
-import type { SessionView, WorktreeTab, WorktreeTabId } from '@/types/arborist';
+import type { SessionView, WorktreeGitStatus, WorktreeTab, WorktreeTabId } from '@/types/arborist';
 
 import { WorktreeDashboard } from './WorktreeDashboard';
 
@@ -166,7 +166,7 @@ describe('WorktreeDashboard', () => {
     useWorktreeTabStore.setState({ tabs: [tab()] });
     // Make the bridge call hang on the first invocation so the in-flight guard
     // would have to suppress the next poll/click attempt.
-    let resolveFirst: (v: unknown) => void = () => {};
+    let resolveFirst: (v: WorktreeGitStatus) => void = () => {};
     bridgeMock.worktreeGitStatus.mockReturnValueOnce(
       new Promise((res) => {
         resolveFirst = res;
@@ -292,7 +292,7 @@ describe('WorktreeDashboard', () => {
     // Switch to TAB_OTHER. Hold the new resolution open so we can observe the
     // intermediate state — the prior tab's error must NOT be visible while the
     // new tab's call is in flight.
-    let resolveSecond: (v: unknown) => void = () => {};
+    let resolveSecond: (v: WorktreeGitStatus) => void = () => {};
     bridgeMock.worktreeGitStatus.mockReturnValueOnce(
       new Promise((res) => {
         resolveSecond = res;

--- a/src/components/sidebar-width.ts
+++ b/src/components/sidebar-width.ts
@@ -1,0 +1,15 @@
+// Shared bounds and helpers for the resizable left sidebar (Issue #94).
+// Hoisted out of `SidebarResizeHandle.tsx` so the constants and pure
+// `clampSidebarWidth` helper can be imported from `Sidebar.tsx` without
+// breaking the `react-refresh/only-export-components` rule on the handle
+// component file.
+
+export const MIN_WIDTH_PX = 180;
+export const MAX_WIDTH_PX = 480;
+export const DEFAULT_WIDTH_PX = 224;
+export const KEYBOARD_STEP_PX = 16;
+
+export function clampSidebarWidth(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_WIDTH_PX;
+  return Math.min(MAX_WIDTH_PX, Math.max(MIN_WIDTH_PX, Math.round(value)));
+}

--- a/src/store/config-store.ts
+++ b/src/store/config-store.ts
@@ -126,6 +126,7 @@ export const selectTabOrder = (s: ConfigStoreState): AppConfig['tabOrder'] => s.
 export const selectLastOpenSessions = (s: ConfigStoreState): AppConfig['lastOpenSessions'] => s.config.lastOpenSessions;
 export const selectCustomProcesses = (s: ConfigStoreState): readonly CustomProcessDef[] => s.config.customProcesses;
 export const selectLastOpenSubSessions = (s: ConfigStoreState): readonly SubSessionRecord[] => s.config.lastOpenSubSessions;
+export const selectSidebarWidthPx = (s: ConfigStoreState): number | undefined => s.config.sidebarWidthPx;
 export const selectStatus = (s: ConfigStoreState): HydrationStatus => s.status;
 export const selectError = (s: ConfigStoreState): string | null => s.error;
 

--- a/src/types/arborist.ts
+++ b/src/types/arborist.ts
@@ -196,8 +196,8 @@ export interface AppConfig {
   /** Most recently focused worktree tab. Added in `configVersion = 5`. */
   activeWorktreeTabId: WorktreeTabId | null;
   /**
-   * User-chosen width of the left sidebar in CSS pixels (Issue #94). `null` /
-   * absent means "use the frontend default" (224 px). The backend clamps any
+   * User-chosen width of the left sidebar in CSS pixels (Issue #94). Absent means "use
+   * the frontend default" (224 px). The backend clamps any
    * value to `[180, 480]` on write.
    */
   sidebarWidthPx?: number;

--- a/src/types/arborist.ts
+++ b/src/types/arborist.ts
@@ -195,6 +195,12 @@ export interface AppConfig {
   worktreeTabOrder: WorktreeTabId[];
   /** Most recently focused worktree tab. Added in `configVersion = 5`. */
   activeWorktreeTabId: WorktreeTabId | null;
+  /**
+   * User-chosen width of the left sidebar in CSS pixels (Issue #94). `null` /
+   * absent means "use the frontend default" (224 px). The backend clamps any
+   * value to `[180, 480]` on write.
+   */
+  sidebarWidthPx?: number;
 }
 
 // MIRROR: src-tauri/src/types.rs::PartialDefaultInstructionSets
@@ -240,6 +246,11 @@ export interface PartialAppConfig {
   worktreeTabOrder?: WorktreeTabId[];
   /** Tri-state: omit to leave alone; `null` to clear; string to set. */
   activeWorktreeTabId?: WorktreeTabId | null;
+  /**
+   * Set the persisted sidebar width (CSS px). Backend clamps to `[180, 480]`.
+   * Omit to leave the persisted value alone. Issue #94.
+   */
+  sidebarWidthPx?: number;
 }
 
 // MIRROR: src-tauri/src/types.rs::CustomProcessDef


### PR DESCRIPTION
Closes #94.

## Summary

- Adds an 8 px hit-zone drag handle on the right edge of the sidebar that reveals a 1 px accent line on hover or active drag.
- Width clamped to [180, 480] px; double-click resets to the 224 px default.
- Persisted via a new optional `sidebarWidthPx` on `AppConfig` (backwards-compatible serde add — no config migration bump).
- Backend clamps in `merge_partial` so a hand-edited config cannot land off-screen.
- Live width is held in local state during a drag (no disk writes on each pointermove); persisted once on commit, and skipped entirely when the value matches what's already on disk.
- Accessibility: handle is a focusable `role="separator"` (`aria-orientation="vertical"`) with ArrowLeft/Right (16 px steps), Home/End (clamp to bounds), and double-click reset.

## Files of note

- `src-tauri/src/types.rs` — adds `AppConfig.sidebar_width_px` + `SIDEBAR_WIDTH_{MIN,MAX}_PX` constants; mirrored in `PartialAppConfig`.
- `src-tauri/src/config_store.rs` — `merge_partial` clamps the incoming width.
- `src/types/arborist.ts` — TS mirror with `// MIRROR:` markers.
- `src/components/SidebarResizeHandle.tsx` + `sidebar-width.ts` — new handle component and shared bounds.
- `src/components/Sidebar.tsx` — replaces fixed `w-56` with inline live width; reads/persists via `useConfigStore`.

## Tests

- `SidebarResizeHandle.test.tsx` — ARIA, pointer drag (live + commit + clamp), pointer-cancel cleanup, keyboard (Arrow/Home/End), double-click reset, ignored keys, in-flight `data-dragging` flag.
- `Sidebar.test.tsx` — default width, persisted-width adoption from config, keyboard persistence, no-op write suppression.
- All 611 frontend tests pass; full `cargo test --workspace --features test-helpers` passes; `cargo clippy -D warnings` clean; lint + prettier clean.

## Drive-by

Fixed two pre-existing TypeScript errors in `WorktreeDashboard.test.tsx` (Promise resolver typed as `unknown` instead of `WorktreeGitStatus`) that surfaced when re-running `tsc --noEmit`.

---

_Filed by the Copilot CLI agent on behalf of @mcaden._
