### PR TITLE
[community-doc-review] Improve public launch documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,97 @@
+name: Bug report
+description: Report reproducible broken behavior in Arborist.
+title: '[Bug]: '
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Arborist. Do not include secrets, tokens, private logs, or exploit details.
+        Security vulnerabilities should use private reporting instead of a public issue.
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing issues for a matching report.
+          required: true
+        - label: I removed secrets, tokens, private repository names, and credential-bearing logs.
+          required: true
+  - type: input
+    id: version
+    attributes:
+      label: Arborist version or commit
+      description: Use the release version, tag, or commit SHA.
+      placeholder: v0.1.0 or abc1234
+    validations:
+      required: true
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Installation method
+      options:
+        - Release installer
+        - Development build with pnpm dev
+        - Local bundle with pnpm tauri:build
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows
+        - macOS
+        - Linux X11
+        - Linux Wayland
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: workspace
+    attributes:
+      label: Workspace shape
+      description: Describe the primary clone, managed worktree, or manually opened worktree shape without private paths.
+      placeholder: Primary clone with Arborist-managed worktree under .arborist/.worktrees/example
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Workspace or Git worktree
+        - Claude session
+        - Copilot session
+        - Terminal custom process
+        - Application custom process
+        - Settings or configuration
+        - Release or installation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps are best.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Optional. Redact secrets, private paths, transcript content, and repository remotes.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/mcaden/arborist/security/advisories/new
+    about: Report vulnerabilities privately. Do not post exploit details publicly.
+  - name: Support guide
+    url: https://github.com/mcaden/arborist/blob/main/SUPPORT.md
+    about: See where to file bugs, feature requests, install problems, and contribution questions.
+  - name: Roadmap
+    url: https://github.com/mcaden/arborist/blob/main/docs/roadmap.md
+    about: Check known gaps and planned follow-up areas before opening a feature request.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,57 @@
+name: Feature request
+description: Suggest a workflow or user experience improvement for Arborist.
+title: '[Feature]: '
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing a feature idea. Please focus on the user workflow and avoid including private repository details.
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing issues and the roadmap for similar work.
+          required: true
+        - label: This request does not include secrets, tokens, private logs, or exploit details.
+          required: true
+  - type: textarea
+    id: workflow
+    attributes:
+      label: User workflow
+      description: What are you trying to do in Arborist?
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Current limitation
+      description: What is hard, missing, confusing, or unsafe today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Describe the outcome you want, not only an implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Include workarounds or other designs you considered.
+  - type: checkboxes
+    id: impact
+    attributes:
+      label: Impact areas
+      description: Select any areas this might affect.
+      options:
+        - label: User-facing workflow or UI
+        - label: Workspace or worktree behavior
+        - label: AI session launch behavior
+        - label: Custom processes or sub-sessions
+        - label: Configuration or persisted data
+        - label: Command/event API
+        - label: Documentation
+        - label: Security, privacy, or process-safety expectations

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- Describe the meaningful change and user/developer impact. -->
+
+## Linked issues
+
+<!-- Use "Closes #123" or "Refs #123" where appropriate. -->
+
+## Checks
+
+- [ ] I ran the relevant local checks, or this is docs-only and I checked formatting/links.
+- [ ] I added or updated tests for new or changed behavior, or documented why tests are not needed.
+- [ ] I updated user-facing, contributor, architecture, configuration, or release docs as needed.
+- [ ] I did not add secrets, private logs, credential-bearing output, or unredacted private repository paths.
+- [ ] I recorded manual smoke results in this PR or a linked issue when changing release, installer, OS, WebView, or terminal behavior.
+- [ ] Any remaining architecture/workflow documentation follow-up is linked to #106 or a more specific issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ Read:
 ## Issue workflow
 
 - Search existing issues before opening a new one.
-- Use a bug report for reproducible broken behavior.
-- Use a feature request for new behavior or user experience changes.
+- Use the GitHub bug report template for reproducible broken behavior.
+- Use the GitHub feature request template for new behavior or user experience changes.
 - Do not post secrets, tokens, private repository paths, logs with credentials, or exploit details in public issues.
 - Security issues should follow [SECURITY](SECURITY.md), not the public issue tracker.
 
@@ -35,6 +35,7 @@ Good bug reports include:
 - Do not push directly to `main`.
 - Do not force-push shared branches.
 - Keep PRs focused. Split unrelated changes.
