### PR TITLE
[termination-cleanup-dir] Add worktree close app policy controls

### DIFF
--- a/crates/arborist-types/src/lib.rs
+++ b/crates/arborist-types/src/lib.rs
@@ -1098,6 +1098,23 @@ pub struct WorktreeTabOpenArgs {
     pub path: String,
 }
 
+/// How `worktree_tab_close` should handle application-kind sub-sessions when
+/// cascading under a closing worktree tab.
+///
+/// Terminal sub-sessions and AI sessions are unaffected by this setting; they
+/// are always terminated by their existing close paths.
+///
+/// MIRROR: `src/types/arborist.ts::WorktreeTabAppClosePolicy`.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum WorktreeTabAppClosePolicy {
+    /// Remove Arborist tracking only; keep external app processes running.
+    #[default]
+    Detach,
+    /// Attempt to terminate app sub-sessions (graceful first, then safe fallback where allowed).
+    Terminate,
+}
+
 /// Arguments for `worktree_tab_close`. Cascades close to all child
 /// sessions and sub-sessions under the tab. The optional `delete_worktree`
 /// flag asks the backend to run `git worktree remove --force` on the
@@ -1112,6 +1129,8 @@ pub struct WorktreeTabCloseArgs {
     pub id: WorktreeTabId,
     #[serde(default)]
     pub delete_worktree: bool,
+    #[serde(default)]
+    pub app_close_policy: WorktreeTabAppClosePolicy,
 }
 
 /// Arguments for `worktree_tab_focus`.
