### PR TITLE
[backend-trim] Refine dependency trim and picker wiring

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,7 +35,7 @@ A cross-platform desktop app (Tauri v2 + React/TS) that manages multiple Claude 
 
 - **Shell**: Tauri v2 (Rust backend, OS WebView frontend) — *not* Electron
 - **Frontend**: React + TypeScript, Vite, Tailwind CSS, Zustand, xterm.js
-- **Backend**: Rust, `portable-pty` for cross-platform PTY (ConPTY on Windows), `tauri-plugin-store` for JSON persistence
+- **Backend**: Rust, `portable-pty` for cross-platform PTY (ConPTY on Windows), custom JSON persistence via `config_store.rs`
 - **Layout**: `src/` (frontend), `src-tauri/` (Rust), `instructions/` (default instruction set files), `dev/docs/` (specs)
 
 ## Architectural conventions (read DESIGN.md before changing)
@@ -62,7 +62,7 @@ Defined in Rust with `serde`, mirrored as TypeScript types in the frontend. Thre
 
 ## Persistence rules
 
-- All persistent state goes through `tauri-plugin-store` (`AppConfig` + session records).
+- All persistent state goes through the Rust `ConfigStore` (`AppConfig` + session records).
 - `lastOpenSessions` and `tabOrder` drive restore-on-launch — update them on session create/close/reorder/focus.
 - The app **must not** store credentials (SPEC NF-05). Auth is delegated to the CLI tools.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ If a task genuinely requires restarting the host, ask the user to do it — neve
 ## Stack
 
 - **Frontend**: React + TypeScript, Vite, Tailwind CSS (class dark-mode strategy), Zustand, xterm.js
-- **Backend**: Rust, Tauri v2, `portable-pty` (ConPTY on Windows), `tauri-plugin-store` for JSON persistence
+- **Backend**: Rust, Tauri v2, `portable-pty` (ConPTY on Windows), custom JSON persistence via `config_store.rs`
 - **Layout**: `src/` (frontend), `src-tauri/src/` (Rust), `instructions/` (default instruction-set files), `dev/docs/` (specs)
 
 ## Commands
@@ -88,7 +88,7 @@ Rust backend owns all PTYs and persistent state; the React frontend communicates
 | `lib.rs`              | App entry: init tracing, build `AppContext`, register commands, run event loop                                                                                   |
 | `types.rs`            | All serde types: `Session`, `AppConfig`, errors, event payloads. **Canonical** — TS mirrors must stay in lockstep                                                |
 | `compose.rs`          | Pure functions: `compose_command`, `dedupe_label`, shell quoting, worktree validation                                                                            |
-| `config_store.rs`     | `tauri-plugin-store` wrapper; atomic writes via `NamedTempFile::persist`; config quarantine on parse failure                                                     |
+| `config_store.rs`     | Custom JSON store; atomic writes via `NamedTempFile::persist`; config quarantine on parse failure                                                                |
 | `pty_pool.rs`         | PTY lifecycle, `PtySpawner` trait (injectable for tests), bounded mpsc backpressure (`OUTPUT_CHANNEL_CAPACITY = 512`), `ESC c` reset on overflow, orphan cleanup |
 | `commands/session.rs` | All real handler logic (thin wrappers in `commands/mod.rs` delegate here)                                                                                        |
 | `git.rs`              | `GitRunner` trait + `RealGitRunner`; parses `git worktree list --porcelain`                                                                                      |

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ program's OS window when you click the sub-tab.
 
 ## Built with
 