+- Fill out the PR template, including linked issues and any checks or manual smoke coverage.
 - Include tests for new or changed behavior.
 - Update docs when behavior, configuration, commands, events, or workflows change.
 - For PR titles created by automation in this repository, prefix the worktree or branch name in square brackets.

--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ Arborist is pre-1.0 and preparing for public open-source use. Expect active chan
 - **Restore on launch:** open sessions are restored from persisted records.
 - **Safe command composition:** worktree paths are passed as process `cwd`, not interpolated into shell commands.
 
-## Install
+## Install for users
 
-Pre-built installers are published on the [Releases page](https://github.com/mcaden/arborist/releases).
+Arborist has not published a stable release yet. When prerelease installers are available, download them from the
+[Releases page](https://github.com/mcaden/arborist/releases). Until then, use the contributor setup below to run Arborist locally.
 
-Release artifacts are not OS code-signed, so first launch may show Windows SmartScreen or macOS Gatekeeper warnings. Published assets should have
-GitHub build attestations:
+Release artifacts are not OS code-signed unless a release note says otherwise, so first launch may show Windows SmartScreen or macOS Gatekeeper
+warnings. Published assets should have GitHub build attestations:
 
 ```sh
 gh attestation verify <downloaded-file> --repo mcaden/arborist
@@ -35,14 +36,14 @@ gh attestation verify <downloaded-file> --repo mcaden/arborist
 Runtime requirements:
 
 - `git` on `PATH`.
-- At least one AI CLI for AI sessions: Claude CLI or GitHub Copilot CLI.
+- At least one authenticated AI CLI for AI sessions: Claude CLI or GitHub Copilot CLI. Arborist does not handle CLI sign-in.
 - Windows WebView2 runtime, if not already present.
 
 Optional runtime dependency:
 
 - Linux X11 application-sub-tab focusing uses `wmctrl`. Wayland focus is unsupported by design; launched applications still run.
 
-## Build from source
+## Run from source for contributors
 
 Prerequisites are covered in [docs/development.md](docs/development.md).
 
@@ -53,6 +54,8 @@ nvm use
 pnpm install
 pnpm dev
 ```
+
+`pnpm dev` starts a local development build. To create a local desktop bundle instead, run `pnpm tauri:build`.
 
 Common verification commands:
 
@@ -88,7 +91,8 @@ Long-form project docs live under [docs](docs/index.md). GitHub community-health
 
 ## Contributing
 
-Public contribution guidance is in [CONTRIBUTING.md](CONTRIBUTING.md). Please read [SECURITY.md](SECURITY.md) before reporting a vulnerability.
+Public contribution guidance is in [CONTRIBUTING.md](CONTRIBUTING.md). Use the GitHub issue templates for bugs and feature requests, and read
+[SECURITY.md](SECURITY.md) before reporting a vulnerability.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Do not open a public issue with exploit details, secrets, tokens, private logs, 
 
 Preferred reporting path:
 
-1. Use GitHub private vulnerability reporting for this repository when it is enabled.
+1. Use [GitHub private vulnerability reporting](https://github.com/mcaden/arborist/security/advisories/new) for this repository when it is enabled.
 2. If private reporting is not available, contact the repository maintainers through a non-public channel listed on the repository owner profile and
    ask where to send details.
 3. Publicly file only a minimal placeholder if there is no private channel, and omit exploit details until a maintainer responds.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,15 +4,21 @@ Arborist is an open-source project maintained on a best-effort basis.
 
 ## Where to get help
 
-| Need                    | Where to go                                                          |
-| ----------------------- | -------------------------------------------------------------------- |
-| Bug report              | Open a GitHub issue with reproduction steps and environment details. |
-| Feature request         | Open a GitHub issue describing the workflow and expected behavior.   |
-| Security vulnerability  | Follow [SECURITY](SECURITY.md); do not post details publicly.        |
-| Contribution question   | Comment on the issue or PR you are working from.                     |
-| Release/install problem | Open an issue with OS, artifact name, and first-run error text.      |
+| Need                    | Where to go                                                     |
+| ----------------------- | --------------------------------------------------------------- |
+| Bug report              | Open a GitHub issue with the bug report template.               |
+| Feature request         | Open a GitHub issue with the feature request template.          |
+| Security vulnerability  | Follow [SECURITY](SECURITY.md); do not post details publicly.   |
+| Contribution question   | Comment on the issue or PR you are working from.                |
+| Release/install problem | Open an issue with OS, artifact name, and first-run error text. |
 
 If GitHub Discussions are enabled in the future, general usage questions may move there. Until then, issues are the public support channel.
+
+Start here:
+
+- [New bug report](https://github.com/mcaden/arborist/issues/new?template=bug_report.yml)
+- [New feature request](https://github.com/mcaden/arborist/issues/new?template=feature_request.yml)
+- [Private vulnerability report](https://github.com/mcaden/arborist/security/advisories/new)
 
 ## What maintainers need
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,12 +23,14 @@ at the repository root using GitHub's conventional filenames.
 
 ## Public project docs
 
-| Document                                 | Use it for                                                                         |
-| ---------------------------------------- | ---------------------------------------------------------------------------------- |
-| [CONTRIBUTING](../CONTRIBUTING.md)       | Branch, PR, review, coding, and acceptance-gate expectations.                      |
-| [SECURITY](../SECURITY.md)               | Responsible disclosure, threat model, security boundaries, and supported versions. |
-| [SUPPORT](../SUPPORT.md)                 | Where public users should ask questions, file bugs, and request features.          |
-| [CODE_OF_CONDUCT](../CODE_OF_CONDUCT.md) | Conduct expectations and enforcement process for the public project.               |
+| Document                                           | Use it for                                                                         |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [CONTRIBUTING](../CONTRIBUTING.md)                 | Branch, PR, review, coding, and acceptance-gate expectations.                      |
+| [SECURITY](../SECURITY.md)                         | Responsible disclosure, threat model, security boundaries, and supported versions. |
+| [SUPPORT](../SUPPORT.md)                           | Where public users should ask questions, file bugs, and request features.          |
+| [CODE_OF_CONDUCT](../CODE_OF_CONDUCT.md)           | Conduct expectations and enforcement process for the public project.               |
+| [Issue templates](../.github/ISSUE_TEMPLATE)       | Public bug and feature request forms for GitHub issues.                            |
+| [PR template](../.github/pull_request_template.md) | Pull request summary, issue-link, check, and smoke-test checklist.                 |
 
 ## Operations and references
 
@@ -42,5 +44,6 @@ at the repository root using GitHub's conventional filenames.
 - Keep long-form documentation under `docs/`.
 - Use lowercase filenames for project docs.
 - Use GitHub's conventional root filenames for community-health docs: `CONTRIBUTING.md`, `SECURITY.md`, `SUPPORT.md`, and `CODE_OF_CONDUCT.md`.
+- Keep GitHub issue and pull request templates under `.github/` so the community profile can discover them.
 - Use Mermaid for diagrams in active docs.
 - Keep source comments brief; link to stable doc anchors for deeper design context.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,12 +23,12 @@ This page tracks known gaps and follow-up work. It is not a promise of delivery 
 
 ## Public open-source readiness
 
-| Area              | Gap                                                                                                     |
-| ----------------- | ------------------------------------------------------------------------------------------------------- |
-| Community files   | Root community-health files now follow GitHub naming conventions; keep them linked from the docs index. |
-| Issue templates   | Public bug/feature/security templates would make triage easier.                                         |
-| Governance        | As contributor volume grows, document maintainer roles and decision process.                            |
-| Dependency review | Add automated dependency and supply-chain review appropriate for public PRs.                            |
+| Area              | Gap                                                                                                            |
+| ----------------- | -------------------------------------------------------------------------------------------------------------- |
+| Community files   | Root community-health files now follow GitHub naming conventions; keep them linked from the docs index.        |
+| Long-form docs    | Architecture/workflow rewrite follow-ups are tracked in [#106](https://github.com/mcaden/arborist/issues/106). |
+| Governance        | As contributor volume grows, document maintainer roles and decision process.                                   |
+| Dependency review | Add automated dependency and supply-chain review appropriate for public PRs.                                   |
 
 ## Longer-term ideas
 


### PR DESCRIPTION
## Summary
- clarify end-user install vs contributor source setup in public docs
- add GitHub issue forms and PR template for launch readiness
- update support/security/docs index/roadmap references and link remaining doc follow-up to #106

Closes #114