@@ -1918,6 +1937,30 @@ mod tests {
     fn custom_process_kind_serializes_lowercase() {
         assert_eq!(serde_json::to_value(CustomProcessKind::Terminal).expect("v"), json!("terminal"));
         assert_eq!(serde_json::to_value(CustomProcessKind::Application).expect("v"), json!("application"));
+    }
+
+    #[test]
+    fn worktree_tab_app_close_policy_serializes_lowercase() {
+        assert_eq!(serde_json::to_value(WorktreeTabAppClosePolicy::Detach).expect("v"), json!("detach"));
+        assert_eq!(serde_json::to_value(WorktreeTabAppClosePolicy::Terminate).expect("v"), json!("terminate"));
+    }
+
+    #[test]
+    fn worktree_tab_close_args_default_app_policy_is_detach() {
+        let parsed: WorktreeTabCloseArgs = serde_json::from_value(json!({
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "deleteWorktree": true
+        }))
+        .expect("deserialize");
+        assert_eq!(parsed.app_close_policy, WorktreeTabAppClosePolicy::Detach);
+        assert!(parsed.delete_worktree);
+
+        let explicit: WorktreeTabCloseArgs = serde_json::from_value(json!({
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "appClosePolicy": "terminate"
+        }))
+        .expect("deserialize explicit terminate");
+        assert_eq!(explicit.app_close_policy, WorktreeTabAppClosePolicy::Terminate);
     }
 
     #[test]

--- a/src-tauri/src/app_launcher.rs
+++ b/src-tauri/src/app_launcher.rs
@@ -573,6 +573,15 @@ impl AppPool {
         self.inner.lock().ok()?.get(id).map(|r| r.pid)
     }
 
+    /// Whether `id` has been re-targeted to a rediscovered owner process
+    /// (e.g. VS Code's long-lived owner) after launcher handoff.
+    #[must_use]
+    pub fn is_retargeted(&self, id: &SubSessionId) -> Option<bool> {
+        let g = self.inner.lock().ok()?;
+        let rt = g.get(id)?;
+        Some(rt.re_targeted.load(Ordering::SeqCst))
+    }
+
     /// Explicit close. Sets the `killed` guard so the wait thread will suppress its status emission, calls `killer.kill()`, and removes the runtime
     /// from the pool. Idempotent (`Ok` if the id is unknown).
     pub fn kill(&self, id: &SubSessionId) -> Result<(), Error> {
@@ -1207,6 +1216,7 @@ mod tests {
                 Some(resolver.clone() as Arc<dyn OwnerResolver>),
             )
             .expect("spawn");
+        assert_eq!(pool.is_retargeted(&id), Some(false));
 
         // Resolver returns a NEW pid + a fresh killer + a probe we hold the death-signal for.
         let new_pid = 99_001;
@@ -1227,6 +1237,11 @@ mod tests {
             || pool.pid(&id) == Some(new_pid),
             Duration::from_secs(2),
             "pool.pid should flip to rediscovered owner",
+        );
+        wait_until(
+            || pool.is_retargeted(&id) == Some(true),
+            Duration::from_secs(2),
+            "runtime should be marked re-targeted",
         );
 
         // Status events: Running(initial_pid) then Running(new_pid).

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -655,7 +655,7 @@ pub async fn worktree_tab_open(app: tauri::AppHandle, args: WorktreeTabOpenArgs)
 pub async fn worktree_tab_close(app: tauri::AppHandle, args: WorktreeTabCloseArgs) -> Result<WorktreeTabCloseResult, AppError> {
     let ctx = ctx_of(&app)?;
     let sub_ctx = sub_ctx_of(&app)?;
-    worktree_tab::worktree_tab_close_impl(&ctx, sub_ctx, args.id, args.delete_worktree).await
+    worktree_tab::worktree_tab_close_impl(&ctx, sub_ctx, args.id, args.delete_worktree, args.app_close_policy).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/subsession.rs
+++ b/src-tauri/src/commands/subsession.rs
@@ -14,7 +14,9 @@
 use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
+use tokio::time::{sleep, Instant};
 use tracing::{info, warn};
 
 use crate::commands::session::acquire_switch_read;
@@ -23,7 +25,7 @@ use crate::commands::AppContext;
 use crate::sub_sessions::{build_sub_session, sub_session_cwd, SubAppContext};
 use crate::types::{
     AppError, ChildId, CustomProcessKind, Error, PartialAppConfig, SubSession, SubSessionCloseIntent, SubSessionCreateArgs, SubSessionId,
-    SubSessionRecord, SubSessionStatus, WorktreeTabId,
+    SubSessionRecord, SubSessionStatus, WorktreeTabAppClosePolicy, WorktreeTabId,
 };
 
 /// Create a new sub-session under `parent_worktree_tab_id` using the `CustomProcessDef` identified by `def_id`. Validates:
@@ -303,6 +305,9 @@ pub fn subsession_resize_impl(ctx: &AppContext, sub_ctx: &SubAppContext, args: c
 // --------------------------------------------------------------------------- Worktree-tab-close cascade
 // ---------------------------------------------------------------------------
 
+const APP_CLOSE_GRACE: Duration = Duration::from_millis(600);
+const APP_CLOSE_POLL: Duration = Duration::from_millis(25);
+
 /// Tear down every sub-session belonging to `tab_id`. Called from the `worktree_tab_close` wrapper BEFORE closing child agent sessions so the
 /// sidebar can converge on "tab and all its children gone" in a single round trip.
 ///
@@ -312,15 +317,19 @@ pub fn subsession_resize_impl(ctx: &AppContext, sub_ctx: &SubAppContext, args: c
 ///   keep the in-memory record + persistence + flip status to `Error` — better
 ///   a visible orphan than a silently-leaked PTY child. `NotFound` from the
 ///   pool (sub-session already exited on its own) counts as success.
-/// * **Application**: `app_pool.detach()` — never kill. The user's editor /
-///   file browser must survive its worktree tab being closed; same rule as
-///   the explicit `subsession_close` path.
+/// * **Application**: obey `app_close_policy` (`Detach` vs `Terminate`).
 ///
-/// Returns `()` — cascade is best-effort and never blocks the tab close. Failures are logged via `tracing::warn`.
-pub async fn close_for_worktree_tab_impl(ctx: &AppContext, sub_ctx: &SubAppContext, tab_id: crate::types::WorktreeTabId) {
+/// Returns a best-effort list of per-child failures to surface via
+/// `WorktreeTabCloseResult.childErrors`. The cascade always continues.
+pub async fn close_for_worktree_tab_impl(
+    ctx: &AppContext,
+    sub_ctx: &SubAppContext,
+    tab_id: crate::types::WorktreeTabId,
+    app_close_policy: WorktreeTabAppClosePolicy,
+) -> Vec<String> {
     let subs = sub_ctx.store.list_for_worktree_tab(&tab_id);
     if subs.is_empty() {
-        return;
+        return Vec::new();
     }
     info!(
         worktree_tab_id = %tab_id,
@@ -354,6 +363,7 @@ pub async fn close_for_worktree_tab_impl(ctx: &AppContext, sub_ctx: &SubAppConte
         }
     }
 
+    let mut child_errors: Vec<String> = Vec::new();
     for sub in subs {
         match sub.kind {
             CustomProcessKind::Terminal => {
@@ -377,6 +387,7 @@ pub async fn close_for_worktree_tab_impl(ctx: &AppContext, sub_ctx: &SubAppConte
                                 Some(pid),
                                 Some(format!("PTY kill unconfirmed during worktree tab close (pid {pid} may still be alive)")),
                             );
+                            child_errors.push(format!("sub-session {}: PTY kill unconfirmed (pid {pid} may still be alive)", sub.id));
                             continue;
                         }
                         Err(e) => {
@@ -392,14 +403,60 @@ pub async fn close_for_worktree_tab_impl(ctx: &AppContext, sub_ctx: &SubAppConte
                                 None,
                                 Some(format!("PTY kill failed during worktree tab close: {e}")),
                             );
+                            child_errors.push(format!("sub-session {}: PTY kill failed: {e}", sub.id));
                             continue;
                         }
                     }
                 }
             }
             CustomProcessKind::Application => {
-                // Detach only — never kill. Closing the tab must NOT terminate the user's editor / file manager.
-                sub_ctx.app_pool.detach(&sub.id);
+                match app_close_policy {
+                    WorktreeTabAppClosePolicy::Detach => {
+                        sub_ctx.app_pool.detach(&sub.id);
+                    }
+                    WorktreeTabAppClosePolicy::Terminate => {
+                        if sub_ctx.app_pool.contains(&sub.id) {
+                            match sub_ctx.app_pool.request_window_close(&sub.id, &*sub_ctx.focuser) {
+                                Ok(()) => {
+                                    let deadline = Instant::now() + APP_CLOSE_GRACE;
+                                    while sub_ctx.app_pool.contains(&sub.id) && Instant::now() < deadline {
+                                        sleep(APP_CLOSE_POLL).await;
+                                    }
+                                }
+                                Err(Error::NotFound(_)) | Err(Error::Unsupported(_)) => {
+                                    // No close-capable window target on this runtime/platform; may still be killable below.
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        worktree_tab_id = %tab_id,
+                                        sub_session_id = %sub.id,
+                                        error = ?e,
+                                        "cascade: request_window_close failed for app sub-session"
+                                    );
+                                    child_errors.push(format!("sub-session {}: graceful app-close request failed: {e}", sub.id));
+                                }
+                            }
+                        }
+
+                        if sub_ctx.app_pool.contains(&sub.id) {
+                            if matches!(sub_ctx.app_pool.is_retargeted(&sub.id), Some(true)) {
+                                sub_ctx.app_pool.detach(&sub.id);
+                                child_errors.push(format!(
+                                    "sub-session {}: detached instead of force-killing a re-targeted/shared app owner",
+                                    sub.id
+                                ));
+                            } else if let Err(e) = sub_ctx.app_pool.kill(&sub.id) {
+                                warn!(
+                                    worktree_tab_id = %tab_id,
+                                    sub_session_id = %sub.id,
+                                    error = ?e,
+                                    "cascade: app terminate failed"
+                                );
+                                child_errors.push(format!("sub-session {}: app terminate failed: {e}", sub.id));
+                            }
+                        }
+                    }
+                }
             }
         }
         sub_ctx.store.remove(&sub.id);
@@ -412,6 +469,7 @@ pub async fn close_for_worktree_tab_impl(ctx: &AppContext, sub_ctx: &SubAppConte
             );
         }
     }
+    child_errors
 }
 
 // --------------------------------------------------------------------------- Phase 7: restore-on-launch second pass

--- a/src-tauri/src/commands/worktree_tab.rs
+++ b/src-tauri/src/commands/worktree_tab.rs
@@ -11,8 +11,8 @@ use tracing::{info, warn};
 use crate::compose;
 use crate::config_store::ConfigStore;
 use crate::types::{
-    AppConfig, AppError, ChildId, PartialAppConfig, SessionId, WorktreeTab, WorktreeTabCloseResult, WorktreeTabId, WorktreeTabOpenArgs,
-    WorktreeTabSetActiveChildArgs,
+    AppConfig, AppError, ChildId, PartialAppConfig, SessionId, WorktreeTab, WorktreeTabAppClosePolicy, WorktreeTabCloseResult, WorktreeTabId,
+    WorktreeTabOpenArgs, WorktreeTabSetActiveChildArgs,
 };
 use crate::worktree_icon::pick_least_used_icon;
 
@@ -150,6 +150,7 @@ pub async fn worktree_tab_close_impl(
     sub_ctx: std::sync::Arc<crate::sub_sessions::SubAppContext>,
     id: WorktreeTabId,
     delete_worktree: bool,
+    app_close_policy: WorktreeTabAppClosePolicy,
 ) -> Result<WorktreeTabCloseResult, AppError> {
     let _switch = session::acquire_switch_read(ctx)?;
 
@@ -168,13 +169,11 @@ pub async fn worktree_tab_close_impl(
     let sessions = ctx.store().load_sessions();
     let child_session_ids: Vec<SessionId> = sessions.values().filter(|s| s.worktree_path == tab_path).map(|s| s.id).collect();
 
-    let mut child_errors: Vec<String> = Vec::new();
-
     // Mark worktree tab as closing (RAII guard). This prevents new sub-sessions being created under this tab during the cascade.
     let _tab_guard = ctx.mark_worktree_tab_closing(id);
 
     // Cascade-close sub-sessions directly (they belong to the worktree tab, not to any agent session).
-    super::subsession::close_for_worktree_tab_impl(ctx, &sub_ctx, id).await;
+    let mut child_errors = super::subsession::close_for_worktree_tab_impl(ctx, &sub_ctx, id, app_close_policy).await;
 
     // Close each child agent session. Sub-sessions are already torn down above; session_close no longer cascades subs.
     for sid in &child_session_ids {

--- a/src-tauri/tests/sub_sessions_e2e.rs
+++ b/src-tauri/tests/sub_sessions_e2e.rs
@@ -1,16 +1,17 @@
 //! Phase 7 sub-session lifecycle integration tests: parent-close cascade, closing-parent tombstone, restore-on-launch second pass, and relaunch.
 //!
 //! Mirrors the FakeSpawner pattern from `tests/session_lifecycle_fake.rs` (each Rust integration test file is its own crate, so helpers must be
-//! duplicated). Application-kind paths are exercised by the `app_launcher` unit tests + the frontend `SidebarSubTab.test.tsx`; this file focuses on
-//! terminal-kind cascade/tombstone/restore/relaunch behaviour, which is the part with non-trivial cross-module coordination.
+//! duplicated). Includes both terminal and application cascade behaviour (detach vs terminate policy), while finer-grained app-runtime semantics are
+//! still covered in `app_launcher` unit tests.
 
+use std::collections::BTreeMap;
 use std::io::Read;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use arborist_lib::app_launcher::{AppPool, AppSpawner, RealAppSpawner};
+use arborist_lib::app_launcher::{AppKiller, AppPool, AppSpawner, AppWaiter, SpawnedApp};
 use arborist_lib::commands::session::{session_create_impl, AppContext};
 use arborist_lib::commands::subsession::{
     close_for_worktree_tab_impl, restore_all_sub_sessions_impl, subsession_close_impl, subsession_create_impl, subsession_relaunch_impl,
@@ -20,7 +21,8 @@ use arborist_lib::pty_pool::{ChildCommand, PtyKiller, PtyPool, PtyResize, PtySin
 use arborist_lib::sub_sessions::{SubPtyPool, SubPtySink, SubSessionStore};
 use arborist_lib::types::{
     ChildId, CustomProcessDef, CustomProcessDefId, CustomProcessKind, InstructionSetId, PartialAppConfig, PartialDefaultInstructionSets,
-    SessionCreateArgs, SessionId, SessionStatus, SubSessionCloseIntent, SubSessionCreateArgs, SubSessionStatus, Tool, WorktreeTab, WorktreeTabId,
+    SessionCreateArgs, SessionId, SessionStatus, SubSessionCloseIntent, SubSessionCreateArgs, SubSessionStatus, Tool, WorktreeTab,
+    WorktreeTabAppClosePolicy, WorktreeTabId,
 };
 use arborist_lib::window_focus::RecordingFocuser;
 use portable_pty::{ExitStatus, PtySize};
@@ -144,6 +146,89 @@ impl PtyWaiter for BlockingWaiter {
     }
 }
 
+// --------------------------------------------------------------------------- Fake app spawner
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct FakeAppState {
+    next_pid: u32,
+    kill_calls: BTreeMap<u32, usize>,
+}
+
+#[derive(Clone)]
+struct FakeAppSpawner {
+    state: Arc<Mutex<FakeAppState>>,
+}
+
+impl FakeAppSpawner {
+    fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(FakeAppState {
+                next_pid: 40_000,
+                kill_calls: BTreeMap::new(),
+            })),
+        }
+    }
+
+    fn kill_calls_for_pid(&self, pid: u32) -> usize {
+        self.state.lock().ok().and_then(|s| s.kill_calls.get(&pid).copied()).unwrap_or(0)
+    }
+}
+
+impl AppSpawner for FakeAppSpawner {
+    fn spawn(&self, _cmd: &str, _cwd: &Path) -> Result<SpawnedApp, arborist_lib::types::Error> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| arborist_lib::types::Error::Internal("fake app state mutex poisoned".into()))?;
+        let pid = state.next_pid;
+        state.next_pid += 1;
+        state.kill_calls.entry(pid).or_insert(0);
+        drop(state);
+
+        let done = Arc::new(AtomicBool::new(false));
+        Ok(SpawnedApp {
+            pid,
+            waiter: Box::new(FakeAppWaiter { done: Arc::clone(&done) }),
+            killer: Arc::new(FakeAppKiller {
+                pid,
+                done,
+                state: Arc::clone(&self.state),
+            }),
+        })
+    }
+}
+
+struct FakeAppWaiter {
+    done: Arc<AtomicBool>,
+}
+
+impl AppWaiter for FakeAppWaiter {
+    fn wait(self: Box<Self>) -> Result<bool, arborist_lib::types::Error> {
+        let start = std::time::Instant::now();
+        while !self.done.load(Ordering::Relaxed) && start.elapsed() < Duration::from_millis(250) {
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        Ok(true)
+    }
+}
+
+struct FakeAppKiller {
+    pid: u32,
+    done: Arc<AtomicBool>,
+    state: Arc<Mutex<FakeAppState>>,
+}
+
+impl AppKiller for FakeAppKiller {
+    fn kill(&self) -> Result<(), arborist_lib::types::Error> {
+        self.done.store(true, Ordering::Relaxed);
+        if let Ok(mut s) = self.state.lock() {
+            *s.kill_calls.entry(self.pid).or_insert(0) += 1;
+        }
+        Ok(())
+    }
+}
+
 // --------------------------------------------------------------------------- Capturing sinks
 // ---------------------------------------------------------------------------
 
@@ -189,12 +274,14 @@ struct Harness {
     sub_ctx: Arc<arborist_lib::sub_sessions::SubAppContext>,
     sub_pool: Arc<SubPtyPool>,
     sub_spawner_flags: SpawnerFlags,
+    app_spawner: FakeAppSpawner,
     sub_events: Arc<CapturedSubEvents>,
     config_dir: TempDir,
     _instructions_dir: TempDir,
     worktree: TempDir,
     instruction_id: InstructionSetId,
     shell_def_id: CustomProcessDefId,
+    app_def_id: CustomProcessDefId,
     worktree_tab_id: WorktreeTabId,
 }
 
@@ -216,6 +303,16 @@ fn build_harness() -> Harness {
         icon: None,
         icon_data_uri: None,
     };
+    let app_def_id = CustomProcessDefId("app".into());
+    let app_def = CustomProcessDef {
+        id: app_def_id.clone(),
+        name: "App".into(),
+        kind: CustomProcessKind::Application,
+        command: "app-launch".into(),
+        enabled: true,
+        icon: None,
+        icon_data_uri: None,
+    };
 
     let store = ConfigStore::open(config_dir.path()).unwrap();
     store
@@ -225,7 +322,7 @@ fn build_harness() -> Harness {
                 claude: Some(instruction_id.clone()),
                 copilot: None,
             }),