-| Layer         | Technology                                                           |
-| ------------- | -------------------------------------------------------------------- |
-| Desktop shell | [Tauri v2](https://v2.tauri.app/) (Rust + OS WebView — not Electron) |
-| Frontend      | React 18 + TypeScript, Vite, Tailwind CSS, Zustand, xterm.js         |
-| Backend       | Rust, `portable-pty` (ConPTY on Windows), `tauri-plugin-store`       |
+| Layer         | Technology                                                                                   |
+| ------------- | -------------------------------------------------------------------------------------------- |
+| Desktop shell | [Tauri v2](https://v2.tauri.app/) (Rust + OS WebView — not Electron)                         |
+| Frontend      | React 18 + TypeScript, Vite, Tailwind CSS, Zustand, xterm.js                                 |
+| Backend       | Rust, `portable-pty` (ConPTY on Windows), custom atomic JSON persistence (`config_store.rs`) |
 
 ## Getting started
 

--- a/dev/docs/ARCHITECTURE.md
+++ b/dev/docs/ARCHITECTURE.md
@@ -11,7 +11,7 @@ Arborist is one process with a clean Rust ↔ WebView split:
 ```
 ┌──────────── Rust backend (Tauri v2) ────────────┐
 │  PTY pool (portable-pty)                         │
-│  Config store (tauri-plugin-store, atomic write) │
+│  Config store (custom JSON store, atomic write) │
 │  Compose / git / commands                        │
 │  ▲                                               │
 │  │  Tauri commands  (invoke)                     │
@@ -37,7 +37,7 @@ DESIGN §6. Both sides go through a single bridge module
 | `lib.rs`                      | `init_tracing`, builds the `AppContext` (PtyPool + ConfigStore + GitRunner + production PtySink), registers commands, runs the Tauri event loop. | DESIGN §2.1                       |
 | `types.rs`                    | All serde types: `Session`, `SessionView`, `AppConfig`, `PartialAppConfig`, `InstructionSet`, `WorktreeInfo`, `SessionStatus`, `Tool`, errors, event payloads, command arg structs. | DESIGN §3                  |
 | `compose.rs`                  | Pure functions: `compose_command`, `dedupe_label`, `validate_worktree`, POSIX/`cmd.exe` shell quoting, `cli_program_for_tool` (test override seam). | DESIGN §5.1, §5.6, §8.1, §8.2     |
-| `config_store.rs`             | `tauri-plugin-store` wrapper: load/save `config.json` + `sessions.json`, atomic write via `NamedTempFile::persist`, deep-merge `PartialAppConfig`, quarantine on parse failure, instruction-set discovery. | DESIGN §3.3, [`CONFIGURATION.md`](./CONFIGURATION.md) |
+| `config_store.rs`             | Custom JSON store: load/save `config.json` + `sessions.json`, atomic write via `NamedTempFile::persist`, deep-merge `PartialAppConfig`, quarantine on parse failure, instruction-set discovery. | DESIGN §3.3, [`CONFIGURATION.md`](./CONFIGURATION.md) |
 | `git.rs`                      | `GitRunner` trait + `RealGitRunner`; parses `git worktree list --porcelain`. Returns `Ok(vec![])` on every error path so the UI's manual "Browse…" fallback isn't blocked. | DESIGN §6 (`worktrees_list`)      |
 | `pty_pool.rs`                 | `PtySpawner` / `ChildPty` traits, `PortablePtySpawner`, `PtyPool` (per-session runtime entry: child handle, drain task, cancel token), bounded mpsc with drop-newest backpressure (`OUTPUT_CHANNEL_CAPACITY = 512`), `ESC c` reset after a drop, streaming UTF-8 decoder, wait thread that persists final status, `cleanup_orphans` (`ORPHAN_AGE_THRESHOLD = 1h`, ignores UUIDs still in `sessions.json`). | DESIGN §2.1, §5.4, §8.3 |
 | `commands/mod.rs`             | Thin `#[tauri::command]` wrappers. Each one resolves the `AppContext` from Tauri managed state and delegates to `commands::session`. Also contains `build_production_sink` which wires the PTY status / output callbacks to `app.emit` and `ConfigStore::update_session_status`. | DESIGN §6 |
@@ -144,7 +144,7 @@ in `src-tauri/capabilities/main.json` referencing a permission file in
 | `allow-session`         | `session_create`, `session_list`, `session_close`, `session_focus`, `session_resize`, `session_input`, `session_restart`. |
 | `allow-frontend-ready`  | `frontend_ready`.                                                       |
 | `allow-worktrees-list`  | `worktrees_list`.                                                       |
-| `dialog:allow-open`     | `tauri-plugin-dialog`'s `open` (used by `pickDirectory` for the New-Session "Browse…" fallback). |
+| `allow-dialog-pick-directory` | `dialog_pick_directory` (used by `pickDirectory` for the New-Session "Browse…" fallback). |
 
 The structural test in `src-tauri/tests/capability_gating.rs` keeps the
 capability JSON, the `permissions/*.toml` files, and the registered

--- a/dev/docs/DESIGN.md
+++ b/dev/docs/DESIGN.md
@@ -12,8 +12,8 @@ _Version 0.6_
 | State management | **Zustand** | Lightweight, minimal boilerplate, good for session state. |
 | Styling | **Tailwind CSS** | Utility-first; fast iteration for layout-heavy UI. |
 | Build / bundle | **Vite + Tauri CLI** | Fast HMR for the frontend; Cargo for the Rust backend. |
-| Persistence | **tauri-plugin-store** | JSON file-backed store exposed to the frontend via Tauri commands. |
-| OS dialogs | **tauri-plugin-dialog** | Native file/directory picker; gated by the `dialog:allow-open` capability. Used by the New-Session flow's manual "Browse…" fallback (Phase 10). |
+| Persistence | **Custom JSON store (`config_store.rs`)** | Atomic JSON persistence (`config.json` / `sessions.json`) in Rust, exposed to the frontend via typed Tauri commands. |
+| OS dialogs | **`rfd` via Tauri command** | Native file/directory picker dispatched from Rust (`dialog_pick_directory`) and capability-gated like other app commands. |
 
 ## 2. Architecture Overview
 
@@ -23,7 +23,7 @@ _Version 0.6_
 │  ┌───────────┐  ┌──────────────┐  ┌──────────────┐  │
 │  │ PTY Pool  │  │ Config Store │  │   Commands   │  │
 │  └───────────┘  └──────────────┘  └──────────────┘  │
-│        │           (tauri-plugin-store)      │        │
+│        │       (custom ConfigStore in Rust)  │        │
 │        │            Tauri Commands / Events  │        │
 ├────────┼──────────────────────────────────────┼──────┤
 │        ▼            OS WebView               ▼       │
@@ -42,7 +42,7 @@ _Version 0.6_
 - **PTY Pool**: Manages `portable-pty` instances. One PTY per session. Responsible for composing the session's CLI launch
   command, spawning the PTY with that composed invocation in the worktree directory, handling resize and data relay, restarting
   on demand, and kill. PTY output is streamed to the frontend via Tauri events.
-- **Config Store**: Reads/writes settings and session state to disk via `tauri-plugin-store`.
+- **Config Store**: Reads/writes settings and session state to disk via the Rust `ConfigStore` (atomic JSON writes).
 - **Commands**: Exposes a typed, capability-gated API to the frontend via Tauri `#[command]` handlers. Replaces the Electron `contextBridge` / `ipcMain` pattern.
 
 ### 2.2 Frontend Responsibilities
@@ -345,7 +345,7 @@ User clicks [+]
           to `git worktree list --porcelain`, parsed in
           `src-tauri/src/git.rs`). Discovery failures degrade to an empty
           list, so the manual "Browse…" button (powered by
-          `tauri-plugin-dialog`) is always available.
+          `dialog_pick_directory`) is always available.
   → User optionally selects instruction set (default pre-selected)
   → Frontend invokes Tauri command: session_create { tool, worktreePath, cols, rows } (instructionSetId is optional and currently never sent by the new-session wizard; cols/rows are measured from the host before invocation, see §5.5b)
   → Rust backend:
