### PR TITLE
[app-metadata] Finalize public metadata

### DIFF
--- a/crates/arborist-types/Cargo.toml
+++ b/crates/arborist-types/Cargo.toml
@@ -2,9 +2,12 @@
 name = "arborist-types"
 version = "0.1.0"
 edition = "2021"
-description = "Shared, serializable wire-contract types for Arborist (frontend↔backend boundary)."
-authors = ["Arborist contributors"]
+description = "Shared serializable wire-contract types for Arborist's frontend/backend boundary."
+authors = ["Aaron Moore", "Arborist contributors"]
 license = "MIT"
+repository = "https://github.com/mcaden/arborist"
+homepage = "https://arborist.tools"
+readme = "../../README.md"
 publish = false
 
 [lib]

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -11,8 +11,22 @@ GitHub Release and generates GitHub build attestations.
   - `package.json`
   - `src-tauri/tauri.conf.json`
   - `src-tauri/Cargo.toml`
+  - `crates/arborist-types/Cargo.toml`
 
 After changing the Rust crate version, run a Cargo command that updates `Cargo.lock` if needed.
+
+## Metadata policy
+
+- The public app identifier is `io.github.mcaden.arborist`. Changing it later changes OS app identity and app data/config paths, so do not change it
+  after public installs without a migration plan.
+- `package.json`, Rust package metadata, and Tauri bundle metadata describe Arborist as a cross-platform desktop app for managing AI coding-assistant
+  sessions across Git worktrees.
+- Package metadata names Aaron Moore as author and `Arborist contributors` as contributors. Rust crates list both in `authors` because Cargo does not
+  have a contributors field.
+- Frontend and Rust packages are not published independently today: `package.json` stays `"private": true`, and Rust crates stay `publish = false`.
+- Public homepage metadata points to `https://arborist.tools`; repository metadata points to `https://github.com/mcaden/arborist`.
+- Keep the GitHub repository description and topics aligned with the README. Current launch topics: `tauri`, `react`, `rust`, `typescript`,
+  `git-worktree`, and `ai-tools`.
 
 ## Cut a release
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,20 @@
   "name": "arborist",
   "private": true,
   "version": "0.1.0",
+  "description": "Cross-platform desktop app for managing AI coding-assistant sessions across Git worktrees.",
+  "license": "MIT",
+  "author": "Aaron Moore",
+  "contributors": [
+    "Arborist contributors"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mcaden/arborist.git"
+  },
+  "bugs": {
+    "url": "https://github.com/mcaden/arborist/issues"
+  },
+  "homepage": "https://arborist.tools",
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,9 +2,12 @@
 name = "arborist"
 version = "0.1.0"
 edition = "2021"
-description = "Arborist — multi-session manager for AI coding CLIs"
-authors = ["Arborist contributors"]
+description = "Cross-platform desktop app for managing AI coding-assistant sessions across Git worktrees."
+authors = ["Aaron Moore", "Arborist contributors"]
 license = "MIT"
+repository = "https://github.com/mcaden/arborist"
+homepage = "https://arborist.tools"
+readme = "../README.md"
 publish = false
 default-run = "arborist"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Arborist",
   "version": "0.1.0",
-  "identifier": "dev.arborist.desktop",
+  "identifier": "io.github.mcaden.arborist",
   "build": {
     "beforeDevCommand": "pnpm run vite",
     "devUrl": "http://localhost:1420",
@@ -54,6 +54,14 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "publisher": "Aaron Moore",
+    "homepage": "https://arborist.tools",
+    "copyright": "Copyright (c) 2026 Aaron Moore",
+    "license": "MIT",
+    "licenseFile": "../LICENSE",
+    "category": "DeveloperTool",
+    "shortDescription": "Manage AI coding-assistant sessions across Git worktrees.",
+    "longDescription": "Arborist manages Claude CLI, GitHub Copilot CLI, and custom process sessions across Git worktrees.",
     "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.png", "icons/icon.icns", "icons/icon.ico"]
   }
 }


### PR DESCRIPTION
## Summary
- Add public package metadata to `package.json` while keeping the frontend package private.
- Add Rust package metadata and keep both crates `publish = false`.
- Confirm the public Tauri app identifier as `io.github.mcaden.arborist` and add Tauri bundle metadata.
- Document release metadata policy and point homepage metadata to `https://arborist.tools`.
- Update GitHub repository homepage/topics/description and the Pages follow-up issue for `arborist.tools`.

Closes #117
Related #128

## Checks
- `pnpm run lint`
- `pnpm run build`
- `cargo metadata --format-version 1 --no-deps --quiet`
- pre-push hook (`pnpm test --run`, `cargo test --workspace --features test-helpers`)