### PR TITLE
[worktree-deletion] Fix worktree cleanup after unconfirmed teardown

### DIFF
--- a/crates/arborist-types/src/lib.rs
+++ b/crates/arborist-types/src/lib.rs
@@ -1203,14 +1203,17 @@ pub struct SessionCloseArgs {
     pub delete_worktree: bool,
 }
 
-/// Result of `session_close`. The session record and PTY are always torn down on success; if the user opted into worktree deletion and the `git
-/// worktree remove` step failed, the failure is reported here as a warning string rather than as a hard error so callers can converge UI state
-/// regardless.
+/// Result of `session_close`. The session record is removed on success; if the PTY kill was issued but reaping could not be confirmed, the warning is
+/// reported here and worktree deletion is refused. If the user opted into worktree deletion and the `git worktree remove` step failed, the failure is
+/// also reported here as a warning string rather than as a hard error so callers can converge UI state regardless.
 ///
 /// MIRROR: `src/lib/tauri-bridge.ts::SessionCloseResult`.
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionCloseResult {
+    /// Human-readable warning from PTY teardown, currently populated when the child kill was issued but process reaping could not be confirmed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub teardown_error: Option<String>,
     /// Human-readable error message from `git worktree remove`. `None` when worktree deletion was not requested or succeeded.
     pub worktree_delete_error: Option<String>,
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,7 +139,7 @@ Every command must be present in all of these places:
 | `frontend_ready`                | none                            | `void`                    | Signal that event listeners are attached; triggers restore registration once.                |
 | `session_create`                | `SessionCreateArgs`             | `SessionView`             | Compose, persist, and spawn a Claude/Copilot PTY in the selected worktree.                   |
 | `session_list`                  | none                            | `SessionView[]`           | Return persisted sessions sorted for the sidebar.                                            |
-| `session_close`                 | `SessionCloseArgs`              | `SessionCloseResult`      | Kill session PTY, remove records, and optionally remove the Git worktree.                    |
+| `session_close`                 | `SessionCloseArgs`              | `SessionCloseResult`      | Kill session PTY, remove records; delete the Git worktree only after confirmed teardown.     |
 | `session_focus`                 | `SessionIdArg`                  | `void`                    | Persist active session id.                                                                   |
 | `session_resize`                | `SessionResizeArgs`             | `void`                    | Resize live PTY or trigger deferred restore spawn.                                           |
 | `session_input`                 | `SessionInputArgs`              | `void`                    | Write bytes to a session PTY.                                                                |
@@ -151,7 +151,7 @@ Every command must be present in all of these places:
 | `worktree_create`               | `WorktreeCreateArgs`            | `WorktreeCreateResult`    | Create `<workspace>/.arborist/.worktrees/<name>` and maybe start prep.                       |
 | `worktree_prep_open_log`        | `WorktreePrepOpenLogArgs`       | `void`                    | Open a contained worktree-prep log file with the OS default handler.                         |
 | `worktree_tab_open`             | `WorktreeTabOpenArgs`           | `WorktreeTab`             | Open or create a top-level worktree tab.                                                     |
-| `worktree_tab_close`            | `WorktreeTabCloseArgs`          | `WorktreeTabCloseResult`  | Cascade-close child sessions/sub-sessions and optionally remove the worktree.                |
+| `worktree_tab_close`            | `WorktreeTabCloseArgs`          | `WorktreeTabCloseResult`  | Cascade-close child sessions/sub-sessions; delete the worktree only if teardown is clean.    |
 | `worktree_tab_focus`            | `WorktreeTabFocusArgs`          | `void`                    | Persist active worktree tab.                                                                 |
 | `worktree_tab_list`             | none                            | `WorktreeTab[]`           | Return persisted worktree tabs.                                                              |
 | `worktree_tab_reorder`          | `WorktreeTabReorderArgs`        | `void`                    | Replace top-level worktree tab ordering.                                                     |

--- a/docs/runtime-flows.md
+++ b/docs/runtime-flows.md
@@ -136,8 +136,9 @@ Session close:
 
 1. The frontend asks for confirmation.
 2. `session_close` tears down the PTY and removes the session record.
-3. If `deleteWorktree` is true, the backend attempts `git worktree remove --force`.
-4. Worktree deletion failure is returned as `worktreeDeleteError`; the session still closes.
+3. If PTY kill/reap is unconfirmed, `teardownError` is returned and worktree deletion is refused because the process may still hold the worktree cwd.
+4. If `deleteWorktree` is true and teardown was confirmed, the backend attempts `git worktree remove --force`.
+5. Worktree deletion failure is returned as `worktreeDeleteError`; the session still closes.
 
 Worktree-tab close:
 
@@ -145,7 +146,7 @@ Worktree-tab close:
 2. `worktree_tab_close` cascades to child AI sessions and sub-sessions.
 3. Terminal children terminate. Application children detach or terminate according to policy.
 4. Child teardown errors are returned in `childErrors`.
-5. Optional worktree deletion happens after child teardown and reports `worktreeDeleteError` on failure.
+5. Optional worktree deletion happens only when child teardown reported no errors; deletion refusal/failure is returned as `worktreeDeleteError`.
 
 ## Custom-process sub-sessions
 

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -76,4 +76,5 @@ Arborist never writes this file. Malformed overlays are ignored with a warning.
 - Worktree paths are canonicalized before use.
 - Worktree paths are never interpolated into shell commands.
 - The workspace root itself is never deleted by session/worktree close flows.
+- Worktree deletion is refused when child process teardown is unconfirmed.
 - Worktree deletion failures are reported as warnings in command results so UI state can still converge on "tab closed".

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -26,7 +26,7 @@ use tracing::{debug, info, warn};
 use crate::compose::{self, ComposeInputs};
 use crate::config_store::{discover_instructions, list_instructions_for, ConfigStore, MAX_INSTRUCTION_FILE_BYTES};
 use crate::git::{GitRunner, RealGitRunner};
-use crate::pty_pool::{cleanup_orphans, PtyPool, PtySink};
+use crate::pty_pool::{cleanup_orphans, KillOutcome, PtyPool, PtySink};
 use crate::session_metrics::{AiSessionDiscoveryCb, MetricsCb, MetricsRegistry, TurnCb};
 use crate::types::{
     AppError, Error, InstructionSet, PartialAppConfig, Session, SessionCloseResult, SessionCreateArgs, SessionId, SessionInputArgs,
@@ -609,9 +609,24 @@ pub async fn session_close_locked(ctx: &AppContext, id: SessionId, delete_worktr
     };
 
     // 1. Best-effort kill (NotFound from the pool is fine — the session may have
-    //    exited on its own already).
+    //    exited on its own already). If reaping is unconfirmed, keep closing the
+    //    session record for UI convergence, but never proceed to destructive
+    //    worktree deletion: the possible orphan may still hold files or cwd under
+    //    that directory.
+    let mut teardown_error: Option<String> = None;
     if ctx.pool.contains(&id) {
-        ctx.pool.kill(&id).await.map_err(AppError::from)?;
+        match ctx.pool.kill(&id).await.map_err(AppError::from)? {
+            KillOutcome::Reaped => {}
+            KillOutcome::Unconfirmed { pid } => {
+                let msg = format!("session process kill was unconfirmed for pid {pid}; process may still be alive");
+                warn!(
+                    session_id = %id,
+                    pid,
+                    "session close: PTY kill issued but reap unconfirmed; refusing worktree deletion if requested",
+                );
+                teardown_error = Some(msg);
+            }
+        }
     }
 
     // 2. Belt-and-braces temp-dir cleanup. `pool.kill` also does this when the
@@ -648,10 +663,22 @@ pub async fn session_close_locked(ctx: &AppContext, id: SessionId, delete_worktr
     //    from the store at this point, so deletion failure must NOT fail the
     //    overall close (that would leave the frontend unable to converge on a "tab
     //    gone" state). Surface the error in the result instead.
-    let mut result = SessionCloseResult::default();
+    let mut result = SessionCloseResult {
+        teardown_error,
+        ..SessionCloseResult::default()
+    };
     match worktree_intent {
         WorktreeDeleteIntent::Path(wt) => {
-            if let Err(error) = delete_worktree_after_close(ctx, &format!("session {id}"), &wt, &cfg_after.workspace_root) {
+            if let Some(teardown_error) = &result.teardown_error {
+                let msg = format!("refusing to delete worktree because {teardown_error}");
+                warn!(
+                    session_id = %id,
+                    worktree_path = %wt.display(),
+                    error = %msg,
+                    "worktree deletion refused after unconfirmed session close",
+                );
+                result.worktree_delete_error = Some(msg);
+            } else if let Err(error) = delete_worktree_after_close(ctx, &format!("session {id}"), &wt, &cfg_after.workspace_root) {
                 warn!(
                     session_id = %id,
                     worktree_path = %wt.display(),

--- a/src-tauri/src/commands/worktree_tab.rs
+++ b/src-tauri/src/commands/worktree_tab.rs
@@ -182,7 +182,17 @@ pub async fn worktree_tab_close_impl(
         // `acquire_switch_read`, which checks `AppContext::switch_pending` independently of guard ownership and would reject mid-cascade if a
         // workspace switch were queued in the gap, leaving the parent worktree tab removed below but the child session record still present.
         match super::session::session_close_locked(ctx, *sid, false).await {
-            Ok(_) => {}
+            Ok(result) => {
+                if let Some(teardown_error) = result.teardown_error {
+                    warn!(
+                        worktree_tab_id = %id,
+                        session_id = %sid,
+                        error = %teardown_error,
+                        "worktree tab close: child session teardown unconfirmed",
+                    );
+                    child_errors.push(format!("session {sid}: {teardown_error}"));
+                }
+            }
             Err(e) => {
                 warn!(session_id = %sid, error = %e.message, "worktree tab close: child session close failed");
                 child_errors.push(format!("session {sid}: {}", e.message));
@@ -213,7 +223,19 @@ pub async fn worktree_tab_close_impl(
     let mut worktree_delete_error: Option<String> = None;
     if delete_worktree {
         let label = format!("worktree-tab {id}");
-        if let Err(error) = session::delete_worktree_after_close(ctx, &label, &tab_path, &cfg_after.workspace_root) {
+        if !child_errors.is_empty() {
+            let msg = format!(
+                "refusing to delete worktree because child teardown reported errors: {}",
+                child_errors.join("; ")
+            );
+            warn!(
+                worktree_tab_id = %id,
+                worktree_path = %tab_path.display(),
+                error = %msg,
+                "worktree deletion refused after worktree tab close",
+            );
+            worktree_delete_error = Some(msg);
+        } else if let Err(error) = session::delete_worktree_after_close(ctx, &label, &tab_path, &cfg_after.workspace_root) {
             warn!(
                 worktree_tab_id = %id,
                 worktree_path = %tab_path.display(),

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -13,6 +13,7 @@
 //! ```
 //! Blocks are separated by blank lines; the very first one is the main worktree.
 
+use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
@@ -206,6 +207,7 @@ impl GitRunner for RealGitRunner {
             repo_root,
             worktree_path,
             || run_git_worktree_remove(repo_root, worktree_path),
+            || remove_residual_worktree_dir(worktree_path),
             std::thread::sleep,
         )
     }
@@ -294,9 +296,11 @@ fn remove_worktree_with_retry(
     repo_root: &Path,
     worktree_path: &Path,
     mut run: impl FnMut() -> Result<GitCommandResult, Error>,
+    mut remove_residual: impl FnMut() -> io::Result<()>,
     mut sleep: impl FnMut(Duration),
 ) -> Result<(), Error> {
     let mut last_stderr = String::new();
+    let mut saw_retryable_delete_failure = false;
     for attempt in 0.. {
         let output = run()?;
         if output.success {
@@ -308,12 +312,22 @@ fn remove_worktree_with_retry(
         } else {
             output.stderr
         };
+        if saw_retryable_delete_failure && is_already_unregistered_worktree_failure(&last_stderr) {
+            warn!(
+                repo_root = %repo_root.display(),
+                worktree_path = %worktree_path.display(),
+                stderr = %last_stderr,
+                "git worktree remove reports the worktree is already unregistered; deleting residual directory directly",
+            );
+            return remove_residual_worktree_dir_with_retry(repo_root, worktree_path, &mut remove_residual, &mut sleep);
+        }
         let Some(delay_ms) = WORKTREE_REMOVE_RETRY_DELAYS_MS.get(attempt) else {
             break;
         };
         if !is_retryable_worktree_remove_failure(&last_stderr) {
             break;
         }
+        saw_retryable_delete_failure = true;
         warn!(
             repo_root = %repo_root.display(),
             worktree_path = %worktree_path.display(),
@@ -328,6 +342,50 @@ fn remove_worktree_with_retry(
     Err(Error::Internal(format!("git worktree remove failed: {last_stderr}")))
 }
 
+fn remove_residual_worktree_dir(worktree_path: &Path) -> io::Result<()> {
+    match std::fs::remove_dir_all(worktree_path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+fn remove_residual_worktree_dir_with_retry(
+    repo_root: &Path,
+    worktree_path: &Path,
+    remove_residual: &mut impl FnMut() -> io::Result<()>,
+    sleep: &mut impl FnMut(Duration),
+) -> Result<(), Error> {
+    let mut last_error = String::new();
+    for attempt in 0.. {
+        match remove_residual() {
+            Ok(()) => return Ok(()),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => {
+                last_error = e.to_string();
+            }
+        }
+
+        let Some(delay_ms) = WORKTREE_REMOVE_RETRY_DELAYS_MS.get(attempt) else {
+            break;
+        };
+        warn!(
+            repo_root = %repo_root.display(),
+            worktree_path = %worktree_path.display(),
+            attempt = attempt + 1,
+            delay_ms,
+            error = %last_error,
+            "residual worktree directory cleanup hit filesystem error; retrying",
+        );
+        sleep(Duration::from_millis(*delay_ms));
+    }
+
+    Err(Error::Internal(format!(
+        "git worktree remove unregistered the worktree but residual directory cleanup failed for {}: {last_error}",
+        worktree_path.display()
+    )))
+}
+
 fn is_retryable_worktree_remove_failure(stderr: &str) -> bool {
     if !cfg!(windows) {
         return false;
@@ -337,6 +395,11 @@ fn is_retryable_worktree_remove_failure(stderr: &str) -> bool {
         || lower.contains("being used by another process")
         || lower.contains("access is denied")
         || lower.contains("permission denied")
+}
+
+fn is_already_unregistered_worktree_failure(stderr: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    lower.contains("not a working tree") || lower.contains("not a worktree")
 }
 
 /// Parse `git worktree list --porcelain` output. The first block is the main worktree; subsequent blocks are linked worktrees. Detached HEADs produce
@@ -717,6 +780,7 @@ locked migrating to slow disk
                     }
                 })
             },
+            || panic!("residual cleanup must not run after a successful git retry"),
             |delay| sleeps.borrow_mut().push(delay),
         )
         .expect("second attempt should succeed");
@@ -745,12 +809,94 @@ locked migrating to slow disk
                     stderr: "fatal: not a git repository".to_owned(),
                 })
             },
+            || panic!("residual cleanup must not run for non-transient failures"),
             |_| panic!("non-transient failure must not sleep/retry"),
         )
         .expect_err("non-transient git failure should surface");
 
         assert_eq!(calls.get(), 1);
         assert!(matches!(err, Error::Internal(msg) if msg.contains("fatal: not a git repository")));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn remove_worktree_cleans_residual_dir_when_git_unregistered_after_transient_delete_failure() {
+        let repo_root = Path::new(r"C:\repo");
+        let worktree_path = Path::new(r"C:\repo\.arborist\.worktrees\feature");
+        let calls = std::cell::Cell::new(0usize);
+        let residual_calls = std::cell::Cell::new(0usize);
+        let sleeps = std::cell::RefCell::new(Vec::new());
+
+        remove_worktree_with_retry(
+            repo_root,
+            worktree_path,
+            || {
+                let n = calls.get();
+                calls.set(n + 1);
+                Ok(if n == 0 {
+                    GitCommandResult {
+                        success: false,
+                        stderr: "error: failed to delete 'feature': Directory not empty".to_owned(),
+                    }
+                } else {
+                    GitCommandResult {
+                        success: false,
+                        stderr: "fatal: 'C:\\repo\\.arborist\\.worktrees\\feature' is not a working tree".to_owned(),
+                    }
+                })
+            },
+            || {
+                residual_calls.set(residual_calls.get() + 1);
+                Ok(())
+            },
+            |delay| sleeps.borrow_mut().push(delay),
+        )
+        .expect("residual directory cleanup should complete the partially unregistered removal");
+
+        assert_eq!(calls.get(), 2);
+        assert_eq!(residual_calls.get(), 1);
+        assert_eq!(&*sleeps.borrow(), &[Duration::from_millis(25)]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn remove_worktree_reports_residual_cleanup_failure_after_git_unregisters() {
+        let repo_root = Path::new(r"C:\repo");
+        let worktree_path = Path::new(r"C:\repo\.arborist\.worktrees\feature");
+        let calls = std::cell::Cell::new(0usize);
+        let residual_calls = std::cell::Cell::new(0usize);
+        let sleeps = std::cell::RefCell::new(Vec::new());
+
+        let err = remove_worktree_with_retry(
+            repo_root,
+            worktree_path,
+            || {
+                let n = calls.get();
+                calls.set(n + 1);
+                Ok(if n == 0 {
+                    GitCommandResult {
+                        success: false,
+                        stderr: "error: failed to delete 'feature': Directory not empty".to_owned(),
+                    }
+                } else {
+                    GitCommandResult {
+                        success: false,
+                        stderr: "fatal: 'C:\\repo\\.arborist\\.worktrees\\feature' is not a working tree".to_owned(),
+                    }
+                })
+            },
+            || {
+                residual_calls.set(residual_calls.get() + 1);
+                Err(io::Error::new(io::ErrorKind::PermissionDenied, "still locked"))
+            },
+            |delay| sleeps.borrow_mut().push(delay),
+        )
+        .expect_err("residual cleanup failure should surface");
+
+        assert_eq!(calls.get(), 2);
+        assert_eq!(residual_calls.get(), WORKTREE_REMOVE_RETRY_DELAYS_MS.len() + 1);
+        assert_eq!(sleeps.borrow().len(), WORKTREE_REMOVE_RETRY_DELAYS_MS.len() + 1);
+        assert!(matches!(err, Error::Internal(msg) if msg.contains("residual directory cleanup failed") && msg.contains("still locked")));
     }
 
     /// Build a `Command` with both repo-selection *and* identity/config `GIT_*` variables stripped. Tests get a stricter scrub than production

--- a/src-tauri/tests/session_lifecycle_fake.rs
+++ b/src-tauri/tests/session_lifecycle_fake.rs
@@ -52,6 +52,7 @@ struct SpawnerState {
 
 struct FakeSpawner {
     state: Mutex<SpawnerState>,
+    kill_fails: Arc<AtomicBool>,
 }
 
 impl FakeSpawner {
@@ -61,7 +62,12 @@ impl FakeSpawner {
                 next_pid: 9000,
                 ..SpawnerState::default()
             }),
+            kill_fails: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    fn set_kill_fails(&self, value: bool) {
+        self.kill_fails.store(value, Ordering::SeqCst);
     }
 }
 
@@ -90,7 +96,10 @@ impl PtySpawner for FakeSpawner {
             writer: Box::new(WriteCapture),
             resize: Arc::new(NoopResize),
             waiter: Box::new(BlockingWaiter { eof: Arc::clone(&eof) }),
-            killer: Arc::new(EofKiller { eof }),
+            killer: Arc::new(EofKiller {
+                eof,
+                fail: Arc::clone(&self.kill_fails),
+            }),
         })
     }
 }
@@ -127,10 +136,14 @@ impl PtyResize for NoopResize {
 
 struct EofKiller {
     eof: Arc<AtomicBool>,
+    fail: Arc<AtomicBool>,
 }
 impl PtyKiller for EofKiller {
     fn kill(&self) -> Result<(), arborist_lib::types::Error> {
         self.eof.store(true, Ordering::Relaxed);
+        if self.fail.load(Ordering::SeqCst) {
+            return Err(arborist_lib::types::Error::PtyKillFailed("injected kill failure".into()));
+        }
         Ok(())
     }
 }
@@ -863,6 +876,42 @@ async fn close_with_delete_worktree_invokes_git_runner_remove() {
     );
     // Session record is gone regardless.
     assert!(session_list_impl(&h.ctx).unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn close_with_delete_worktree_refuses_git_remove_when_kill_unconfirmed() {
+    let git = RecordingGitRunner::new();
+    let h = build_harness_with_git(git.clone() as Arc<dyn GitRunner>);
+    let ws_root = h.worktree.path().parent().unwrap().to_path_buf();
+    h.ctx
+        .store()
+        .save_config(PartialAppConfig {
+            workspace_root: Some(Some(ws_root)),
+            ..Default::default()
+        })
+        .unwrap();
+    let view = session_create_impl(&h.ctx, create_args(&h)).unwrap();
+    h.spawner.set_kill_fails(true);
+
+    let result = session_close_impl(&h.ctx, view.id, true)
+        .await
+        .expect("close itself should succeed so the UI can converge");
+
+    let teardown = result.teardown_error.expect("unconfirmed kill should be reported");
+    assert!(teardown.contains("unconfirmed"), "unexpected teardown error: {teardown}");
+    let delete_error = result.worktree_delete_error.expect("delete should be refused when kill is unconfirmed");
+    assert!(
+        delete_error.contains("refusing to delete worktree") && delete_error.contains("unconfirmed"),
+        "unexpected delete error: {delete_error}",
+    );
+    assert!(
+        git.removes.lock().unwrap().is_empty(),
+        "git worktree remove must not run when the PTY may still be alive in that worktree"
+    );
+    assert!(
+        session_list_impl(&h.ctx).unwrap().is_empty(),
+        "session record should still be removed for close convergence"
+    );
 }
 
 #[tokio::test]

--- a/src-tauri/tests/sub_sessions_e2e.rs
+++ b/src-tauri/tests/sub_sessions_e2e.rs
@@ -6,7 +6,7 @@
 
 use std::collections::BTreeMap;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -16,12 +16,14 @@ use arborist_lib::commands::session::{session_create_impl, AppContext};
 use arborist_lib::commands::subsession::{
     close_for_worktree_tab_impl, restore_all_sub_sessions_impl, subsession_close_impl, subsession_create_impl, subsession_relaunch_impl,
 };
+use arborist_lib::commands::worktree_tab::worktree_tab_close_impl;
 use arborist_lib::config_store::ConfigStore;
+use arborist_lib::git::GitRunner;
 use arborist_lib::pty_pool::{ChildCommand, PtyKiller, PtyPool, PtyResize, PtySink, PtySpawner, PtyWaiter, SpawnedChild};
 use arborist_lib::sub_sessions::{SubPtyPool, SubPtySink, SubSessionStore};
 use arborist_lib::types::{
     ChildId, CustomProcessDef, CustomProcessDefId, CustomProcessKind, InstructionSetId, PartialAppConfig, PartialDefaultInstructionSets,
-    SessionCreateArgs, SessionId, SessionStatus, SubSessionCloseIntent, SubSessionCreateArgs, SubSessionStatus, Tool, WorktreeTab,
+    SessionCreateArgs, SessionId, SessionStatus, SubSessionCloseIntent, SubSessionCreateArgs, SubSessionStatus, Tool, WorktreeInfo, WorktreeTab,
     WorktreeTabAppClosePolicy, WorktreeTabId,
 };
 use arborist_lib::window_focus::RecordingFocuser;
@@ -229,6 +231,40 @@ impl AppKiller for FakeAppKiller {
     }
 }
 
+#[derive(Default)]
+struct RecordingGitRunner {
+    removes: Mutex<Vec<(PathBuf, PathBuf)>>,
+}
+
+impl RecordingGitRunner {
+    fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+}
+
+impl GitRunner for RecordingGitRunner {
+    fn list_worktrees(&self, _: &Path) -> Result<Vec<WorktreeInfo>, arborist_lib::types::Error> {
+        Ok(vec![])
+    }
+
+    fn git_toplevel(&self, path: &Path) -> Result<Option<PathBuf>, arborist_lib::types::Error> {
+        Ok(Some(path.to_path_buf()))
+    }
+
+    fn create_worktree(&self, repo_root: &Path, relative_path: &Path, _branch: &str) -> Result<PathBuf, arborist_lib::types::Error> {
+        Ok(repo_root.join(relative_path))
+    }
+
+    fn remove_worktree(&self, repo_root: &Path, worktree_path: &Path) -> Result<(), arborist_lib::types::Error> {
+        self.removes.lock().unwrap().push((repo_root.to_path_buf(), worktree_path.to_path_buf()));
+        Ok(())
+    }
+
+    fn git_status(&self, _worktree_path: &Path) -> Result<arborist_lib::types::WorktreeGitStatus, arborist_lib::types::Error> {
+        Ok(arborist_lib::types::WorktreeGitStatus::default())
+    }
+}
+
 // --------------------------------------------------------------------------- Capturing sinks
 // ---------------------------------------------------------------------------
 
@@ -273,6 +309,7 @@ struct Harness {
     ctx: Arc<AppContext>,
     sub_ctx: Arc<arborist_lib::sub_sessions::SubAppContext>,
     sub_pool: Arc<SubPtyPool>,
+    parent_spawner_flags: SpawnerFlags,
     sub_spawner_flags: SpawnerFlags,
     app_spawner: FakeAppSpawner,
     sub_events: Arc<CapturedSubEvents>,
@@ -286,6 +323,10 @@ struct Harness {
 }
 
 fn build_harness() -> Harness {
+    build_harness_with_git(Arc::new(arborist_lib::git::RealGitRunner) as Arc<dyn GitRunner>)
+}
+
+fn build_harness_with_git(git: Arc<dyn GitRunner>) -> Harness {
     let config_dir = TempDir::new().unwrap();
     let instructions_dir = TempDir::new().unwrap();
     let worktree = TempDir::new().unwrap();
@@ -348,13 +389,14 @@ fn build_harness() -> Harness {
         .unwrap();
 
     let parent_spawner = Arc::new(FakeSpawner::new());
+    let parent_spawner_flags = parent_spawner.flags();
     let parent_pool = Arc::new(PtyPool::new(parent_spawner.clone() as Arc<dyn PtySpawner>));
     let parent_sink = make_parent_sink(store.clone());
     let ctx = Arc::new(AppContext::new(
         parent_pool,
         store.clone(),
         parent_sink,
-        Arc::new(arborist_lib::git::RealGitRunner),
+        git,
         Arc::new(|_| {}),
         Arc::new(|_, _| {}),
         Arc::new(|_, _| {}),
@@ -387,6 +429,7 @@ fn build_harness() -> Harness {
         ctx,
         sub_ctx,
         sub_pool,
+        parent_spawner_flags,
         sub_spawner_flags,
         app_spawner,
         sub_events,
@@ -469,6 +512,51 @@ async fn cascade_kills_terminal_subs_and_prunes_persistence() {
     assert!(!h.sub_pool.contains(&sub_b.id), "sub_b still in pool");
     assert!(h.sub_ctx.store.list_for_worktree_tab(&h.worktree_tab_id).is_empty(), "store not pruned");
     assert!(h.ctx.store().load_config().last_open_sub_sessions.is_empty(), "persistence not pruned");
+}
+
+#[tokio::test]
+async fn worktree_tab_close_refuses_delete_when_child_session_kill_is_unconfirmed() {
+    let git = RecordingGitRunner::new();
+    let h = build_harness_with_git(git.clone() as Arc<dyn GitRunner>);
+    h.ctx
+        .store()
+        .save_config(PartialAppConfig {
+            workspace_root: Some(Some(h.worktree.path().parent().unwrap().to_path_buf())),
+            ..Default::default()
+        })
+        .unwrap();
+    let parent = create_parent(&h);
+    h.parent_spawner_flags.kill_fails.store(true, Ordering::SeqCst);
+
+    let result = worktree_tab_close_impl(
+        &h.ctx,
+        Arc::clone(&h.sub_ctx),
+        h.worktree_tab_id,
+        true,
+        WorktreeTabAppClosePolicy::Terminate,
+    )
+    .await
+    .expect("worktree tab close should converge even when child teardown is unconfirmed");
+
+    assert!(
+        result
+            .child_errors
+            .iter()
+            .any(|msg| msg.contains(&parent.id.to_string()) && msg.contains("unconfirmed")),
+        "child teardown warning should be returned, got {:?}",
+        result.child_errors,
+    );
+    let delete_error = result
+        .worktree_delete_error
+        .expect("worktree deletion should be refused when a child may still be alive");
+    assert!(
+        delete_error.contains("refusing to delete worktree") && delete_error.contains("child teardown") && delete_error.contains("unconfirmed"),
+        "unexpected delete error: {delete_error}",
+    );
+    assert!(
+        git.removes.lock().unwrap().is_empty(),
+        "git worktree remove must not run after unconfirmed child teardown"
+    );
 }
 
 #[tokio::test]

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -116,8 +116,9 @@ export interface SessionCloseArgs {
 }
 
 /**
- * Result of `session_close`. The session record + PTY are always torn
- * down on success; if the user opted into worktree deletion and the
+ * Result of `session_close`. The session record is removed on success; if
+ * PTY teardown was unconfirmed, `teardownError` is populated and worktree
+ * deletion is refused. If the user opted into worktree deletion and the
  * `git worktree remove` step failed, that failure is reported here as a
  * warning string instead of as a hard error so the UI can converge on a
  * "tab gone" state regardless.
@@ -125,6 +126,7 @@ export interface SessionCloseArgs {
  * MIRROR: `src-tauri/src/types.rs::SessionCloseResult`.
  */
 export interface SessionCloseResult {
+  teardownError?: string | null;
   worktreeDeleteError: string | null;
 }
 


### PR DESCRIPTION
## Summary
- refuse worktree deletion when PTY/session teardown is unconfirmed
- prevent worktree-tab deletion when child teardown reports errors
- handle Windows partial `git worktree remove` unregisters by retrying residual directory cleanup

## Validation
- pnpm run build
- pnpm run lint
- pnpm test --run
- cargo clippy --workspace --all-targets --features test-helpers -- -D warnings
- cargo test --workspace --features test-helpers