@@ -1003,6 +1003,7 @@ All commands are gated by Tauri capability declarations in `capabilities/main.js
 | `session_input` | `{ sessionId, data }` | — | Send keystrokes to PTY |
 | `session_restart` | `{ sessionId, cols, rows }` | — | Re-spawn a session using its stored `composedCommand` (DESIGN §5.4). `cols`/`rows` are the frontend-measured current PTY dimensions so the new child paints at the right size from the first byte (see §5.5b). The conversation id is rotated (Copilot: a freshly-allocated uuid is spliced via `--resume` on the spawn-time copy; Claude: cleared) so the new spawn is a fresh AI conversation by user contract. The persisted `Session.composedCommand` is never mutated. |
 | `frontend_ready` | — | — | One-shot signal from the frontend after first paint; **awaits** restore-on-launch completion so the frontend's first `session_resize` is guaranteed to find the pending session entry registered (see §5.5/§5.5b). Idempotent — subsequent calls are no-ops. |
+| `dialog_pick_directory` | — | `string \| null` | Open the native OS directory picker and return the chosen absolute path, or `null` when cancelled. Implemented in Rust (`commands::dialog_pick_directory`) and dispatched on Tauri's main thread so Linux/GTK stays thread-safe. Powers the New-Session flow's manual "Browse…" fallback (SPEC W-03). |
 | `config_get` | — | `AppConfig` | Retrieve AppConfig |
 | `config_set` | `Partial<AppConfig>` | — | Update AppConfig (`activeSessionId` is tri-state: omit to leave alone, `null` to clear, value to set) |
 | `instructions_list` | — | `InstructionSet[]` | List available instruction sets from `instructionSetsDir` |
@@ -1048,20 +1049,19 @@ All commands are gated by Tauri capability declarations in `capabilities/main.js
 > on the `workspace_switch` reply (`{ config, sessions }`); see the
 > `workspace_switch` row above and §5.5c.
 
