### PR TITLE
[three-dots-align] Align sidebar tab vertical-ellipsis and close buttons

### DIFF
--- a/src/components/SidebarTab.tsx
+++ b/src/components/SidebarTab.tsx
@@ -171,7 +171,7 @@ export function SidebarTab({
           const rect = button.getBoundingClientRect();
           onOpenContextMenu(id, { x: rect.left, y: rect.bottom + 2 }, button);
         }}
-        className="absolute right-7 top-1.5 rounded p-1 leading-none text-slate-500 opacity-0 transition-opacity hover:bg-slate-200 hover:text-slate-900 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 group-hover:opacity-100 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-slate-100"
+        className="absolute right-7 top-1.5 inline-flex h-6 w-6 items-center justify-center rounded leading-none text-slate-500 opacity-0 transition-opacity hover:bg-slate-200 hover:text-slate-900 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 group-hover:opacity-100 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-slate-100"
       >
         <span aria-hidden="true">⋮</span>
       </button>
@@ -184,7 +184,7 @@ export function SidebarTab({
             console.warn(`[sidebar-tab] close failed for session ${id}: ${formatError(err)}`);
           });
         }}
-        className="absolute right-3 top-1.5 rounded p-1 text-slate-500 opacity-0 transition-opacity hover:bg-slate-200 hover:text-slate-900 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 group-hover:opacity-100 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-slate-100"
+        className="absolute right-3 top-1.5 inline-flex h-6 w-6 items-center justify-center rounded leading-none text-slate-500 opacity-0 transition-opacity hover:bg-slate-200 hover:text-slate-900 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 group-hover:opacity-100 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-slate-100"
       >
         <span aria-hidden="true">×</span>
       </button>

--- a/src/components/SidebarWorktreeTab.tsx
+++ b/src/components/SidebarWorktreeTab.tsx
@@ -107,7 +107,7 @@ export function SidebarWorktreeTab({ tabId, isActive, onOpenContextMenu }: Sideb
           e.stopPropagation();
           wttActions.requestClose(tab.id);
         }}
-        className="absolute right-3 top-4 rounded p-0.5 text-slate-500 opacity-0 transition-opacity hover:bg-slate-200 hover:text-slate-900 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 group-hover:opacity-100 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-slate-100"
+        className="absolute right-3 top-4 inline-flex h-5 w-5 items-center justify-center rounded leading-none text-slate-500 opacity-0 transition-opacity hover:bg-slate-200 hover:text-slate-900 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 group-hover:opacity-100 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-slate-100"
       >
         <span aria-hidden="true">×</span>
       </button>


### PR DESCRIPTION
## Problem

In `SidebarTab` and `SidebarWorktreeTab`, the three-dots (⋮) menu trigger and the close (×) button did not line up vertically.

- `SidebarTab`: both buttons used `p-1` around raw glyph spans. The ⋮ and × characters have different intrinsic heights, so the resulting button boxes ended up different sizes despite the matching `top-1.5` offset.
- `SidebarWorktreeTab`: ⋮ used a fixed `inline-flex h-5 w-5 items-center justify-center` box while × used `p-0.5` around the raw glyph — two visibly different boxes at the same `top-4`.

## Fix

Normalize both pairs to fixed `inline-flex h-* w-* items-center justify-center` containers, matching the already-aligned `SidebarSubTab` pattern. Now each pair occupies identical, centered boxes at the same top offset regardless of glyph metrics.

- `SidebarTab`: ⋮ and × both use `inline-flex h-6 w-6 items-center justify-center`.
- `SidebarWorktreeTab`: ⋮ and × both use `inline-flex h-5 w-5 items-center justify-center`.

## Verification

- `pnpm run lint`: pass
- `pnpm test --run` for `SidebarTab` / `SidebarSubTab` / `SidebarWorktreeTab`: 28/28 pass
- Pre-push hook (full `pnpm test --run` + `cargo test --workspace --features test-helpers`): pass