### PR TITLE
[termination-fix-again] Fix Windows worktree termination cleanup

### DIFF
--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -15,10 +15,16 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
 use tracing::{debug, warn};
 
 use crate::types::{Error, GitStatusFile, GitStatusFileKind, WorktreeGitStatus, WorktreeInfo, MAX_GIT_STATUS_FILES};
+
+#[cfg(windows)]
+const WORKTREE_REMOVE_RETRY_DELAYS_MS: &[u64] = &[25, 50, 100, 200, 400, 800, 1_000];
+#[cfg(not(windows))]
+const WORKTREE_REMOVE_RETRY_DELAYS_MS: &[u64] = &[];
 
 /// Build a `git` [`Command`] with the repo-selection environment variables stripped.
 ///
@@ -64,7 +70,8 @@ pub trait GitRunner: Send + Sync {
     fn create_worktree(&self, repo_root: &Path, relative_path: &Path, branch: &str) -> Result<PathBuf, Error>;
 
     /// Run `git -C <repo_root> worktree remove --force <worktree_path>`. `--force` is used because the user has explicitly confirmed deletion in the
-    /// UI (CloseConfirmDialog) and we have just torn down the PTY that owned the cwd.
+    /// UI (CloseConfirmDialog) and we have just torn down the PTY that owned the cwd. The production runner retries transient Windows filesystem
+    /// errors because process exit and handle release can lag the close call by a short interval.
     ///
     /// `repo_root` must be a stable checkout of the same repository *outside* the target `worktree_path` — typically the configured `workspace_root`.
     /// Callers must not pass `worktree_path` itself as `repo_root`: the spawned `git` would inherit it as its CWD, and on Windows the OS prevents
@@ -195,22 +202,12 @@ impl GitRunner for RealGitRunner {
         if !repo_root.is_dir() {
             return Err(Error::WorktreeMissing(repo_root.to_path_buf()));
         }
-        let output = git_command()
-            .current_dir(repo_root)
-            .arg("-C")
-            .arg(repo_root)
-            .args(["worktree", "remove", "--force"])
-            .arg(worktree_path)
-            .output()
-            .map_err(|e| Error::Internal(format!("git worktree remove: {e}")))?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-            return Err(Error::Internal(format!(
-                "git worktree remove failed: {}",
-                if stderr.is_empty() { "<no stderr>".to_owned() } else { stderr }
-            )));
-        }
-        Ok(())
+        remove_worktree_with_retry(
+            repo_root,
+            worktree_path,
+            || run_git_worktree_remove(repo_root, worktree_path),
+            std::thread::sleep,
+        )
     }
 
     fn git_status(&self, worktree_path: &Path) -> Result<WorktreeGitStatus, Error> {
@@ -269,6 +266,77 @@ impl GitRunner for RealGitRunner {
         }
         Ok(parse_status_v2(&output.stdout))
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GitCommandResult {
+    success: bool,
+    stderr: String,
+}
+
+fn run_git_worktree_remove(repo_root: &Path, worktree_path: &Path) -> Result<GitCommandResult, Error> {
+    let output = git_command()
+        .current_dir(repo_root)
+        .arg("-C")
+        .arg(repo_root)
+        .args(["worktree", "remove", "--force"])
+        .arg(worktree_path)
+        .output()
+        .map_err(|e| Error::Internal(format!("git worktree remove: {e}")))?;
+
+    Ok(GitCommandResult {
+        success: output.status.success(),
+        stderr: String::from_utf8_lossy(&output.stderr).trim().to_owned(),
+    })
+}
+
+fn remove_worktree_with_retry(
+    repo_root: &Path,
+    worktree_path: &Path,
+    mut run: impl FnMut() -> Result<GitCommandResult, Error>,
+    mut sleep: impl FnMut(Duration),
+) -> Result<(), Error> {
+    let mut last_stderr = String::new();
+    for attempt in 0.. {
+        let output = run()?;
+        if output.success {
+            return Ok(());
+        }
+
+        last_stderr = if output.stderr.is_empty() {
+            "<no stderr>".to_owned()
+        } else {
+            output.stderr
+        };
+        let Some(delay_ms) = WORKTREE_REMOVE_RETRY_DELAYS_MS.get(attempt) else {
+            break;
+        };
+        if !is_retryable_worktree_remove_failure(&last_stderr) {
+            break;
+        }
+        warn!(
+            repo_root = %repo_root.display(),
+            worktree_path = %worktree_path.display(),
+            attempt = attempt + 1,
+            delay_ms,
+            stderr = %last_stderr,
+            "git worktree remove hit transient filesystem error; retrying",
+        );
+        sleep(Duration::from_millis(*delay_ms));
+    }
+
+    Err(Error::Internal(format!("git worktree remove failed: {last_stderr}")))
+}
+
+fn is_retryable_worktree_remove_failure(stderr: &str) -> bool {
+    if !cfg!(windows) {
+        return false;
+    }
+    let lower = stderr.to_ascii_lowercase();
+    lower.contains("directory not empty")
+        || lower.contains("being used by another process")
+        || lower.contains("access is denied")
+        || lower.contains("permission denied")
 }
 
 /// Parse `git worktree list --porcelain` output. The first block is the main worktree; subsequent blocks are linked worktrees. Detached HEADs produce
@@ -621,6 +689,68 @@ locked migrating to slow disk
         let out = runner.list_worktrees(dir.path()).expect("non-repo must degrade gracefully");
         // Empty even though `git` is on PATH: the command exits non-zero because it isn't a repository.
         assert!(out.is_empty());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn remove_worktree_retries_transient_directory_not_empty_failure() {
+        let repo_root = Path::new(r"C:\repo");
+        let worktree_path = Path::new(r"C:\repo\.arborist\.worktrees\feature");
+        let calls = std::cell::Cell::new(0usize);
+        let sleeps = std::cell::RefCell::new(Vec::new());
+
+        remove_worktree_with_retry(
+            repo_root,
+            worktree_path,
+            || {
+                let n = calls.get();
+                calls.set(n + 1);
+                Ok(if n == 0 {
+                    GitCommandResult {
+                        success: false,
+                        stderr: "error: failed to delete 'feature': Directory not empty".to_owned(),
+                    }
+                } else {
+                    GitCommandResult {
+                        success: true,
+                        stderr: String::new(),
+                    }
+                })
+            },
+            |delay| sleeps.borrow_mut().push(delay),
+        )
+        .expect("second attempt should succeed");
+
+        assert_eq!(calls.get(), 2);
+        assert_eq!(&*sleeps.borrow(), &[Duration::from_millis(25)]);
+    }
+
+    #[test]
+    fn remove_worktree_does_not_retry_non_transient_failure() {
+        let repo_root = Path::new(if cfg!(windows) { r"C:\repo" } else { "/repo" });
+        let worktree_path = Path::new(if cfg!(windows) {
+            r"C:\repo\.arborist\.worktrees\feature"
+        } else {
+            "/repo/.arborist/.worktrees/feature"
+        });
+        let calls = std::cell::Cell::new(0usize);
+
+        let err = remove_worktree_with_retry(
+            repo_root,
+            worktree_path,
+            || {
+                calls.set(calls.get() + 1);
+                Ok(GitCommandResult {
+                    success: false,
+                    stderr: "fatal: not a git repository".to_owned(),
+                })
+            },
+            |_| panic!("non-transient failure must not sleep/retry"),
+        )
+        .expect_err("non-transient git failure should surface");
+
+        assert_eq!(calls.get(), 1);
+        assert!(matches!(err, Error::Internal(msg) if msg.contains("fatal: not a git repository")));
     }
 
     /// Build a `Command` with both repo-selection *and* identity/config `GIT_*` variables stripped. Tests get a stricter scrub than production

--- a/src-tauri/src/pty_pool.rs
+++ b/src-tauri/src/pty_pool.rs
@@ -350,6 +350,12 @@ mod windows_process_tree {
         creation_time: Option<u64>,
     }
 
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct ProcessToTerminate {
+        pid: u32,
+        creation_time: u64,
+    }
+
     #[repr(C)]
     #[derive(Default)]
     #[allow(non_snake_case)]
@@ -386,9 +392,12 @@ mod windows_process_tree {
         let descendants = descendant_pids_deepest_first(root_pid, root_creation_time, &entries);
         let mut first_error: Option<(u32, io::Error)> = None;
 
-        for pid in descendants.into_iter().chain(std::iter::once(root_pid)) {
-            if let Err(e) = terminate_pid(pid) {
-                first_error.get_or_insert((pid, e));
+        for process in descendants.into_iter().chain(std::iter::once(ProcessToTerminate {
+            pid: root_pid,
+            creation_time: root_creation_time,
+        })) {
+            if let Err(e) = terminate_pid(process) {
+                first_error.get_or_insert((process.pid, e));
             }
         }
 
@@ -472,25 +481,26 @@ mod windows_process_tree {
             return None;
         }
 
+        let creation_time = process_creation_time_from_handle(handle);
+        // SAFETY: handle is valid and closed exactly once.
+        unsafe {
+            CloseHandle(handle);
+        }
+
+        creation_time
+    }
+
+    fn process_creation_time_from_handle(handle: Handle) -> Option<u64> {
         let mut creation_time = FileTime::default();
         let mut exit_time = FileTime::default();
         let mut kernel_time = FileTime::default();
         let mut user_time = FileTime::default();
         // SAFETY: handle is valid and all FILETIME pointers are initialized writable buffers.
         let ok = unsafe { GetProcessTimes(handle, &mut creation_time, &mut exit_time, &mut kernel_time, &mut user_time) };
-        // SAFETY: handle is valid and closed exactly once.
-        unsafe {
-            CloseHandle(handle);
-        }
-
-        if ok == 0 {
-            None
-        } else {
-            Some((u64::from(creation_time.dwHighDateTime) << 32) | u64::from(creation_time.dwLowDateTime))
-        }
+        (ok != 0).then_some((u64::from(creation_time.dwHighDateTime) << 32) | u64::from(creation_time.dwLowDateTime))
     }
 
-    fn descendant_pids_deepest_first(root_pid: u32, root_created_at: u64, entries: &[ProcessSnapshotEntry]) -> Vec<u32> {
+    fn descendant_pids_deepest_first(root_pid: u32, root_created_at: u64, entries: &[ProcessSnapshotEntry]) -> Vec<ProcessToTerminate> {
         let mut children_by_parent: HashMap<u32, Vec<ProcessSnapshotEntry>> = HashMap::new();
         for entry in entries {
             if entry.pid != root_pid && entry.creation_time.is_some() {
@@ -512,7 +522,7 @@ mod windows_process_tree {
         parent_created_at: u64,
         children_by_parent: &HashMap<u32, Vec<ProcessSnapshotEntry>>,
         seen: &mut HashSet<u32>,
-        ordered: &mut Vec<u32>,
+        ordered: &mut Vec<ProcessToTerminate>,
     ) -> bool {
         if !seen.insert(pid) {
             return false;
@@ -528,15 +538,18 @@ mod windows_process_tree {
                 continue;
             }
             if append_descendants(child.pid, child_created_at, children_by_parent, seen, ordered) {
-                ordered.push(child.pid);
+                ordered.push(ProcessToTerminate {
+                    pid: child.pid,
+                    creation_time: child_created_at,
+                });
             }
         }
         true
     }
 
-    fn terminate_pid(pid: u32) -> io::Result<()> {
+    fn terminate_pid(process: ProcessToTerminate) -> io::Result<()> {
         // SAFETY: OpenProcess accepts any PID and returns NULL for stale/invalid ones; no pointers are dereferenced here.
-        let handle = unsafe { OpenProcess(PROCESS_TERMINATE | SYNCHRONIZE, 0, pid) };
+        let handle = unsafe { OpenProcess(PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE, 0, process.pid) };
         if handle.is_null() {
             let error = io::Error::last_os_error();
             return if error.raw_os_error() == Some(ERROR_INVALID_PARAMETER) {
@@ -544,6 +557,16 @@ mod windows_process_tree {
             } else {
                 Err(error)
             };
+        }
+
+        let actual_creation_time = process_creation_time_from_handle(handle);
+        if actual_creation_time != Some(process.creation_time) {
+            // The PID went stale or was reused after the snapshot; never terminate a process we cannot re-identify by creation time.
+            // SAFETY: handle is valid and closed exactly once on this early-return path.
+            unsafe {
+                CloseHandle(handle);
+            }
+            return Ok(());
         }
 
         // SAFETY: handle is a valid process handle opened with PROCESS_TERMINATE. CloseHandle is called exactly once.
@@ -572,12 +595,12 @@ mod windows_process_tree {
         } else if wait == Some(WAIT_TIMEOUT) {
             Err(io::Error::new(
                 io::ErrorKind::TimedOut,
-                format!("timed out waiting for pid {pid} to terminate"),
+                format!("timed out waiting for pid {} to terminate", process.pid),
             ))
         } else if wait == Some(WAIT_FAILED) {
             Err(wait_error)
         } else {
-            Err(io::Error::other(format!("unexpected wait result {:?} for pid {pid}", wait)))
+            Err(io::Error::other(format!("unexpected wait result {:?} for pid {}", wait, process.pid)))
         }
     }
 
@@ -594,6 +617,13 @@ mod windows_process_tree {
             }
         }
 
+        fn descendant_pids(root_pid: u32, root_created_at: u64, entries: &[ProcessSnapshotEntry]) -> Vec<u32> {
+            descendant_pids_deepest_first(root_pid, root_created_at, entries)
+                .into_iter()
+                .map(|process| process.pid)
+                .collect()
+        }
+
         #[test]
         fn descendant_pids_are_deepest_first_without_root() {
             let entries = [
@@ -607,7 +637,7 @@ mod windows_process_tree {
                 entry(20, 2, 170),
             ];
 
-            assert_eq!(descendant_pids_deepest_first(10, 100, &entries), vec![99, 14, 13, 11, 15, 12]);
+            assert_eq!(descendant_pids(10, 100, &entries), vec![99, 14, 13, 11, 15, 12]);
         }
 
         #[test]
@@ -620,7 +650,7 @@ mod windows_process_tree {
                 entry(13, 12, 130),
             ];
 
-            assert_eq!(descendant_pids_deepest_first(10, 100, &entries), vec![11]);
+            assert_eq!(descendant_pids(10, 100, &entries), vec![11]);
         }
 
         #[test]

--- a/src-tauri/src/pty_pool.rs
+++ b/src-tauri/src/pty_pool.rs
@@ -141,8 +141,8 @@ pub trait PtyWaiter: Send {
 
 /// Kill handle. Independent of the waiter so the kill caller never has to contend with the wait thread.
 ///
-/// On Unix the production impl sends SIGTERM, waits up to [`KILL_GRACE`], then escalates to SIGKILL. On Windows it forwards to portable-pty's `kill`,
-/// which terminates the child via `TerminateProcess`.
+/// On Unix the production impl sends SIGTERM, waits up to [`KILL_GRACE`], then escalates to SIGKILL. On Windows it terminates the spawned shell's
+/// process tree before forwarding to portable-pty's `kill`, because `%COMSPEC% /c <cmd>` can leave the actual CLI as a child process.
 pub trait PtyKiller: Send + Sync {
     fn kill(&self) -> Result<(), Error>;
 }
@@ -256,16 +256,35 @@ impl PtyWaiter for PortableWaiter {
 
 struct PortableKiller {
     inner: Mutex<Box<dyn portable_pty::ChildKiller + Send + Sync>>,
-    #[allow(dead_code)]
     pid: u32,
 }
 
 impl PtyKiller for PortableKiller {
     fn kill(&self) -> Result<(), Error> {
+        #[cfg(windows)]
+        let tree_kill_result = windows_process_tree::kill_process_tree(self.pid);
+
         {
             let mut guard = self.inner.lock().map_err(|_| Error::PtyKillFailed("killer mutex poisoned".into()))?;
-            guard.kill().map_err(|e| Error::PtyKillFailed(format!("kill failed: {e}")))?;
+            #[cfg(windows)]
+            {
+                // portable-pty 0.8.x/0.9.x has the WinChildKiller success check inverted, so successful TerminateProcess calls surface as
+                // "The operation completed successfully. (os error 0)". We still invoke it to let the backend release its handle, but our
+                // process-tree kill above is the load-bearing Windows termination path.
+                if let Err(e) = guard.kill() {
+                    if e.raw_os_error() != Some(0) {
+                        return Err(Error::PtyKillFailed(format!("kill failed: {e}")));
+                    }
+                }
+            }
+            #[cfg(not(windows))]
+            {
+                guard.kill().map_err(|e| Error::PtyKillFailed(format!("kill failed: {e}")))?;
+            }
         }
+
+        #[cfg(windows)]
+        tree_kill_result?;
 
         // Unix-only SIGKILL escalation if the child doesn't react to SIGTERM within KILL_GRACE.
         #[cfg(unix)]
@@ -277,6 +296,224 @@ impl PtyKiller for PortableKiller {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(windows)]
+mod windows_process_tree {
+    use std::collections::{HashMap, HashSet};
+    use std::ffi::c_void;
+    use std::io;
+
+    use crate::types::Error;
+
+    type Bool = i32;
+    type Dword = u32;
+    type Handle = *mut c_void;
+
+    const TH32CS_SNAPPROCESS: Dword = 0x0000_0002;
+    const PROCESS_TERMINATE: Dword = 0x0001;
+    const SYNCHRONIZE: Dword = 0x0010_0000;
+    const ERROR_INVALID_PARAMETER: i32 = 87;
+    const ERROR_NO_MORE_FILES: i32 = 18;
+    const INVALID_HANDLE_VALUE: isize = -1;
+    const MAX_PATH: usize = 260;
+    const WAIT_OBJECT_0: Dword = 0x0000_0000;
+    const WAIT_TIMEOUT: Dword = 0x0000_0102;
+    const WAIT_FAILED: Dword = 0xffff_ffff;
+    const TERMINATE_WAIT_MS: Dword = 2_000;
+
+    #[repr(C)]
+    #[allow(non_snake_case)]
+    struct ProcessEntry32W {
+        dwSize: Dword,
+        cntUsage: Dword,
+        th32ProcessID: Dword,
+        th32DefaultHeapID: usize,
+        th32ModuleID: Dword,
+        cntThreads: Dword,
+        th32ParentProcessID: Dword,
+        pcPriClassBase: i32,
+        dwFlags: Dword,
+        szExeFile: [u16; MAX_PATH],
+    }
+
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn CreateToolhelp32Snapshot(dw_flags: Dword, process_id: Dword) -> Handle;
+        fn Process32FirstW(snapshot: Handle, entry: *mut ProcessEntry32W) -> Bool;
+        fn Process32NextW(snapshot: Handle, entry: *mut ProcessEntry32W) -> Bool;
+        fn OpenProcess(desired_access: Dword, inherit_handle: Bool, process_id: Dword) -> Handle;
+        fn TerminateProcess(process: Handle, exit_code: u32) -> Bool;
+        fn WaitForSingleObject(handle: Handle, milliseconds: Dword) -> Dword;
+        fn CloseHandle(object: Handle) -> Bool;
+    }
+
+    pub(super) fn kill_process_tree(root_pid: u32) -> Result<(), Error> {
+        let entries =
+            snapshot_process_parent_pairs().map_err(|e| Error::PtyKillFailed(format!("process tree snapshot failed for pid {root_pid}: {e}")))?;
+        let descendants = descendant_pids_deepest_first(root_pid, &entries);
+        let mut first_error: Option<(u32, io::Error)> = None;
+
+        for pid in descendants.into_iter().chain(std::iter::once(root_pid)) {
+            if let Err(e) = terminate_pid(pid) {
+                first_error.get_or_insert((pid, e));
+            }
+        }
+
+        if let Some((pid, error)) = first_error {
+            Err(Error::PtyKillFailed(format!("process tree kill failed for pid {pid}: {error}")))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn snapshot_process_parent_pairs() -> io::Result<Vec<(u32, u32)>> {
+        // SAFETY: CreateToolhelp32Snapshot is called with the documented process-snapshot flag and process id 0 for all processes.
+        let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+        if snapshot as isize == INVALID_HANDLE_VALUE {
+            return Err(io::Error::last_os_error());
+        }
+
+        let result = collect_process_parent_pairs(snapshot);
+
+        // SAFETY: snapshot is a valid HANDLE returned by CreateToolhelp32Snapshot.
+        unsafe {
+            CloseHandle(snapshot);
+        }
+
+        result
+    }
+
+    fn collect_process_parent_pairs(snapshot: Handle) -> io::Result<Vec<(u32, u32)>> {
+        let mut entry = ProcessEntry32W {
+            dwSize: std::mem::size_of::<ProcessEntry32W>() as Dword,
+            cntUsage: 0,
+            th32ProcessID: 0,
+            th32DefaultHeapID: 0,
+            th32ModuleID: 0,
+            cntThreads: 0,
+            th32ParentProcessID: 0,
+            pcPriClassBase: 0,
+            dwFlags: 0,
+            szExeFile: [0; MAX_PATH],
+        };
+
+        // SAFETY: entry points to an initialized PROCESSENTRY32W with dwSize set as required by the Toolhelp API.
+        if unsafe { Process32FirstW(snapshot, &mut entry) } == 0 {
+            let error = io::Error::last_os_error();
+            return if error.raw_os_error() == Some(ERROR_NO_MORE_FILES) {
+                Ok(Vec::new())
+            } else {
+                Err(error)
+            };
+        }
+
+        let mut entries = Vec::new();
+        loop {
+            entries.push((entry.th32ProcessID, entry.th32ParentProcessID));
+            // SAFETY: same initialized entry buffer; Process32NextW mutates it in place until it returns 0.
+            if unsafe { Process32NextW(snapshot, &mut entry) } == 0 {
+                let error = io::Error::last_os_error();
+                return if error.raw_os_error() == Some(ERROR_NO_MORE_FILES) {
+                    Ok(entries)
+                } else {
+                    Err(error)
+                };
+            }
+        }
+    }
+
+    fn descendant_pids_deepest_first(root_pid: u32, entries: &[(u32, u32)]) -> Vec<u32> {
+        let mut children_by_parent: HashMap<u32, Vec<u32>> = HashMap::new();
+        for (pid, parent) in entries {
+            if *pid != root_pid {
+                children_by_parent.entry(*parent).or_default().push(*pid);
+            }
+        }
+        for children in children_by_parent.values_mut() {
+            children.sort_unstable();
+        }
+
+        let mut seen = HashSet::new();
+        let mut ordered = Vec::new();
+        let _ = append_descendants(root_pid, &children_by_parent, &mut seen, &mut ordered);
+        ordered
+    }
+
+    fn append_descendants(pid: u32, children_by_parent: &HashMap<u32, Vec<u32>>, seen: &mut HashSet<u32>, ordered: &mut Vec<u32>) -> bool {
+        if !seen.insert(pid) {
+            return false;
+        }
+        let Some(children) = children_by_parent.get(&pid) else {
+            return true;
+        };
+        for child in children {
+            if append_descendants(*child, children_by_parent, seen, ordered) {
+                ordered.push(*child);
+            }
+        }
+        true
+    }
+
+    fn terminate_pid(pid: u32) -> io::Result<()> {
+        // SAFETY: OpenProcess accepts any PID and returns NULL for stale/invalid ones; no pointers are dereferenced here.
+        let handle = unsafe { OpenProcess(PROCESS_TERMINATE | SYNCHRONIZE, 0, pid) };
+        if handle.is_null() {
+            let error = io::Error::last_os_error();
+            return if error.raw_os_error() == Some(ERROR_INVALID_PARAMETER) {
+                Ok(())
+            } else {
+                Err(error)
+            };
+        }
+
+        // SAFETY: handle is a valid process handle opened with PROCESS_TERMINATE. CloseHandle is called exactly once.
+        let terminated = unsafe { TerminateProcess(handle, 1) };
+        let error = io::Error::last_os_error();
+        let wait = if terminated != 0 {
+            // SAFETY: handle is a valid process handle opened with SYNCHRONIZE.
+            Some(unsafe { WaitForSingleObject(handle, TERMINATE_WAIT_MS) })
+        } else {
+            None
+        };
+        let wait_error = io::Error::last_os_error();
+        // SAFETY: handle is valid and must be closed regardless of TerminateProcess success.
+        unsafe {
+            CloseHandle(handle);
+        }
+
+        if terminated == 0 {
+            if error.raw_os_error() == Some(ERROR_INVALID_PARAMETER) {
+                Ok(())
+            } else {
+                Err(error)
+            }
+        } else if wait == Some(WAIT_OBJECT_0) {
+            Ok(())
+        } else if wait == Some(WAIT_TIMEOUT) {
+            Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!("timed out waiting for pid {pid} to terminate"),
+            ))
+        } else if wait == Some(WAIT_FAILED) {
+            Err(wait_error)
+        } else {
+            Err(io::Error::other(format!("unexpected wait result {:?} for pid {pid}", wait)))
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::descendant_pids_deepest_first;
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn descendant_pids_are_deepest_first_without_root() {
+            let entries = [(10, 1), (11, 10), (12, 10), (13, 11), (14, 13), (15, 12), (99, 14), (20, 2)];
+
+            assert_eq!(descendant_pids_deepest_first(10, &entries), vec![99, 14, 13, 11, 15, 12]);
+        }
     }
 }
 

--- a/src-tauri/src/pty_pool.rs
+++ b/src-tauri/src/pty_pool.rs
@@ -212,6 +212,8 @@ impl PtySpawner for PortablePtySpawner {
         let killer = Arc::new(PortableKiller {
             inner: Mutex::new(killer_inner),
             pid,
+            #[cfg(windows)]
+            root_creation_time: windows_process_tree::process_creation_time(pid),
         });
         let waiter = Box::new(PortableWaiter { child });
 
@@ -257,12 +259,14 @@ impl PtyWaiter for PortableWaiter {
 struct PortableKiller {
     inner: Mutex<Box<dyn portable_pty::ChildKiller + Send + Sync>>,
     pid: u32,
+    #[cfg(windows)]
+    root_creation_time: Option<u64>,
 }
 
 impl PtyKiller for PortableKiller {
     fn kill(&self) -> Result<(), Error> {
         #[cfg(windows)]
-        let tree_kill_result = windows_process_tree::kill_process_tree(self.pid);
+        let tree_kill_result = windows_process_tree::kill_process_tree(self.pid, self.root_creation_time);
 
         {
             let mut guard = self.inner.lock().map_err(|_| Error::PtyKillFailed("killer mutex poisoned".into()))?;
@@ -372,10 +376,14 @@ mod windows_process_tree {
         fn CloseHandle(object: Handle) -> Bool;
     }
 
-    pub(super) fn kill_process_tree(root_pid: u32) -> Result<(), Error> {
+    pub(super) fn kill_process_tree(root_pid: u32, expected_root_creation_time: Option<u64>) -> Result<(), Error> {
         let entries =
             snapshot_process_parent_pairs().map_err(|e| Error::PtyKillFailed(format!("process tree snapshot failed for pid {root_pid}: {e}")))?;
-        let descendants = descendant_pids_deepest_first(root_pid, &entries);
+        let Some(root_creation_time) = validated_root_creation_time(root_pid, expected_root_creation_time, &entries) else {
+            return Ok(());
+        };
+
+        let descendants = descendant_pids_deepest_first(root_pid, root_creation_time, &entries);
         let mut first_error: Option<(u32, io::Error)> = None;
 
         for pid in descendants.into_iter().chain(std::iter::once(root_pid)) {
@@ -451,7 +459,13 @@ mod windows_process_tree {
         }
     }
 
-    fn process_creation_time(pid: u32) -> Option<u64> {
+    fn validated_root_creation_time(root_pid: u32, expected_root_creation_time: Option<u64>, entries: &[ProcessSnapshotEntry]) -> Option<u64> {
+        let expected = expected_root_creation_time?;
+        let actual = entries.iter().find(|entry| entry.pid == root_pid).and_then(|entry| entry.creation_time)?;
+        (actual == expected).then_some(actual)
+    }
+
+    pub(super) fn process_creation_time(pid: u32) -> Option<u64> {
         // SAFETY: OpenProcess accepts any PID and returns NULL for stale/invalid ones; no pointers are dereferenced.
         let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
         if handle.is_null() {
@@ -476,11 +490,7 @@ mod windows_process_tree {
         }
     }
 
-    fn descendant_pids_deepest_first(root_pid: u32, entries: &[ProcessSnapshotEntry]) -> Vec<u32> {
-        let Some(root_created_at) = entries.iter().find(|entry| entry.pid == root_pid).and_then(|entry| entry.creation_time) else {
-            return Vec::new();
-        };
-
+    fn descendant_pids_deepest_first(root_pid: u32, root_created_at: u64, entries: &[ProcessSnapshotEntry]) -> Vec<u32> {
         let mut children_by_parent: HashMap<u32, Vec<ProcessSnapshotEntry>> = HashMap::new();
         for entry in entries {
             if entry.pid != root_pid && entry.creation_time.is_some() {
@@ -573,7 +583,7 @@ mod windows_process_tree {
 
     #[cfg(test)]
     mod tests {
-        use super::{descendant_pids_deepest_first, ProcessSnapshotEntry};
+        use super::{descendant_pids_deepest_first, validated_root_creation_time, ProcessSnapshotEntry};
         use pretty_assertions::assert_eq;
 
         fn entry(pid: u32, parent_pid: u32, creation_time: u64) -> ProcessSnapshotEntry {
@@ -597,7 +607,7 @@ mod windows_process_tree {
                 entry(20, 2, 170),
             ];
 
-            assert_eq!(descendant_pids_deepest_first(10, &entries), vec![99, 14, 13, 11, 15, 12]);
+            assert_eq!(descendant_pids_deepest_first(10, 100, &entries), vec![99, 14, 13, 11, 15, 12]);
         }
 
         #[test]
@@ -610,12 +620,13 @@ mod windows_process_tree {
                 entry(13, 12, 130),
             ];
 
-            assert_eq!(descendant_pids_deepest_first(10, &entries), vec![11]);
+            assert_eq!(descendant_pids_deepest_first(10, 100, &entries), vec![11]);
         }
 
         #[test]
-        fn descendant_pids_skip_when_root_creation_time_is_unknown() {
+        fn root_creation_validation_rejects_missing_unknown_or_reused_root() {
             let entries = [
+                entry(9, 1, 90),
                 ProcessSnapshotEntry {
                     pid: 10,
                     parent_pid: 1,
@@ -624,7 +635,10 @@ mod windows_process_tree {
                 entry(11, 10, 110),
             ];
 
-            assert_eq!(descendant_pids_deepest_first(10, &entries), Vec::<u32>::new());
+            assert_eq!(validated_root_creation_time(10, Some(100), &entries), None);
+            assert_eq!(validated_root_creation_time(11, None, &entries), None);
+            assert_eq!(validated_root_creation_time(11, Some(100), &entries), None);
+            assert_eq!(validated_root_creation_time(11, Some(110), &entries), Some(110));
         }
     }
 }

--- a/src-tauri/src/pty_pool.rs
+++ b/src-tauri/src/pty_pool.rs
@@ -313,6 +313,7 @@ mod windows_process_tree {
 
     const TH32CS_SNAPPROCESS: Dword = 0x0000_0002;
     const PROCESS_TERMINATE: Dword = 0x0001;
+    const PROCESS_QUERY_LIMITED_INFORMATION: Dword = 0x1000;
     const SYNCHRONIZE: Dword = 0x0010_0000;
     const ERROR_INVALID_PARAMETER: i32 = 87;
     const ERROR_NO_MORE_FILES: i32 = 18;
@@ -338,12 +339,34 @@ mod windows_process_tree {
         szExeFile: [u16; MAX_PATH],
     }
 
+    #[derive(Debug, Clone, Copy)]
+    struct ProcessSnapshotEntry {
+        pid: u32,
+        parent_pid: u32,
+        creation_time: Option<u64>,
+    }
+
+    #[repr(C)]
+    #[derive(Default)]
+    #[allow(non_snake_case)]
+    struct FileTime {
+        dwLowDateTime: Dword,
+        dwHighDateTime: Dword,
+    }
+
     #[link(name = "kernel32")]
     extern "system" {
         fn CreateToolhelp32Snapshot(dw_flags: Dword, process_id: Dword) -> Handle;
         fn Process32FirstW(snapshot: Handle, entry: *mut ProcessEntry32W) -> Bool;
         fn Process32NextW(snapshot: Handle, entry: *mut ProcessEntry32W) -> Bool;
         fn OpenProcess(desired_access: Dword, inherit_handle: Bool, process_id: Dword) -> Handle;
+        fn GetProcessTimes(
+            process: Handle,
+            creation_time: *mut FileTime,
+            exit_time: *mut FileTime,
+            kernel_time: *mut FileTime,
+            user_time: *mut FileTime,
+        ) -> Bool;
         fn TerminateProcess(process: Handle, exit_code: u32) -> Bool;
         fn WaitForSingleObject(handle: Handle, milliseconds: Dword) -> Dword;
         fn CloseHandle(object: Handle) -> Bool;
@@ -368,7 +391,7 @@ mod windows_process_tree {
         }
     }
 
-    fn snapshot_process_parent_pairs() -> io::Result<Vec<(u32, u32)>> {
+    fn snapshot_process_parent_pairs() -> io::Result<Vec<ProcessSnapshotEntry>> {
         // SAFETY: CreateToolhelp32Snapshot is called with the documented process-snapshot flag and process id 0 for all processes.
         let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
         if snapshot as isize == INVALID_HANDLE_VALUE {
@@ -385,7 +408,7 @@ mod windows_process_tree {
         result
     }
 
-    fn collect_process_parent_pairs(snapshot: Handle) -> io::Result<Vec<(u32, u32)>> {
+    fn collect_process_parent_pairs(snapshot: Handle) -> io::Result<Vec<ProcessSnapshotEntry>> {
         let mut entry = ProcessEntry32W {
             dwSize: std::mem::size_of::<ProcessEntry32W>() as Dword,
             cntUsage: 0,
@@ -411,7 +434,11 @@ mod windows_process_tree {
 
         let mut entries = Vec::new();
         loop {
-            entries.push((entry.th32ProcessID, entry.th32ParentProcessID));
+            entries.push(ProcessSnapshotEntry {
+                pid: entry.th32ProcessID,
+                parent_pid: entry.th32ParentProcessID,
+                creation_time: process_creation_time(entry.th32ProcessID),
+            });
             // SAFETY: same initialized entry buffer; Process32NextW mutates it in place until it returns 0.
             if unsafe { Process32NextW(snapshot, &mut entry) } == 0 {
                 let error = io::Error::last_os_error();
@@ -424,24 +451,59 @@ mod windows_process_tree {
         }
     }
 
-    fn descendant_pids_deepest_first(root_pid: u32, entries: &[(u32, u32)]) -> Vec<u32> {
-        let mut children_by_parent: HashMap<u32, Vec<u32>> = HashMap::new();
-        for (pid, parent) in entries {
-            if *pid != root_pid {
-                children_by_parent.entry(*parent).or_default().push(*pid);
+    fn process_creation_time(pid: u32) -> Option<u64> {
+        // SAFETY: OpenProcess accepts any PID and returns NULL for stale/invalid ones; no pointers are dereferenced.
+        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+        if handle.is_null() {
+            return None;
+        }
+
+        let mut creation_time = FileTime::default();
+        let mut exit_time = FileTime::default();
+        let mut kernel_time = FileTime::default();
+        let mut user_time = FileTime::default();
+        // SAFETY: handle is valid and all FILETIME pointers are initialized writable buffers.
+        let ok = unsafe { GetProcessTimes(handle, &mut creation_time, &mut exit_time, &mut kernel_time, &mut user_time) };
+        // SAFETY: handle is valid and closed exactly once.
+        unsafe {
+            CloseHandle(handle);
+        }
+
+        if ok == 0 {
+            None
+        } else {
+            Some((u64::from(creation_time.dwHighDateTime) << 32) | u64::from(creation_time.dwLowDateTime))
+        }
+    }
+
+    fn descendant_pids_deepest_first(root_pid: u32, entries: &[ProcessSnapshotEntry]) -> Vec<u32> {
+        let Some(root_created_at) = entries.iter().find(|entry| entry.pid == root_pid).and_then(|entry| entry.creation_time) else {
+            return Vec::new();
+        };
+
+        let mut children_by_parent: HashMap<u32, Vec<ProcessSnapshotEntry>> = HashMap::new();
+        for entry in entries {
+            if entry.pid != root_pid && entry.creation_time.is_some() {
+                children_by_parent.entry(entry.parent_pid).or_default().push(*entry);
             }
         }
         for children in children_by_parent.values_mut() {
-            children.sort_unstable();
+            children.sort_unstable_by_key(|entry| entry.pid);
         }
 
         let mut seen = HashSet::new();
         let mut ordered = Vec::new();
-        let _ = append_descendants(root_pid, &children_by_parent, &mut seen, &mut ordered);
+        let _ = append_descendants(root_pid, root_created_at, &children_by_parent, &mut seen, &mut ordered);
         ordered
     }
 
-    fn append_descendants(pid: u32, children_by_parent: &HashMap<u32, Vec<u32>>, seen: &mut HashSet<u32>, ordered: &mut Vec<u32>) -> bool {
+    fn append_descendants(
+        pid: u32,
+        parent_created_at: u64,
+        children_by_parent: &HashMap<u32, Vec<ProcessSnapshotEntry>>,
+        seen: &mut HashSet<u32>,
+        ordered: &mut Vec<u32>,
+    ) -> bool {
         if !seen.insert(pid) {
             return false;
         }
@@ -449,8 +511,14 @@ mod windows_process_tree {
             return true;
         };
         for child in children {
-            if append_descendants(*child, children_by_parent, seen, ordered) {
-                ordered.push(*child);
+            let Some(child_created_at) = child.creation_time else {
+                continue;
+            };
+            if child_created_at < parent_created_at {
+                continue;
+            }
+            if append_descendants(child.pid, child_created_at, children_by_parent, seen, ordered) {
+                ordered.push(child.pid);
             }
         }
         true
@@ -505,14 +573,58 @@ mod windows_process_tree {
 
     #[cfg(test)]
     mod tests {
-        use super::descendant_pids_deepest_first;
+        use super::{descendant_pids_deepest_first, ProcessSnapshotEntry};
         use pretty_assertions::assert_eq;
+
+        fn entry(pid: u32, parent_pid: u32, creation_time: u64) -> ProcessSnapshotEntry {
+            ProcessSnapshotEntry {
+                pid,
+                parent_pid,
+                creation_time: Some(creation_time),
+            }
+        }
 
         #[test]
         fn descendant_pids_are_deepest_first_without_root() {
-            let entries = [(10, 1), (11, 10), (12, 10), (13, 11), (14, 13), (15, 12), (99, 14), (20, 2)];
+            let entries = [
+                entry(10, 1, 100),
+                entry(11, 10, 110),
+                entry(12, 10, 120),
+                entry(13, 11, 130),
+                entry(14, 13, 140),
+                entry(15, 12, 150),
+                entry(99, 14, 160),
+                entry(20, 2, 170),
+            ];
 
             assert_eq!(descendant_pids_deepest_first(10, &entries), vec![99, 14, 13, 11, 15, 12]);
+        }
+
+        #[test]
+        fn descendant_pids_skip_children_older_than_parent_pid() {
+            let entries = [
+                entry(10, 1, 100),
+                entry(11, 10, 110),
+                // Simulates a long-lived unrelated process whose original parent PID was later reused by the root process.
+                entry(12, 10, 90),
+                entry(13, 12, 130),
+            ];
+
+            assert_eq!(descendant_pids_deepest_first(10, &entries), vec![11]);
+        }
+
+        #[test]
+        fn descendant_pids_skip_when_root_creation_time_is_unknown() {
+            let entries = [
+                ProcessSnapshotEntry {
+                    pid: 10,
+                    parent_pid: 1,
+                    creation_time: None,
+                },
+                entry(11, 10, 110),
+            ];
+
+            assert_eq!(descendant_pids_deepest_first(10, &entries), Vec::<u32>::new());
         }
     }
 }

--- a/src-tauri/src/test_bin/arborist_test_child.rs
+++ b/src-tauri/src/test_bin/arborist_test_child.rs
@@ -10,6 +10,8 @@
 //! - `unicode\n`            → write a known multibyte UTF-8 string (used by the
 //!   streaming-decoder tests).
 //! - any other line `X`     → write `echo: X\n`.
+//! - `--spawn-grandchild`   → spawn a long-lived `--hold` child, print its PID,
+//!   and then stay alive (used by Windows PTY process-tree kill tests).
 //!
 //! Cross-platform: pure stdlib, no extra dependencies. The binary is wired into `Cargo.toml` so integration tests in this crate receive its path via
 //! `env!("CARGO_BIN_EXE_arborist-test-child")`.
@@ -20,8 +22,19 @@
 
 use std::io::{self, BufRead, Write};
 use std::process::ExitCode;
+use std::time::Duration;
 
 fn main() -> ExitCode {
+    let args: Vec<std::ffi::OsString> = std::env::args_os().collect();
+    if args.get(1).is_some_and(|arg| arg == std::ffi::OsStr::new("--hold")) {
+        loop {
+            std::thread::sleep(Duration::from_secs(60));
+        }
+    }
+    if args.get(1).is_some_and(|arg| arg == std::ffi::OsStr::new("--spawn-grandchild")) {
+        return spawn_grandchild(args.get(2));
+    }
+
     let stdout = io::stdout();
     let mut out = stdout.lock();
     if writeln!(out, "ARBORIST-TEST-CHILD READY").is_err() {
@@ -75,4 +88,34 @@ fn main() -> ExitCode {
     }
 
     ExitCode::SUCCESS
+}
+
+fn spawn_grandchild(marker_path: Option<&std::ffi::OsString>) -> ExitCode {
+    let exe = match std::env::current_exe() {
+        Ok(exe) => exe,
+        Err(_) => return ExitCode::from(2),
+    };
+    let child = match std::process::Command::new(exe).arg("--hold").spawn() {
+        Ok(child) => child,
+        Err(_) => return ExitCode::from(2),
+    };
+    if let Some(marker_path) = marker_path {
+        let marker_path = std::path::PathBuf::from(marker_path);
+        if std::fs::write(&marker_path, child.id().to_string()).is_err() {
+            return ExitCode::from(2);
+        }
+    }
+
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    if writeln!(out, "ARBORIST-TEST-CHILD GRANDCHILD {}", child.id()).is_err() {
+        return ExitCode::from(2);
+    }
+    if out.flush().is_err() {
+        return ExitCode::from(2);
+    }
+
+    loop {
+        std::thread::sleep(Duration::from_secs(60));
+    }
 }

--- a/src-tauri/src/test_bin/arborist_test_child.rs
+++ b/src-tauri/src/test_bin/arborist_test_child.rs
@@ -21,7 +21,7 @@
 //! prevents `tauri build` from trying to copy this helper into the AppImage / .deb / .app bundle. Do not move this file back into `src/bin/`.
 
 use std::io::{self, BufRead, Write};
-use std::process::ExitCode;
+use std::process::{Child, ExitCode};
 use std::time::Duration;
 
 fn main() -> ExitCode {
@@ -95,13 +95,14 @@ fn spawn_grandchild(marker_path: Option<&std::ffi::OsString>) -> ExitCode {
         Ok(exe) => exe,
         Err(_) => return ExitCode::from(2),
     };
-    let child = match std::process::Command::new(exe).arg("--hold").spawn() {
+    let mut child = match std::process::Command::new(exe).arg("--hold").spawn() {
         Ok(child) => child,
         Err(_) => return ExitCode::from(2),
     };
     if let Some(marker_path) = marker_path {
         let marker_path = std::path::PathBuf::from(marker_path);
         if std::fs::write(&marker_path, child.id().to_string()).is_err() {
+            terminate_spawned_child(&mut child);
             return ExitCode::from(2);
         }
     }
@@ -109,13 +110,20 @@ fn spawn_grandchild(marker_path: Option<&std::ffi::OsString>) -> ExitCode {
     let stdout = io::stdout();
     let mut out = stdout.lock();
     if writeln!(out, "ARBORIST-TEST-CHILD GRANDCHILD {}", child.id()).is_err() {
+        terminate_spawned_child(&mut child);
         return ExitCode::from(2);
     }
     if out.flush().is_err() {
+        terminate_spawned_child(&mut child);
         return ExitCode::from(2);
     }
 
     loop {
         std::thread::sleep(Duration::from_secs(60));
     }
+}
+
+fn terminate_spawned_child(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
 }

--- a/src-tauri/tests/pty_pool.rs
+++ b/src-tauri/tests/pty_pool.rs
@@ -77,39 +77,55 @@ fn parse_grandchild_pid(output: &str) -> Option<u32> {
 }
 
 #[cfg(windows)]
-struct PidCleanupGuard {
-    pid: u32,
+type Handle = *mut std::ffi::c_void;
+#[cfg(windows)]
+const PROCESS_TERMINATE: u32 = 0x0001;
+#[cfg(windows)]
+const SYNCHRONIZE: u32 = 0x0010_0000;
+#[cfg(windows)]
+const WAIT_TIMEOUT: u32 = 0x0000_0102;
+
+#[cfg(windows)]
+#[link(name = "kernel32")]
+extern "system" {
+    fn OpenProcess(desired_access: u32, inherit_handle: i32, process_id: u32) -> Handle;
+    fn WaitForSingleObject(handle: Handle, milliseconds: u32) -> u32;
+    fn TerminateProcess(process: Handle, exit_code: u32) -> i32;
+    fn CloseHandle(object: Handle) -> i32;
 }
 
 #[cfg(windows)]
-impl PidCleanupGuard {
-    fn new(pid: u32) -> Self {
-        Self { pid }
+struct ProcessCleanupGuard {
+    handle: Handle,
+}
+
+#[cfg(windows)]
+impl ProcessCleanupGuard {
+    fn new(pid: u32) -> Option<Self> {
+        // SAFETY: OpenProcess accepts stale PIDs and returns NULL; no pointers are dereferenced.
+        let handle = unsafe { OpenProcess(PROCESS_TERMINATE | SYNCHRONIZE, 0, pid) };
+        if handle.is_null() {
+            None
+        } else {
+            Some(Self { handle })
+        }
     }
 }
 
 #[cfg(windows)]
-impl Drop for PidCleanupGuard {
+impl Drop for ProcessCleanupGuard {
     fn drop(&mut self) {
-        terminate_pid_best_effort(self.pid);
+        // SAFETY: handle was opened while the child PID was known to be alive and is closed exactly once here. Keeping the handle avoids PID-reuse
+        // cleanup hazards if the test fails before the normal pool.kill path reaps the process.
+        unsafe {
+            TerminateProcess(self.handle, 1);
+            CloseHandle(self.handle);
+        }
     }
 }
 
 #[cfg(windows)]
 fn is_pid_running(pid: u32) -> bool {
-    use std::ffi::c_void;
-
-    type Handle = *mut c_void;
-    const SYNCHRONIZE: u32 = 0x0010_0000;
-    const WAIT_TIMEOUT: u32 = 0x0000_0102;
-
-    #[link(name = "kernel32")]
-    extern "system" {
-        fn OpenProcess(desired_access: u32, inherit_handle: i32, process_id: u32) -> Handle;
-        fn WaitForSingleObject(handle: Handle, milliseconds: u32) -> u32;
-        fn CloseHandle(object: Handle) -> i32;
-    }
-
     // SAFETY: OpenProcess accepts stale PIDs and returns NULL; no pointers are dereferenced.
     let handle = unsafe { OpenProcess(SYNCHRONIZE, 0, pid) };
     if handle.is_null() {
@@ -122,32 +138,6 @@ fn is_pid_running(pid: u32) -> bool {
         CloseHandle(handle);
     }
     wait == WAIT_TIMEOUT
-}
-
-#[cfg(windows)]
-fn terminate_pid_best_effort(pid: u32) {
-    use std::ffi::c_void;
-
-    type Handle = *mut c_void;
-    const PROCESS_TERMINATE: u32 = 0x0001;
-
-    #[link(name = "kernel32")]
-    extern "system" {
-        fn OpenProcess(desired_access: u32, inherit_handle: i32, process_id: u32) -> Handle;
-        fn TerminateProcess(process: Handle, exit_code: u32) -> i32;
-        fn CloseHandle(object: Handle) -> i32;
-    }
-
-    // SAFETY: best-effort cleanup for a PID this test spawned; invalid/stale PIDs return NULL.
-    let handle = unsafe { OpenProcess(PROCESS_TERMINATE, 0, pid) };
-    if handle.is_null() {
-        return;
-    }
-    // SAFETY: handle is valid and opened with PROCESS_TERMINATE.
-    unsafe {
-        TerminateProcess(handle, 1);
-        CloseHandle(handle);
-    }
 }
 
 /// Construct a `(sink, recordings)` pair where output and status updates are pushed into shared `Vec`s for inspection.
@@ -955,11 +945,11 @@ fn kill_terminates_shell_descendants_on_windows() {
         panic!("test child did not report grandchild pid; output was {:?}", outs.lock().unwrap());
     };
     let grandchild_pid = parse_grandchild_pid(&output).expect("predicate already confirmed pid is present");
-    let _cleanup = PidCleanupGuard::new(grandchild_pid);
     assert!(
         is_pid_running(grandchild_pid),
         "grandchild pid {grandchild_pid} should be running before kill"
     );
+    let _cleanup = ProcessCleanupGuard::new(grandchild_pid).expect("open cleanup handle for spawned grandchild");
 
     let outcome = rt.block_on(async { pool.kill(&session.id).await.expect("kill") });
 

--- a/src-tauri/tests/pty_pool.rs
+++ b/src-tauri/tests/pty_pool.rs
@@ -929,6 +929,7 @@ fn kill_returns_unconfirmed_when_killer_errors() {
 
 #[cfg(windows)]
 #[test]
+#[serial_test::serial(real_pty)]
 fn kill_terminates_shell_descendants_on_windows() {
     let pool = PtyPool::new(Arc::new(PortablePtySpawner));
     let dir = tempfile::tempdir().unwrap();

--- a/src-tauri/tests/pty_pool.rs
+++ b/src-tauri/tests/pty_pool.rs
@@ -68,6 +68,88 @@ fn quote_program(p: &str) -> String {
     arborist_lib::compose::shell_quote_posix(p)
 }
 
+#[cfg(windows)]
+fn parse_grandchild_pid(output: &str) -> Option<u32> {
+    let marker = "ARBORIST-TEST-CHILD GRANDCHILD ";
+    let (_, rest) = output.split_once(marker)?;
+    let digits: String = rest.chars().take_while(|ch| ch.is_ascii_digit()).collect();
+    digits.parse::<u32>().ok()
+}
+
+#[cfg(windows)]
+struct PidCleanupGuard {
+    pid: u32,
+}
+
+#[cfg(windows)]
+impl PidCleanupGuard {
+    fn new(pid: u32) -> Self {
+        Self { pid }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for PidCleanupGuard {
+    fn drop(&mut self) {
+        terminate_pid_best_effort(self.pid);
+    }
+}
+
+#[cfg(windows)]
+fn is_pid_running(pid: u32) -> bool {
+    use std::ffi::c_void;
+
+    type Handle = *mut c_void;
+    const SYNCHRONIZE: u32 = 0x0010_0000;
+    const WAIT_TIMEOUT: u32 = 0x0000_0102;
+
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn OpenProcess(desired_access: u32, inherit_handle: i32, process_id: u32) -> Handle;
+        fn WaitForSingleObject(handle: Handle, milliseconds: u32) -> u32;
+        fn CloseHandle(object: Handle) -> i32;
+    }
+
+    // SAFETY: OpenProcess accepts stale PIDs and returns NULL; no pointers are dereferenced.
+    let handle = unsafe { OpenProcess(SYNCHRONIZE, 0, pid) };
+    if handle.is_null() {
+        return false;
+    }
+    // SAFETY: handle is a valid process handle opened for SYNCHRONIZE.
+    let wait = unsafe { WaitForSingleObject(handle, 0) };
+    // SAFETY: handle is valid and closed exactly once.
+    unsafe {
+        CloseHandle(handle);
+    }
+    wait == WAIT_TIMEOUT
+}
+
+#[cfg(windows)]
+fn terminate_pid_best_effort(pid: u32) {
+    use std::ffi::c_void;
+
+    type Handle = *mut c_void;
+    const PROCESS_TERMINATE: u32 = 0x0001;
+
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn OpenProcess(desired_access: u32, inherit_handle: i32, process_id: u32) -> Handle;
+        fn TerminateProcess(process: Handle, exit_code: u32) -> i32;
+        fn CloseHandle(object: Handle) -> i32;
+    }
+
+    // SAFETY: best-effort cleanup for a PID this test spawned; invalid/stale PIDs return NULL.
+    let handle = unsafe { OpenProcess(PROCESS_TERMINATE, 0, pid) };
+    if handle.is_null() {
+        return;
+    }
+    // SAFETY: handle is valid and opened with PROCESS_TERMINATE.
+    unsafe {
+        TerminateProcess(handle, 1);
+        CloseHandle(handle);
+    }
+}
+
 /// Construct a `(sink, recordings)` pair where output and status updates are pushed into shared `Vec`s for inspection.
 type OutputLog = Arc<Mutex<Vec<String>>>;
 type StatusLog = Arc<Mutex<Vec<(SessionStatus, Option<u32>)>>>;
@@ -853,6 +935,40 @@ fn kill_returns_unconfirmed_when_killer_errors() {
     // Even on Unconfirmed, the runtime entry must be evicted so the SessionId is free for a fresh respawn (this matches the existing pool-eviction
     // contract that callers already rely on).
     assert!(!pool.contains(&session.id));
+}
+
+#[cfg(windows)]
+#[test]
+fn kill_terminates_shell_descendants_on_windows() {
+    let pool = PtyPool::new(Arc::new(PortablePtySpawner));
+    let dir = tempfile::tempdir().unwrap();
+    let mut session = make_session(dir.path());
+    session.composed_command = format!("{} --spawn-grandchild", quote_program(TEST_CHILD_PATH));
+    let (sink, outs, _stats) = recording_sink();
+
+    let rt = rt();
+    let _g = rt.enter();
+    pool.spawn(&session, sink, DEFAULT_PTY_SIZE).expect("spawn");
+
+    let Some(output) = wait_for(&outs, |out| parse_grandchild_pid(out).is_some(), Duration::from_secs(5)) else {
+        let _ = rt.block_on(async { pool.kill(&session.id).await });
+        panic!("test child did not report grandchild pid; output was {:?}", outs.lock().unwrap());
+    };
+    let grandchild_pid = parse_grandchild_pid(&output).expect("predicate already confirmed pid is present");
+    let _cleanup = PidCleanupGuard::new(grandchild_pid);
+    assert!(
+        is_pid_running(grandchild_pid),
+        "grandchild pid {grandchild_pid} should be running before kill"
+    );
+
+    let outcome = rt.block_on(async { pool.kill(&session.id).await.expect("kill") });
+
+    assert_eq!(
+        outcome,
+        arborist_lib::pty_pool::KillOutcome::Reaped,
+        "Windows PTY kill should treat portable-pty's os-error-0 success as confirmed when the wait thread joins"
+    );
+    assert!(!is_pid_running(grandchild_pid), "grandchild pid {grandchild_pid} survived PTY kill");
 }
 
 // Silence unused-import lints when the platform-specific quoter selects only one of the two variants.


### PR DESCRIPTION
## Summary
- kill Windows PTY process trees before removing worktrees
- ignore portable-pty's bogus Windows os-error-0 kill result when the wait thread confirms exit
- retry transient Windows git worktree remove failures while filesystem handles settle
- add regression coverage for descendant PTY cleanup and worktree-remove retry behavior

## Validation
- pnpm run build
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --features test-helpers -- -D warnings
- cargo test --workspace --features test-helpers