-### Plugin commands routed via the bridge
+### Bridge-only helper command
 
-`src/lib/tauri-bridge.ts` also wraps one third-party plugin command so
-that callers stay on the single bridge surface (no direct
-`@tauri-apps/plugin-*` imports from components):
+`src/lib/tauri-bridge.ts` exposes one helper that maps directly to a first-party
+Tauri command so callers stay on the single bridge surface:
 
-| Bridge function | Underlying plugin call | Capability | Purpose |
-|-----------------|------------------------|------------|---------|
-| `pickDirectory()` | `tauri-plugin-dialog`'s `open({ directory: true, multiple: false })` | `dialog:allow-open` | Native OS directory picker; powers the New-Session dialog's manual "Browse…" fallback when `worktrees_list` returns nothing useful (SPEC W-03). |
+| Bridge function | Underlying command | Capability | Purpose |
+|-----------------|--------------------|------------|---------|
+| `pickDirectory()` | `dialog_pick_directory` | `allow-dialog-pick-directory` | Native OS directory picker; powers the New-Session dialog's manual "Browse…" fallback when `worktrees_list` returns nothing useful (SPEC W-03). |
 
-The `dialog:allow-open` permission is declared in
-`src-tauri/capabilities/main.json`; the plugin itself is initialised in
-`arborist_lib::run`. Adding any further plugin command must follow the same
-capability + bridge-wrapper + mock-stub discipline (see
+The command is declared in `src-tauri/src/commands/mod.rs` and gated via
+`src-tauri/permissions/allow-dialog-pick-directory.toml` +
+`src-tauri/capabilities/main.json`. Any future bridge helper must follow the
+same capability + bridge-wrapper + mock-stub discipline (see
 [`TESTING.md`](./TESTING.md) §6).
 
 ## 7. Directory Structure (Proposed)
@@ -1098,7 +1098,7 @@ arborist/
 │   │   ├── sub_sessions.rs       # SubPtyPool + SubSessionStore (terminal sub-tabs)
 │   │   ├── app_launcher.rs       # AppPool + AppSpawner (application sub-tabs)
 │   │   ├── window_focus.rs       # Platform-gated WindowFocuser (Win32/osascript/wmctrl)
-│   │   ├── config_store.rs       # tauri-plugin-store wrapper
+│   │   ├── config_store.rs       # custom JSON config/session store (atomic writes)
 │   │   ├── activity.rs           # PTY-byte scanner (OSC + byte-rate)
 │   │   ├── session_metrics.rs    # Token/context-window watcher (Claude JSONL + Copilot OTel)
 │   │   ├── copilot_events.rs     # Copilot ~/.copilot/session-state/<aid>/events.jsonl tailer

--- a/dev/docs/DEVELOPMENT.md
+++ b/dev/docs/DEVELOPMENT.md
@@ -82,7 +82,7 @@ arborist/
 │   │   ├── main.rs, lib.rs
 │   │   ├── commands/            # #[tauri::command] handlers (mod.rs + session.rs)
 │   │   ├── compose.rs           # pure command composition + label dedup
-│   │   ├── config_store.rs      # tauri-plugin-store wrapper, atomic writes, quarantine
+│   │   ├── config_store.rs      # custom JSON store, atomic writes, quarantine
 │   │   ├── git.rs               # GitRunner trait + git worktree list parser
 │   │   ├── pty_pool.rs          # PTY pool, PtySpawner trait, backpressure
 │   │   ├── types.rs             # serde types (Session, AppConfig, errors, events)

--- a/dev/e2e/linux/specs/helpers/state.ts
+++ b/dev/e2e/linux/specs/helpers/state.ts
@@ -10,7 +10,7 @@ import os from "os";
 import path from "path";
 
 /**
- * Returns the path where tauri-plugin-store persists data on Linux.
+ * Returns the path where Arborist persists data on Linux.
  * XDG_CONFIG_HOME defaults to ~/.config; Tauri uses the app identifier.
  */
 export function getConfigDir(): string {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,11 +60,9 @@ tempfile = "3"
 dunce = "1"
 sha2 = "0.10"
 fs2 = "0.4"
-# default-features disabled to avoid xdg-portal + gtk3 conflict on Linux
-# (tauri-plugin-dialog already enables rfd/gtk3; rfd panics if both are active).
-# `gtk3` is explicitly listed so the test-helpers-only build path (which does
-# not pull in tauri-plugin-dialog transitively) still picks a backend — rfd
-# 0.17 panics in build.rs when neither backend is enabled on Linux.
+# `rfd` is used directly for boot-time dialogs and the runtime `dialog_pick_directory`
+# command. Keep `default-features = false` and explicitly enable `gtk3` to avoid
+# backend auto-selection surprises on Linux.
 rfd = { version = "0.17", default-features = false, features = ["gtk3"] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -19,6 +19,7 @@
     "allow-subsession",
     "allow-subsession-icon",
     "allow-worktree-tab",
+    "allow-dialog-pick-directory",
     "dialog:allow-open"
   ]
 }

--- a/src-tauri/permissions/allow-dialog-pick-directory.toml
+++ b/src-tauri/permissions/allow-dialog-pick-directory.toml
@@ -1,0 +1,6 @@
+"$schema" = "../gen/schemas/desktop-schema.json"
+
+[[permission]]
+identifier = "allow-dialog-pick-directory"
+description = "Allows the frontend to open the native directory picker via `dialog_pick_directory`."
+commands.allow = ["dialog_pick_directory"]

--- a/src-tauri/src/boot.rs
+++ b/src-tauri/src/boot.rs
@@ -24,12 +24,12 @@
 //! holds it), we surface a synchronous native message dialog ([`rfd::MessageDialog`]) naming the branch + workspace and exit with a non-zero status.
 //! The dialog is the user's signal that this isn't an Arborist crash but a deliberate single-writer refusal.
 //!
-//! ## Why `rfd` instead of `tauri-plugin-dialog`
+//! ## Why `rfd` for boot-time dialogs
 //!
-//! `tauri-plugin-dialog` requires an `AppHandle`, which by the time we're inside `setup` is half-built. Routing the failure path through the
-//! half-built Tauri app introduces ordering hazards (the main webview window may or may not exist yet). `rfd` is a standalone synchronous OS-dialog
-//! crate (already a transitive dep via `tauri-plugin-dialog`), so we use it directly for boot-time UX. No `AppHandle` needed; works before any Tauri
-//! lifecycle.
+//! Boot-time workspace selection runs before the full Tauri runtime is ready, so
+//! we need a standalone synchronous OS-dialog path that does not depend on any
+//! WebView/plugin lifecycle. `rfd` gives us that for the first-launch picker and
+//! lock/contention error dialogs.
 
 use std::path::{Path, PathBuf};
 use std::{ffi::OsString, fs};

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -102,6 +102,23 @@ pub async fn instructions_list(app: tauri::AppHandle) -> Result<Vec<InstructionS
     list_instructions_for(&cfg)
 }
 