-            custom_processes: Some(vec![shell_def]),
+            custom_processes: Some(vec![shell_def, app_def]),
             ..Default::default()
         })
         .unwrap();
@@ -269,9 +366,8 @@ fn build_harness() -> Harness {
     let sub_store = Arc::new(SubSessionStore::new());
     let sub_events = Arc::new(CapturedSubEvents::default());
     let sub_sink = make_sub_sink(Arc::clone(&sub_events));
-    // App pool with the real spawner: cascade for terminal kind only touches the SubPtyPool, so we never call AppPool::spawn in these tests; passing
-    // RealAppSpawner is harmless.
-    let app_pool = Arc::new(AppPool::new(Arc::new(RealAppSpawner) as Arc<dyn AppSpawner>));
+    let app_spawner = FakeAppSpawner::new();
+    let app_pool = Arc::new(AppPool::new(Arc::new(app_spawner.clone()) as Arc<dyn AppSpawner>));
     let focuser = Arc::new(RecordingFocuser::new());
     let icon_cache = Arc::new(arborist_lib::process_icon::IconCache::new(Arc::new(
         arborist_lib::process_icon::RealIconExtractor,
@@ -290,12 +386,14 @@ fn build_harness() -> Harness {
         sub_ctx,
         sub_pool,
         sub_spawner_flags,
+        app_spawner,
         sub_events,
         config_dir,
         _instructions_dir: instructions_dir,
         worktree,
         instruction_id,
         shell_def_id,
+        app_def_id,
         worktree_tab_id,
     }
 }
@@ -321,6 +419,17 @@ fn create_sub(h: &Harness, tab_id: WorktreeTabId) -> Result<arborist_lib::types:
         SubSessionCreateArgs {
             parent_worktree_tab_id: tab_id,
             def_id: h.shell_def_id.clone(),
+        },
+    )
+}
+
+fn create_app_sub(h: &Harness, tab_id: WorktreeTabId) -> Result<arborist_lib::types::SubSession, arborist_lib::types::AppError> {
+    subsession_create_impl(
+        &h.ctx,
+        &h.sub_ctx,
+        SubSessionCreateArgs {
+            parent_worktree_tab_id: tab_id,
+            def_id: h.app_def_id.clone(),
         },
     )
 }
@@ -352,12 +461,69 @@ async fn cascade_kills_terminal_subs_and_prunes_persistence() {
     assert_eq!(h.ctx.store().load_config().last_open_sub_sessions.len(), 2);
 
     // Cascade and verify both sub-sessions are gone everywhere.
-    close_for_worktree_tab_impl(&h.ctx, &h.sub_ctx, h.worktree_tab_id).await;
+    let _ = close_for_worktree_tab_impl(&h.ctx, &h.sub_ctx, h.worktree_tab_id, WorktreeTabAppClosePolicy::Detach).await;
 
     assert!(!h.sub_pool.contains(&sub_a.id), "sub_a still in pool");
     assert!(!h.sub_pool.contains(&sub_b.id), "sub_b still in pool");
     assert!(h.sub_ctx.store.list_for_worktree_tab(&h.worktree_tab_id).is_empty(), "store not pruned");
     assert!(h.ctx.store().load_config().last_open_sub_sessions.is_empty(), "persistence not pruned");
+}
+
+#[tokio::test]
+async fn cascade_terminate_policy_still_kills_terminal_subs() {
+    let h = build_harness();
+    let _parent = create_parent(&h).id;
+    let sub = create_sub(&h, h.worktree_tab_id).expect("sub created");
+    assert!(wait_until(|| h.sub_pool.contains(&sub.id), Duration::from_secs(2)));
+
+    let child_errors = close_for_worktree_tab_impl(&h.ctx, &h.sub_ctx, h.worktree_tab_id, WorktreeTabAppClosePolicy::Terminate).await;
+
+    assert!(child_errors.is_empty(), "unexpected child errors: {child_errors:?}");
+    assert!(!h.sub_pool.contains(&sub.id), "terminal sub should be killed regardless of app policy");
+    assert!(h.sub_ctx.store.list_for_worktree_tab(&h.worktree_tab_id).is_empty(), "store not pruned");
+    assert!(h.ctx.store().load_config().last_open_sub_sessions.is_empty(), "persistence not pruned");
+}
+
+#[tokio::test]
+async fn cascade_detach_policy_keeps_application_process_running() {
+    let h = build_harness();
+    let _parent = create_parent(&h).id;
+    let app_sub = create_app_sub(&h, h.worktree_tab_id).expect("app sub created");
+    let app_pid = app_sub.pid.expect("app pid");
+    assert!(wait_until(|| h.sub_ctx.app_pool.contains(&app_sub.id), Duration::from_secs(1)));
+
+    let child_errors = close_for_worktree_tab_impl(&h.ctx, &h.sub_ctx, h.worktree_tab_id, WorktreeTabAppClosePolicy::Detach).await;
+
+    assert!(child_errors.is_empty(), "unexpected child errors: {child_errors:?}");
+    assert_eq!(h.app_spawner.kill_calls_for_pid(app_pid), 0, "detach policy must not kill app runtimes");
+    assert!(!h.sub_ctx.app_pool.contains(&app_sub.id), "app runtime should be detached from pool");
+    assert!(
+        h.sub_ctx.store.get(&app_sub.id).is_none(),
+        "app sub should be removed from in-memory store"
+    );
+}
+
+#[tokio::test]
+async fn cascade_terminate_policy_kills_non_retargeted_application_runtime() {
+    let h = build_harness();
+    let _parent = create_parent(&h).id;
+    let app_sub = create_app_sub(&h, h.worktree_tab_id).expect("app sub created");
+    let app_pid = app_sub.pid.expect("app pid");
+    assert!(wait_until(|| h.sub_ctx.app_pool.contains(&app_sub.id), Duration::from_secs(1)));
+
+    let child_errors = close_for_worktree_tab_impl(&h.ctx, &h.sub_ctx, h.worktree_tab_id, WorktreeTabAppClosePolicy::Terminate).await;
+
+    assert!(child_errors.is_empty(), "unexpected child errors: {child_errors:?}");
+    assert_eq!(
+        h.app_spawner.kill_calls_for_pid(app_pid),
+        1,
+        "terminate policy should kill non-re-targeted app runtimes"
+    );
+    assert!(!h.sub_ctx.app_pool.contains(&app_sub.id), "app runtime should be gone after terminate");
+    assert!(
+        h.sub_ctx.store.get(&app_sub.id).is_none(),
+        "app sub should be removed from in-memory store"
+    );
 }
 
 #[tokio::test]
@@ -377,7 +543,7 @@ async fn worktree_tab_closing_tombstone_rejects_new_subs_and_cascades() {
         let err = blocked.err().unwrap();
         assert_eq!(err.code, "InvalidArgument");
 
-        close_for_worktree_tab_impl(&h.ctx, &h.sub_ctx, h.worktree_tab_id).await;
+        let _ = close_for_worktree_tab_impl(&h.ctx, &h.sub_ctx, h.worktree_tab_id, WorktreeTabAppClosePolicy::Detach).await;
     }
 
     // Guard dropped: tombstone clears, sub gone.
@@ -394,7 +560,7 @@ async fn restore_drops_orphan_records_when_worktree_tab_is_gone() {
     assert!(wait_until(|| h.sub_pool.contains(&sub.id), Duration::from_secs(2)));
 
     // Tear down existing subs.
-    close_for_worktree_tab_impl(&h.ctx, &h.sub_ctx, h.worktree_tab_id).await;
+    let _ = close_for_worktree_tab_impl(&h.ctx, &h.sub_ctx, h.worktree_tab_id, WorktreeTabAppClosePolicy::Detach).await;
 
     // Remove the worktree tab from config so the orphan record references a non-existent tab.
     h.ctx
@@ -585,7 +751,7 @@ async fn cascade_kill_failure_leaves_orphan_visible() {
     // Flip the killer to fail. Cascade hits this branch on the next pool.kill call.
     h.sub_spawner_flags.kill_fails.store(true, Ordering::SeqCst);
 
-    close_for_worktree_tab_impl(&h.ctx, &h.sub_ctx, h.worktree_tab_id).await;
+    let _ = close_for_worktree_tab_impl(&h.ctx, &h.sub_ctx, h.worktree_tab_id, WorktreeTabAppClosePolicy::Detach).await;
 
     // Orphan record kept in the in-memory store and on disk so the user can see the runaway PID.
     assert_eq!(
@@ -861,7 +1027,7 @@ async fn cascade_with_no_matching_active_child_skips_config_write() {
     let cfg_path = h.config_dir.path().join("config.json");
     let (bytes_before, mtime_before) = snapshot_with_rolled_back_mtime(&cfg_path);
 
-    close_for_worktree_tab_impl(&h.ctx, &h.sub_ctx, h.worktree_tab_id).await;
+    let _ = close_for_worktree_tab_impl(&h.ctx, &h.sub_ctx, h.worktree_tab_id, WorktreeTabAppClosePolicy::Detach).await;
 
     let (bytes_after, mtime_after) = snapshot_file(&cfg_path);
     assert_eq!(
@@ -885,7 +1051,7 @@ async fn cascade_with_matching_active_child_rewrites_config_and_clears_pointer()
     let cfg_path = h.config_dir.path().join("config.json");
     let (_, mtime_before) = snapshot_with_rolled_back_mtime(&cfg_path);
 
-    close_for_worktree_tab_impl(&h.ctx, &h.sub_ctx, h.worktree_tab_id).await;
+    let _ = close_for_worktree_tab_impl(&h.ctx, &h.sub_ctx, h.worktree_tab_id, WorktreeTabAppClosePolicy::Detach).await;
 
     let (_, mtime_after) = snapshot_file(&cfg_path);
     assert!(

--- a/src/components/WorktreeCloseConfirmDialog.tsx
+++ b/src/components/WorktreeCloseConfirmDialog.tsx
@@ -14,6 +14,7 @@ import { formatError } from '@/lib/tauri-bridge';
 import { useSessionStore } from '@/store/session-store';
 import { useSubSessionStore } from '@/store/sub-session-store';
 import { usePendingWorktreeTabClose, useWorktreeTabActions, useWorktreeTabStore } from '@/store/worktree-tab-store';
+import type { WorktreeTabAppClosePolicy } from '@/types/arborist';
 
 export function WorktreeCloseConfirmDialog(): JSX.Element | null {
   const pendingId = usePendingWorktreeTabClose();
@@ -22,10 +23,14 @@ export function WorktreeCloseConfirmDialog(): JSX.Element | null {
 
   const sessionCount = useSessionStore((s) => (tab ? s.sessions.filter((sess) => sess.worktreePath === tab.path).length : 0));
   const subSessionCount = useSubSessionStore((s) => (tab ? s.subSessions.filter((sub) => sub.parentWorktreeTabId === tab.id).length : 0));
+  const appSubSessionCount = useSubSessionStore((s) =>
+    tab ? s.subSessions.filter((sub) => sub.parentWorktreeTabId === tab.id && sub.kind === 'application').length : 0,
+  );
 
   const dialogRef = useRef<HTMLDialogElement | null>(null);
   const cancelRef = useRef<HTMLButtonElement | null>(null);
   const [deleteWorktree, setDeleteWorktree] = useState<boolean>(false);
+  const [appClosePolicy, setAppClosePolicy] = useState<WorktreeTabAppClosePolicy>('detach');
   const [busy, setBusy] = useState<boolean>(false);
 
   useEffect(() => {
@@ -35,6 +40,7 @@ export function WorktreeCloseConfirmDialog(): JSX.Element | null {
       // Reset transient state every time the dialog opens — deletion
       // is destructive and should never be sticky across tabs.
       setDeleteWorktree(false);
+      setAppClosePolicy('detach');
       setBusy(false);
       if (!dialog.open) {
         if (typeof dialog.showModal === 'function') {
@@ -72,7 +78,7 @@ export function WorktreeCloseConfirmDialog(): JSX.Element | null {
     setBusy(true);
     let alertMessage: string | null = null;
     try {
-      const result = await actions.close(pendingId, deleteWorktree);
+      const result = await actions.close(pendingId, deleteWorktree, appClosePolicy);
       if (result.worktreeDeleteError) {
         alertMessage = `Worktree tab closed, but deleting the worktree failed:\n\n${result.worktreeDeleteError}`;
       }
@@ -105,8 +111,50 @@ export function WorktreeCloseConfirmDialog(): JSX.Element | null {
       </h2>
       {childSummary.length > 0 ? (
         <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
-          This will terminate <span className="font-medium">{childSummary}</span> running under this worktree.
+          This will close <span className="font-medium">{childSummary}</span> running under this worktree.
         </p>
+      ) : null}
+      {appSubSessionCount > 0 ? (
+        <fieldset className="mb-3 rounded-md border border-slate-200 p-3 text-sm dark:border-slate-700">
+          <legend className="px-1 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Application sub-processes ({appSubSessionCount})
+          </legend>
+          <p className="mb-2 text-xs text-slate-600 dark:text-slate-300">
+            Choose whether application sub-processes are left running or terminated when possible.
+          </p>
+          <label className="flex items-start gap-2">
+            <input
+              type="radio"
+              name="worktree-app-close-policy"
+              value="detach"
+              checked={appClosePolicy === 'detach'}
+              disabled={busy}
+              onChange={() => setAppClosePolicy('detach')}
+              className="mt-0.5 h-4 w-4 cursor-pointer accent-sky-600 disabled:cursor-not-allowed disabled:opacity-50"
+            />
+            <span>
+              <span className="font-medium">Detach and keep running</span>
+              <span className="block text-xs text-slate-500 dark:text-slate-400">Default and safest for shared app processes.</span>
+            </span>
+          </label>
+          <label className="mt-2 flex items-start gap-2">
+            <input
+              type="radio"
+              name="worktree-app-close-policy"
+              value="terminate"
+              checked={appClosePolicy === 'terminate'}
+              disabled={busy}
+              onChange={() => setAppClosePolicy('terminate')}
+              className="mt-0.5 h-4 w-4 cursor-pointer accent-red-600 disabled:cursor-not-allowed disabled:opacity-50"
+            />
+            <span>
+              <span className="font-medium">Terminate</span>
+              <span className="block text-xs text-slate-500 dark:text-slate-400">
+                Requests a graceful close first, then terminates only when Arborist can do so safely.
+              </span>
+            </span>
+          </label>
+        </fieldset>
       ) : null}
       <label className="mb-4 flex items-start gap-2 text-sm">
         <input

--- a/src/store/worktree-tab-store.test.ts
+++ b/src/store/worktree-tab-store.test.ts
@@ -204,6 +204,32 @@ describe('useWorktreeTabStore', () => {
   });
 
   describe('close', () => {
+    it('forwards default appClosePolicy=detach to the backend when omitted', async () => {
+      const a = makeTab(TAB_A);
+      useWorktreeTabStore.setState({ tabs: [a], activeId: TAB_A });
+
+      await useWorktreeTabStore.getState().actions.close(TAB_A);
+
+      expect(bridgeMock.worktreeTabClose).toHaveBeenCalledWith({
+        id: TAB_A,
+        deleteWorktree: false,
+        appClosePolicy: 'detach',
+      });
+    });
+
+    it('forwards explicit appClosePolicy to the backend', async () => {
+      const a = makeTab(TAB_A);
+      useWorktreeTabStore.setState({ tabs: [a], activeId: TAB_A });
+
+      await useWorktreeTabStore.getState().actions.close(TAB_A, true, 'terminate');
+
+      expect(bridgeMock.worktreeTabClose).toHaveBeenCalledWith({
+        id: TAB_A,
+        deleteWorktree: true,
+        appClosePolicy: 'terminate',
+      });
+    });
+
     it('removes the tab and picks the first remaining as active when the closed one was active', async () => {
       const a = makeTab(TAB_A, { tabIndex: 0 });
       const b = makeTab(TAB_B, { tabIndex: 1 });

--- a/src/store/worktree-tab-store.ts
+++ b/src/store/worktree-tab-store.ts
@@ -22,7 +22,7 @@ import {
   configGet,
   formatError,
 } from '@/lib/tauri-bridge';
-import type { ChildId, WorktreeTab, WorktreeTabCloseResult, WorktreeTabId } from '@/types/arborist';
+import type { ChildId, WorktreeTab, WorktreeTabAppClosePolicy, WorktreeTabCloseResult, WorktreeTabId } from '@/types/arborist';
 
 // ---------------------------------------------------------------------------
 // State shape
@@ -56,7 +56,7 @@ export interface WorktreeTabStoreActions {
    * `git worktree remove --force` on the tab's worktree path; the failure of that step is surfaced as `worktreeDeleteError` on the result instead
    * of as a thrown error so the UI can always converge on a "tab gone" state.
    */
-  close: (id: WorktreeTabId, deleteWorktree?: boolean) => Promise<WorktreeTabCloseResult>;
+  close: (id: WorktreeTabId, deleteWorktree?: boolean, appClosePolicy?: WorktreeTabAppClosePolicy) => Promise<WorktreeTabCloseResult>;
   focus: (id: WorktreeTabId) => Promise<void>;
   reorder: (ids: WorktreeTabId[]) => Promise<void>;
   setActiveChild: (id: WorktreeTabId, childId: ChildId | null) => Promise<void>;
@@ -127,12 +127,16 @@ export const useWorktreeTabStore = create<Store>((set, get) => {
       return tab;
     },
 
-    async close(id: WorktreeTabId, deleteWorktree?: boolean) {
+    async close(id: WorktreeTabId, deleteWorktree?: boolean, appClosePolicy?: WorktreeTabAppClosePolicy) {
       // Capture the path BEFORE the backend call so we can converge frontend caches even if the result payload were missing it. Backend
       // cascade closes child sessions/sub-sessions but we don't get per-child UI events for that — the session-store would otherwise leave
       // zombie rows. Lazy-import session-store to avoid a circular import (session-store already imports this module).
       const closingTab = get().tabs.find((t) => t.id === id);
-      const result = await worktreeTabClose({ id, deleteWorktree: deleteWorktree ?? false });
+      const result = await worktreeTabClose({
+        id,
+        deleteWorktree: deleteWorktree ?? false,
+        appClosePolicy: appClosePolicy ?? 'detach',
+      });
       if (result.childErrors && result.childErrors.length > 0) {
         console.warn('[worktree-tab-store] close had child errors:', result.childErrors);
       }

--- a/src/types/arborist.ts
+++ b/src/types/arborist.ts
@@ -418,6 +418,12 @@ export interface WorktreeTabOpenArgs {
   path: string;
 }
 
+// MIRROR: src-tauri/src/types.rs::WorktreeTabAppClosePolicy
+//
+// Policy for application-kind sub-sessions during worktree-tab cascade close.
+// Terminal sub-sessions and AI sessions are always terminated by their own paths.
+export type WorktreeTabAppClosePolicy = 'detach' | 'terminate';
+
 // MIRROR: src-tauri/src/types.rs::WorktreeTabCloseArgs
 export interface WorktreeTabCloseArgs {
   id: WorktreeTabId;
@@ -430,6 +436,11 @@ export interface WorktreeTabCloseArgs {
    * thrown error.
    */
   deleteWorktree?: boolean;
+  /**
+   * Close policy for application-kind sub-sessions under the worktree tab.
+   * Omitted means `'detach'` for backwards-compatible behavior.
+   */
+  appClosePolicy?: WorktreeTabAppClosePolicy;
 }
 
 // MIRROR: src-tauri/src/types.rs::WorktreeTabFocusArgs


### PR DESCRIPTION
## Summary
- add ppClosePolicy (detach/	erminate) to worktree-tab close args in Rust + TS contracts
- thread policy through backend/frontend worktree-close flows and add UI choice for app subprocess handling
- keep AI/terminal teardown as terminate-only and add safe app terminate behavior for non-retargeted runtimes
- add regression tests for default policy wiring and detach vs terminate cascade behavior

## Validation
- pnpm run lint
- pnpm test --run
- pnpm run build
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --features test-helpers -- -D warnings
- cargo test --workspace --features test-helpers