### PR TITLE
[plugin-check] Add built-in custom process plugins

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,12 +2,12 @@
 
 ## Repository status
 
-This repo currently contains **only design documents** — no source code, build, lint, or test tooling exists yet. The authoritative specs live in:
+This repo contains the Arborist Tauri/React application. The authoritative specs live in:
 
 - `dev/docs/SPEC.md` — product requirements (functional + non-functional)
 - `dev/docs/DESIGN.md` — architecture, data model, command/event API, directory layout
 
-Read both before proposing implementation work. When the codebase is scaffolded, update this file with real build/test/lint commands.
+Read both before proposing structural implementation work.
 
 This repo has a remote at `origin` -> `https://github.com/mcaden/arborist.git`. Agents may commit, push feature branches, and open pull requests. Do not push directly to `main` and do not force-push shared branches; land changes through PRs.
 
@@ -68,7 +68,7 @@ Defined in Rust with `serde`, mirrored as TypeScript types in the frontend. Thre
 
 ## Out of scope for v1 (don't implement)
 
-Built-in chat UI, remote/SSH worktrees, plugin system, multi-window, in-app instruction-file editor (SPEC §7).
+Built-in chat UI, remote/SSH worktrees, multi-window, in-app instruction-file editor (SPEC §7).
 
 ---
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -263,8 +263,7 @@ pub fn run() {
             let ctx_for_backfill = ctx.clone();
             app.manage(ctx);
 
-            // Plugin registry wiring. Issue #97 registers built-in custom-process plugins here; #96 (AI plugins) and #98 (dashboard widgets)
-            // extend the same `plugins::build_registry()` seam.
+            // Plugin registry wiring: built-in AI, custom-process, and dashboard-widget plugins all register through `plugins::build_registry()`.
             //
             // A `RegisterError` here means a developer added two plugins with the same id — log + structured exit instead of an `expect()` panic
             // so the user sees a single clear line and the process exits cleanly (matches the boot-failure pattern earlier in this block).

--- a/src-tauri/src/plugins/ai/mod.rs
+++ b/src-tauri/src/plugins/ai/mod.rs
@@ -117,6 +117,9 @@ pub const BUILTIN_AI: [BuiltinAi; 2] = [
 ];
 
 /// Resolve a built-in AI plugin for a persisted [`Tool`].
+///
+/// This is the intentional serde-glue seam: the exhaustive match keeps the compiler checking that every persisted `Tool` variant has a plugin.
+/// Call sites outside `plugins/ai/*` should use the wrapper helpers below instead of branching on `Tool` directly.
 #[must_use]
 pub fn plugin_for_tool(tool: Tool) -> &'static dyn AiPlugin {
     match tool {

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -7,8 +7,8 @@
 //! * **Dashboard-widget plugins** ([`dashboard_widget::DashboardWidgetBackend`]) — Git Status / AI Usage today.
 //!
 //! The registry is append-only and populated with built-ins in [`build_registry`].
-//! Today that includes custom-process plugins (issue #97: VS Code + Windows Explorer) and dashboard widgets (issue #98: Git Status + AI Usage).
-//! AI plugin migrations remain deferred to sub-issue #96.
+//! Today that includes AI plugins (issue #96: Claude + Copilot), custom-process plugins (issue #97: VS Code + Windows Explorer), and dashboard
+//! widgets (issue #98: Git Status + AI Usage).
 //!
 //! ## Design constraints (kept open for out-of-tree plugins later — see #93)
 //!
@@ -63,9 +63,9 @@ impl std::error::Error for RegisterError {}
 
 /// Typed context passed into plugin trait methods.
 ///
-/// Plugins never reach into `AppContext` directly — instead they receive a `PluginCtx` carrying the minimum surface they need. The v1 surface is
-/// deliberately tiny (worktree path + config snapshot); later migration sub-issues add fields as they discover them. Keeping the surface narrow is
-/// what lets us swap in a WASM or dlopen bridge without rewriting the trait surface.
+/// Plugins never reach into `AppContext` directly — instead they receive a `PluginCtx` carrying the minimum surface they need. The v1 surface stays
+/// deliberately tiny (worktree path + config snapshot); future plugin surfaces should add fields only when a concrete behavior needs them. Keeping
+/// the surface narrow is what lets us swap in a WASM or dlopen bridge without rewriting the trait surface.
 #[derive(Debug, Clone, Copy)]
 pub struct PluginCtx<'a> {
     /// Absolute path to the worktree the plugin is operating against. PTY spawn / git invocations / file lookups MUST treat this as authoritative;

--- a/src/components/SidebarTab.tsx
+++ b/src/components/SidebarTab.tsx
@@ -156,7 +156,11 @@ export function SidebarTab({
             openPermissions={openPermissions}
           />
         </span>
-        <MetricsLine metrics={session.status === 'running' ? metrics : undefined} tool={session.tool} isActive={isActive} />
+        <MetricsLine
+          metrics={session.status === 'running' ? metrics : undefined}
+          contextMetricsLimitTooltipSuffix={registry.aiById(session.tool)?.contextMetricsLimitTooltipSuffix ?? ''}
+          isActive={isActive}
+        />
       </button>
       <button
         type="button"
@@ -204,11 +208,11 @@ export function SidebarTab({
 
 interface MetricsLineProps {
   metrics: SessionMetrics | undefined;
-  tool: Tool;
+  contextMetricsLimitTooltipSuffix: string;
   isActive: boolean;
 }
 
-function MetricsLine({ metrics, tool, isActive }: MetricsLineProps): JSX.Element {
+function MetricsLine({ metrics, contextMetricsLimitTooltipSuffix, isActive }: MetricsLineProps): JSX.Element {
   const colour = isActive ? 'text-sky-800/80 dark:text-sky-200/80' : 'text-slate-500 dark:text-slate-400';
 
   if (!metrics) {
@@ -239,11 +243,10 @@ function MetricsLine({ metrics, tool, isActive }: MetricsLineProps): JSX.Element
 
   const longParts: string[] = [];
   if (typeof metrics.contextTokensUsed === 'number' && typeof metrics.contextTokensLimit === 'number') {
-    const suffix =
-      tool === 'copilot'
-        ? ' (Copilot-reported; excludes its system-prompt + tool overhead)'
-        : ' (model nominal max; includes harness overhead in usage)';
-    longParts.push(`Context ${metrics.contextTokensUsed.toLocaleString()} / ` + `${metrics.contextTokensLimit.toLocaleString()} tokens${suffix}`);
+    longParts.push(
+      `Context ${metrics.contextTokensUsed.toLocaleString()} / ` +
+        `${metrics.contextTokensLimit.toLocaleString()} tokens${contextMetricsLimitTooltipSuffix}`,
+    );
   }
   if (typeof metrics.inputTokens === 'number' && typeof metrics.outputTokens === 'number') {
     longParts.push(`Session totals: ${metrics.inputTokens.toLocaleString()} in, ` + `${metrics.outputTokens.toLocaleString()} out`);

--- a/src/plugins/ai/claude/index.ts
+++ b/src/plugins/ai/claude/index.ts
@@ -7,5 +7,6 @@ export const ClaudeAiPlugin: AiPlugin = {
   displayName: 'Claude',
   defaultProgram: 'claude',
   defaultInstructionSetPath: 'claude-default.md',
+  contextMetricsLimitTooltipSuffix: ' (model nominal max; includes harness overhead in usage)',
   Icon: ClaudeIcon,
 };

--- a/src/plugins/ai/copilot/index.ts
+++ b/src/plugins/ai/copilot/index.ts
@@ -7,5 +7,6 @@ export const CopilotAiPlugin: AiPlugin = {
   displayName: 'Copilot',
   defaultProgram: 'copilot',
   defaultInstructionSetPath: 'copilot-default.md',
+  contextMetricsLimitTooltipSuffix: ' (Copilot-reported; excludes its system-prompt + tool overhead)',
   Icon: CopilotIcon,
 };

--- a/src/plugins/builtins.test.ts
+++ b/src/plugins/builtins.test.ts
@@ -1,11 +1,31 @@
 import { describe, expect, it } from 'vitest';
 
 import { createBuiltinsRegistry } from './builtins';
+import type { CustomProcessDef } from '@/types/arborist';
+
+const makeDef = (id: string, command: string): CustomProcessDef => ({
+  id,
+  name: id,
+  kind: 'application',
+  command,
+  enabled: true,
+});
 
 describe('createBuiltinsRegistry()', () => {
-  it('registers AI tools and dashboard widgets in deterministic order', () => {
+  it('registers every built-in plugin kind in deterministic order', () => {
     const registry = createBuiltinsRegistry();
     expect(registry.ai().map((p) => p.id)).toEqual(['claude', 'copilot']);
+    expect(registry.customProcesses().map((p) => p.id)).toEqual(['vscode', 'explorer']);
     expect(registry.widgets().map((w) => w.id)).toEqual(['git-status', 'ai-usage']);
+  });
+
+  it('uses built-in custom-process descriptors for command-shape matching', () => {
+    const registry = createBuiltinsRegistry();
+    const vscode = registry.customProcesses().find((p) => p.id === 'vscode');
+    const explorer = registry.customProcesses().find((p) => p.id === 'explorer');
+
+    expect(vscode?.matches(makeDef('custom-code', 'code .'))).toBe(true);
+    expect(vscode?.matches(makeDef('custom-open', 'open .'))).toBe(false);
+    expect(explorer?.matches(makeDef('custom-explorer', 'explorer .'))).toBe(true);
   });
 });

--- a/src/plugins/builtins.ts
+++ b/src/plugins/builtins.ts
@@ -1,5 +1,6 @@
 import { ClaudeAiPlugin } from './ai/claude';
 import { CopilotAiPlugin } from './ai/copilot';
+import { ExplorerCustomProcessPlugin, VsCodeCustomProcessPlugin } from './custom-process';
 import { aiUsageWidget } from './dashboard-widget/ai-usage';
 import { gitStatusWidget } from './dashboard-widget/git-status';
 import { createRegistry, type PluginRegistry } from './registry';
@@ -12,6 +13,8 @@ export function createBuiltinsRegistry(): PluginRegistry {
   const registry = createRegistry();
   registry.registerAi(ClaudeAiPlugin);
   registry.registerAi(CopilotAiPlugin);
+  registry.registerCustomProcess(VsCodeCustomProcessPlugin);
+  registry.registerCustomProcess(ExplorerCustomProcessPlugin);
   registry.registerWidget(gitStatusWidget);
   registry.registerWidget(aiUsageWidget);
   return registry;

--- a/src/plugins/custom-process/explorer/index.ts
+++ b/src/plugins/custom-process/explorer/index.ts
@@ -1,0 +1,13 @@
+import type { CustomProcessPlugin } from '../../registry';
+import { looksLikeExplorerCommand } from '../match-command';
+
+function isWindowsFrontend(): boolean {
+  return typeof navigator !== 'undefined' && /Windows/i.test(navigator.userAgent);
+}
+
+export const ExplorerCustomProcessPlugin: CustomProcessPlugin = {
+  id: 'explorer',
+  displayName: 'Windows Explorer',
+  matches: (def) => looksLikeExplorerCommand(def.command),
+  supportedOnPlatform: isWindowsFrontend,
+};

--- a/src/plugins/custom-process/index.ts
+++ b/src/plugins/custom-process/index.ts
@@ -1,0 +1,3 @@
+export { ExplorerCustomProcessPlugin } from './explorer';
+export { VsCodeCustomProcessPlugin } from './vscode';
+export { looksLikeExplorerCommand, looksLikeVsCodeCommand } from './match-command';

--- a/src/plugins/custom-process/match-command.test.ts
+++ b/src/plugins/custom-process/match-command.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { looksLikeExplorerCommand, looksLikeVsCodeCommand } from './match-command';
+
+describe('custom-process command matching', () => {
+  it('recognizes canonical VS Code launcher commands', () => {
+    for (const command of [
+      'code .',
+      'code.cmd .',
+      'code.exe .',
+      'code-insiders .',
+      'code-insiders.cmd .',
+      'code-insiders.exe .',
+      '"C:\\Users\\me\\AppData\\Local\\Programs\\Microsoft VS Code\\bin\\code.cmd" .',
+      'env ELECTRON_RUN_AS_NODE=0 code .',
+      'FOO=bar code .',
+    ]) {
+      expect(looksLikeVsCodeCommand(command), command).toBe(true);
+    }
+  });
+
+  it('rejects non-VS Code commands', () => {
+    for (const command of ['', 'codium .', 'code-server .', 'my-code .', 'pwsh -c code', '/usr/bin/codium .']) {
+      expect(looksLikeVsCodeCommand(command), command).toBe(false);
+    }
+  });
+
+  it('recognizes canonical Windows Explorer launcher commands', () => {
+    for (const command of ['explorer .', 'explorer.exe .', '"C:\\Windows\\explorer.exe" .', 'env FOO=bar explorer .']) {
+      expect(looksLikeExplorerCommand(command), command).toBe(true);
+    }
+  });
+
+  it('rejects non-Explorer commands', () => {
+    for (const command of ['', 'open .', 'xdg-open .', 'my-explorer .', 'pwsh -c explorer']) {
+      expect(looksLikeExplorerCommand(command), command).toBe(false);
+    }
+  });
+});

--- a/src/plugins/custom-process/match-command.ts
+++ b/src/plugins/custom-process/match-command.ts
@@ -1,0 +1,67 @@
+function shellTokens(command: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | undefined;
+
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i]!;
+    if (quote) {
+      if (ch === quote) {
+        quote = undefined;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += ch;
+  }
+
+  if (current.length > 0) tokens.push(current);
+  return tokens;
+}
+
+function firstExecutableToken(command: string): string | undefined {
+  for (const token of shellTokens(command)) {
+    if (token === 'env' || /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(token)) {
+      continue;
+    }
+    return token;
+  }
+  return undefined;
+}
+
+function executableBasename(command: string): string | undefined {
+  const executable = firstExecutableToken(command);
+  if (!executable) return undefined;
+  const normalized = executable.replace(/\\/g, '/');
+  return normalized.slice(normalized.lastIndexOf('/') + 1).toLowerCase();
+}
+
+export function looksLikeVsCodeCommand(command: string): boolean {
+  const base = executableBasename(command);
+  return (
+    base === 'code' ||
+    base === 'code.cmd' ||
+    base === 'code.exe' ||
+    base === 'code-insiders' ||
+    base === 'code-insiders.cmd' ||
+    base === 'code-insiders.exe'
+  );
+}
+
+export function looksLikeExplorerCommand(command: string): boolean {
+  const base = executableBasename(command);
+  return base === 'explorer' || base === 'explorer.exe';
+}

--- a/src/plugins/custom-process/vscode/index.ts
+++ b/src/plugins/custom-process/vscode/index.ts
@@ -1,0 +1,9 @@
+import type { CustomProcessPlugin } from '../../registry';
+import { looksLikeVsCodeCommand } from '../match-command';
+
+export const VsCodeCustomProcessPlugin: CustomProcessPlugin = {
+  id: 'vscode',
+  displayName: 'VS Code',
+  matches: (def) => looksLikeVsCodeCommand(def.command),
+  supportedOnPlatform: () => true,
+};

--- a/src/plugins/index.test.ts
+++ b/src/plugins/index.test.ts
@@ -9,6 +9,7 @@ const makeAi = (id: Tool): AiPlugin => ({
   displayName: id,
   defaultProgram: id,
   defaultInstructionSetPath: `${id}-default.md`,
+  contextMetricsLimitTooltipSuffix: `${id} context source`,
   Icon: () => null,
 });
 
@@ -125,6 +126,7 @@ describe('createRegistry()', () => {
       displayName: 'Counter AI',
       defaultProgram: 'noop',
       defaultInstructionSetPath: 'noop.md',
+      contextMetricsLimitTooltipSuffix: 'counter context source',
       Icon: () => null,
     };
     const r = createRegistry();

--- a/src/plugins/registry-context.test.tsx
+++ b/src/plugins/registry-context.test.tsx
@@ -22,6 +22,7 @@ describe('PluginRegistryProvider / useRegistry', () => {
       displayName: 'Claude',
       defaultProgram: 'claude',
       defaultInstructionSetPath: 'claude-default.md',
+      contextMetricsLimitTooltipSuffix: 'model nominal max',
       Icon: () => null,
     });
     r.registerWidget({ id: 'git-status', displayName: 'Git', order: 0, Component: () => null });

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -38,6 +38,8 @@ export interface AiPlugin extends Plugin {
   defaultProgram: string;
   /** Filename of the built-in instruction-set markdown under `instructions/` (e.g. `"claude-default.md"`). */
   defaultInstructionSetPath: string;
+  /** Tooltip copy explaining how this plugin reports context-window limits. */
+  contextMetricsLimitTooltipSuffix: string;
   /** SVG icon component for the plugin's launcher / tab chrome. */
   Icon: ComponentType<{ className?: string }>;
 }


### PR DESCRIPTION
## Summary
- Register built-in custom-process plugins for VS Code and Windows Explorer
- Move AI context-window tooltip copy into AI plugin metadata
- Update plugin registry tests and agent docs

## Validation
- pnpm run lint && pnpm test --run && pnpm run build && cargo fmt --all -- --check && cargo clippy --workspace --all-targets --features test-helpers -- -D warnings && cargo test --workspace --features test-helpers