+fn pick_directory_native() -> Option<String> {
+    rfd::FileDialog::new().pick_folder().map(|p| p.to_string_lossy().into_owned())
+}
+
+/// Open the native OS directory picker and return the selected path (or `None`
+/// on cancel). The picker is dispatched to Tauri's main thread because GTK's
+/// sync dialog APIs must run there on Linux.
+#[tauri::command]
+pub async fn dialog_pick_directory(app: tauri::AppHandle) -> Result<Option<String>, AppError> {
+    let (tx, rx) = tokio::sync::oneshot::channel::<Option<String>>();
+    app.run_on_main_thread(move || {
+        let _ = tx.send(pick_directory_native());
+    })
+    .map_err(|e| AppError::new("Internal", format!("dispatch directory picker: {e}")))?;
+    rx.await.map_err(|_| AppError::new("Internal", "directory picker channel closed"))
+}
+
 // --------------------------------------------------------------------------- Phase 7: session commands. Each wrapper resolves the managed
 // `Arc<AppContext>`, hands the typed args to the matching `*_impl`, and returns the result. *No* business logic in this layer.
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -349,6 +349,7 @@ pub fn run() {
             commands::config_get,
             commands::config_set,
             commands::instructions_list,
+            commands::dialog_pick_directory,
             commands::session_create,
             commands::session_list,
             commands::session_close,

--- a/src-tauri/tests/capability_gating.rs
+++ b/src-tauri/tests/capability_gating.rs
@@ -90,8 +90,12 @@ fn main_capability_allows_core_default_and_ping() {
         "main capability must include allow-worktree-prep-open-log so worktree_prep_open_log is callable; got {identifiers:?}",
     );
     assert!(
+        identifiers.contains(&"allow-dialog-pick-directory"),
+        "main capability must include allow-dialog-pick-directory so pickDirectory is callable; got {identifiers:?}",
+    );
+    assert!(
         identifiers.contains(&"dialog:allow-open"),
-        "main capability must include dialog:allow-open so the file picker is callable; got {identifiers:?}",
+        "main capability must include dialog:allow-open so plugin dialog open is callable; got {identifiers:?}",
     );
     assert!(
         identifiers.contains(&"allow-subsession-icon"),
@@ -228,6 +232,20 @@ fn allow_frontend_ready_permission_file_declares_frontend_ready_command() {
         "permission identifier must remain `allow-frontend-ready`",
     );
     assert!(raw.contains("\"frontend_ready\""), "permission must allow the `frontend_ready` command",);
+}
+
+#[test]
+fn allow_dialog_pick_directory_permission_file_declares_command() {
+    let path = manifest_dir().join("permissions").join("allow-dialog-pick-directory.toml");
+    let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+    assert!(
+        raw.contains("identifier = \"allow-dialog-pick-directory\""),
+        "permission identifier must remain `allow-dialog-pick-directory`",
+    );
+    assert!(
+        raw.contains("\"dialog_pick_directory\""),
+        "permission must allow the `dialog_pick_directory` command",
+    );
 }
 
 #[test]

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -15,7 +15,6 @@
 
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
-import { open as openDialog } from '@tauri-apps/plugin-dialog';
 
 export { formatError, isAppErrorLike } from '@/lib/tauri-error';
 export type { AppErrorLike } from '@/lib/tauri-error';
@@ -349,16 +348,13 @@ export function workspaceSwitch(path: string): Promise<WorkspaceSwitchResult> {
 /**
  * Open the OS native directory picker. Resolves to the absolute path the
  * user chose, or `null` if they cancelled. Backed by the
- * `tauri-plugin-dialog` plugin (Phase 10).
+ * `dialog_pick_directory` Tauri command.
  *
- * Components MUST go through this wrapper rather than importing the plugin
- * directly so the bridge mock can stub it in tests.
+ * Components MUST go through this wrapper so the bridge mock can stub it in
+ * tests.
  */
-export async function pickDirectory(): Promise<string | null> {
-  const picked = await openDialog({ directory: true, multiple: false });
-  // The plugin returns `string | string[] | null` depending on `multiple`;
-  // we asked for a single selection so any non-string is treated as cancel.
-  return typeof picked === 'string' ? picked : null;
+export function pickDirectory(): Promise<string | null> {
+  return invoke<string | null>('dialog_pick_directory');
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a backend dialog_pick_directory command and route pickDirectory() through it
- dispatch directory picker on Tauri main thread for Linux/GTK safety
- keep plugin-related dependencies and initialization in place (	auri-plugin-store, 	auri-plugin-dialog, @tauri-apps/plugin-dialog)
- update capability wiring/tests and related documentation to match current behavior

## Validation
- pnpm run lint
- pnpm run build
- pnpm test --run
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --features test-helpers -- -D warnings
- cargo test --workspace --features test-helpers