### PR TITLE
[github-pages] Create GitHub Pages site for Arborist

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,8 +36,12 @@ jobs:
           test -f website/styles.css
           test -f website/CNAME
           grep -qFx "arborist.tools" website/CNAME
-          if grep -RInE '<script|src="https?://' website; then
-            echo "::error::The Pages site must not include scripts or remote script/embed assets."
+          if grep -RInE '<script|src="https?://|href="https?://|srcset="https?://' website --include='*.html'; then
+            echo "::error::The Pages site must not include scripts or remote assets in HTML files."
+            exit 1
+          fi
+          if grep -RInE 'url\(https?://' website --include='*.css'; then
+            echo "::error::The Pages site must not load remote resources from CSS."
             exit 1
           fi
           if grep -RInE '(href|src)="/' website; then

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,6 +40,10 @@ jobs:
             echo "::error::The Pages site must not include scripts or remote resource-loading attributes."
             exit 1
           fi
+          if grep -RinE '\bon[a-z]+\s*=' website --include='*.html'; then
+            echo "::error::The Pages site must not include inline event handlers."
+            exit 1
+          fi
           if grep -RInE '<link[^>]+(stylesheet|preload|icon|manifest)[^>]+href="https?://' website --include='*.html'; then
             echo "::error::The Pages site must not load remote stylesheets, fonts, or icons."
             exit 1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,54 @@
+name: Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy GitHub Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/configure-pages@v5
+
+      - name: Validate static website
+        run: |
+          set -euo pipefail
+          test -f website/index.html
+          test -f website/styles.css
+          test -f website/CNAME
+          grep -qFx "arborist.tools" website/CNAME
+          if grep -RInE '<script|src="https?://' website; then
+            echo "::error::The Pages site must not include scripts or remote script/embed assets."
+            exit 1
+          fi
+          if grep -RInE '(href|src)="/' website; then
+            echo "::error::Use relative asset URLs so the mcaden.github.io/arborist fallback works."
+            exit 1
+          fi
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: website
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,8 +36,16 @@ jobs:
           test -f website/styles.css
           test -f website/CNAME
           grep -qFx "arborist.tools" website/CNAME
-          if grep -RInE '<script|src="https?://|href="https?://|srcset="https?://' website --include='*.html'; then
-            echo "::error::The Pages site must not include scripts or remote assets in HTML files."
+          if grep -RInE '<script|srcset="https?://' website --include='*.html'; then
+            echo "::error::The Pages site must not include scripts or remote resource-loading attributes."
+            exit 1
+          fi
+          if grep -RInE '<link[^>]+(stylesheet|preload|icon|manifest)[^>]+href="https?://' website --include='*.html'; then
+            echo "::error::The Pages site must not load remote stylesheets, fonts, or icons."
+            exit 1
+          fi
+          if grep -RInE '<(img|source|video|audio|embed|iframe)[^>]+src="https?://' website --include='*.html'; then
+            echo "::error::The Pages site must not embed remote media or iframes."
             exit 1
           fi
           if grep -RInE 'url\(https?://' website --include='*.css'; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,11 +154,10 @@ jobs:
           releaseBody: |
             See the assets below to download installers for your platform.
 
-            **Note:** these builds are not OS code-signed (no Apple
-            notarization or Authenticode signature), so each OS will show a
-            one-time warning on first launch. See the
+            These builds are OS-signed and notarized where each platform
+            supports it. See the
             [README](https://github.com/${{ github.repository }}#install) for
-            first-run instructions on macOS, Windows, and Linux.
+            install instructions on macOS, Windows, and Linux.
 
             Every published asset has a Sigstore-signed
             [GitHub build attestation](https://github.com/${{ github.repository }}/attestations).

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 It gives each worktree its own persistent terminal-backed context for Claude CLI, GitHub Copilot CLI, and configured custom processes. Worktree tabs
 live in a sidebar; the main area shows the active worktree dashboard or terminal while background PTYs keep running.
 
+Website: [https://arborist.tools](https://arborist.tools)
+
 ## Status
 
-Arborist is pre-1.0 and preparing for public open-source use. Expect active changes to docs, workflows, and APIs while the project stabilizes.
+Arborist is a public open-source desktop app. Expect active changes to docs, workflows, and APIs while the project stabilizes.
 
 ## What it does
 
@@ -23,11 +25,10 @@ Arborist is pre-1.0 and preparing for public open-source use. Expect active chan
 
 ## Install for users
 
-Arborist has not published a stable release yet. When prerelease installers are available, download them from the
-[Releases page](https://github.com/mcaden/arborist/releases). Until then, use the contributor setup below to run Arborist locally.
+Download signed installers from the [Releases page](https://github.com/mcaden/arborist/releases). Contributors can also use the setup below to run
+Arborist locally from source.
 
-Release artifacts are not OS code-signed unless a release note says otherwise, so first launch may show Windows SmartScreen or macOS Gatekeeper
-warnings. Published assets should have GitHub build attestations:
+Release artifacts are OS-signed and notarized where each platform supports it. Published assets include GitHub build attestations:
 
 ```sh
 gh attestation verify <downloaded-file> --repo mcaden/arborist

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,11 +77,11 @@ forks may retain it.
 
 ## Release trust
 
-Release artifacts are unsigned by OS code-signing systems unless release notes say otherwise. GitHub build attestations are published for release
-assets and can be verified with:
+Release artifacts are OS-signed and notarized where each platform supports it. GitHub build attestations are published for release assets and can be
+verified with:
 
 ```sh
 gh attestation verify <downloaded-file> --repo mcaden/arborist
 ```
 
-Unsigned binaries may trigger Windows SmartScreen or macOS Gatekeeper first-run warnings. See [releasing](docs/releasing.md) for release mechanics.
+See [releasing](docs/releasing.md) for release mechanics.

--- a/docs/product.md
+++ b/docs/product.md
@@ -127,4 +127,3 @@ Success looks like:
 - In-app instruction-file editing.
 - A general third-party plugin marketplace.
 - Automatic app updates.
-- Code signing and notarization.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -28,6 +28,33 @@ After changing the Rust crate version, run a Cargo command that updates `Cargo.l
 - Keep the GitHub repository description and topics aligned with the README. Current launch topics: `tauri`, `react`, `rust`, `typescript`,
   `git-worktree`, and `ai-tools`.
 
+## Project website and GitHub Pages
+
+The public website is published from `website/` by `.github/workflows/pages.yml` using GitHub Actions artifact deployment. The primary public URL is
+`https://arborist.tools`; `https://mcaden.github.io/arborist/` is the fallback and diagnostic GitHub Pages URL.
+
+Preview the committed static site locally without starting the Tauri app:
+
+```sh
+pnpm run website:dev
+```
+
+The preview serves `http://127.0.0.1:4173/` and also maps `http://127.0.0.1:4173/arborist/` to the same files so the GitHub Pages fallback path can be
+checked locally. Use `pnpm run website:dev -- --port 4174` if the default port is busy.
+
+Keep these values aligned when changing site or release metadata:
+
+- `website/CNAME`
+- GitHub Pages custom-domain settings and DNS for `arborist.tools`
+- the GitHub repository homepage URL
+- `package.json` homepage metadata
+- Rust package `homepage` fields
+- Tauri bundle `homepage`
+
+Pages uses **GitHub Actions** as the source with the `arborist.tools` custom domain. Maintainers keep DNS, HTTPS provisioning, and repository settings
+aligned with `website/CNAME`. The website is curated for public users and contributors; it should not imply package-manager distribution or automatic
+updates because signed installers are distributed through GitHub Releases.
+
 ## Cut a release
 
 1. Land the version bump through PR.
@@ -64,10 +91,9 @@ The exact filenames are produced by Tauri and include the version.
 
 ## Trust and signing
 
-Release artifacts are not OS code-signed unless a future release note says otherwise. Users should expect first-run warnings from Windows SmartScreen
-and macOS Gatekeeper.
+Release artifacts are OS-signed and notarized where each platform supports it. Signed installers are distributed through GitHub Releases.
 
-Every published release artifact should have a GitHub build attestation:
+Every published release artifact has a GitHub build attestation:
 
 ```sh
 gh attestation verify <downloaded-file> --repo mcaden/arborist
@@ -78,8 +104,8 @@ Attestations prove the artifact was produced by the repository workflow for the 
 ## Release smoke checklist
 
 - Windows installer completes and the app launches.
-- Windows SmartScreen warning is dismissible.
-- macOS DMG opens; right-click Open works on first launch.
+- Windows installer publisher and signature are verified.
+- macOS DMG opens and Gatekeeper verifies the notarized app.
 - Linux AppImage runs after `chmod +x`.
 - Linux `.deb` installs and launches.
 - First-boot workspace picker accepts a primary clone and rejects a linked worktree.
@@ -93,8 +119,6 @@ Use a throwaway tag to validate workflow changes. Delete the draft release and t
 
 ## Out of scope today
 
-- Apple notarization.
-- Authenticode signing.
 - Auto-updates.
 - Package-manager distribution.
 - ARM Linux release artifacts.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,7 +21,7 @@ This page tracks known gaps and follow-up work. It is not a promise of delivery 
 | Application focus       | Launcher wrappers and Wayland limitations make app focus best-effort. Better owner discovery can improve this per platform.               |
 | Instruction management  | Users manage instruction files on disk. An in-app editor remains out of scope for v1 but is a natural later feature.                      |
 
-## Public open-source readiness
+## Public project operations
 
 | Area              | Gap                                                                                                            |
 | ----------------- | -------------------------------------------------------------------------------------------------------------- |
@@ -37,5 +37,4 @@ This page tracks known gaps and follow-up work. It is not a promise of delivery 
 - Public plugin API.
 - Built-in chat UI.
 - Automatic updates.
-- OS code signing and notarization.
 - Package-manager distribution.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dev": "node scripts/tauri-dev.mjs",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
+    "website:dev": "node scripts/serve-website.mjs",
     "vite": "vite",
     "tauri": "tauri",
     "tauri:dev": "node scripts/tauri-dev.mjs",

--- a/scripts/serve-website.mjs
+++ b/scripts/serve-website.mjs
@@ -139,6 +139,14 @@ async function fileForRequest(pathname) {
       if (!isInsideWebsiteRoot(indexPath)) {
         return { status: 403, message: 'Forbidden.' };
       }
+      try {
+        const indexInfo = await stat(indexPath);
+        if (!indexInfo.isFile()) {
+          return { status: 404, message: 'Not found.' };
+        }
+      } catch {
+        return { status: 404, message: 'Not found.' };
+      }
       return { filePath: indexPath };
     }
     if (!info.isFile()) {

--- a/scripts/serve-website.mjs
+++ b/scripts/serve-website.mjs
@@ -160,7 +160,8 @@ async function handleRequest(req, res, host) {
     return;
   }
 
-  const url = new URL(req.url ?? '/', `http://${host}`);
+  const urlHost = host.includes(':') ? `[${host}]` : host;
+  const url = new URL(req.url ?? '/', `http://${urlHost}`);
   const result = await fileForRequest(url.pathname);
 
   if (result.redirectTo) {
@@ -201,9 +202,10 @@ function startServer({ host, port }) {
   });
 
   server.listen(port, host, () => {
+    const displayHost = host.includes(':') ? `[${host}]` : host;
     process.stdout.write(`Serving ${websiteRoot}\n`);
-    process.stdout.write(`  Local URL: http://${host}:${port}/\n`);
-    process.stdout.write(`  Pages fallback path: http://${host}:${port}${FALLBACK_BASE}/\n`);
+    process.stdout.write(`  Local URL: http://${displayHost}:${port}/\n`);
+    process.stdout.write(`  Pages fallback path: http://${displayHost}:${port}${FALLBACK_BASE}/\n`);
     process.stdout.write('Press Ctrl+C to stop.\n');
   });
 }

--- a/scripts/serve-website.mjs
+++ b/scripts/serve-website.mjs
@@ -1,0 +1,219 @@
+import { createServer } from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { basename, dirname, extname, isAbsolute, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_HOST = '127.0.0.1';
+const DEFAULT_PORT = 4173;
+const FALLBACK_BASE = '/arborist';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const websiteRoot = join(repoRoot, 'website');
+
+const contentTypes = new Map([
+  ['.css', 'text/css; charset=utf-8'],
+  ['.html', 'text/html; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.svg', 'image/svg+xml; charset=utf-8'],
+  ['.txt', 'text/plain; charset=utf-8'],
+  ['.webmanifest', 'application/manifest+json; charset=utf-8'],
+  ['.xml', 'application/xml; charset=utf-8'],
+]);
+
+function usage() {
+  return `Usage: pnpm run website:dev -- [--host <host>] [--port <port>]
+
+Serves website/ as static files for local testing.
+The server maps both / and /arborist/ to website/ so the GitHub Pages fallback path can be checked locally.
+`;
+}
+
+function readOptionValue(argv, index, optionName) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`Missing value for ${optionName}`);
+  }
+  return value;
+}
+
+function parseArgs(argv) {
+  let host = DEFAULT_HOST;
+  let port = DEFAULT_PORT;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      process.stdout.write(usage());
+      process.exitCode = 0;
+      return null;
+    }
+    if (arg === '--host') {
+      host = readOptionValue(argv, i, arg);
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--host=')) {
+      host = arg.slice('--host='.length);
+      continue;
+    }
+    if (arg === '--port') {
+      port = parsePort(readOptionValue(argv, i, arg));
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--port=')) {
+      port = parsePort(arg.slice('--port='.length));
+      continue;
+    }
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  return { host, port };
+}
+
+function parsePort(value) {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid port: ${value}`);
+  }
+  return port;
+}
+
+function contentTypeFor(filePath) {
+  if (basename(filePath) === 'CNAME') {
+    return 'text/plain; charset=utf-8';
+  }
+  return contentTypes.get(extname(filePath).toLowerCase()) ?? 'application/octet-stream';
+}
+
+function isInsideWebsiteRoot(filePath) {
+  const rel = relative(websiteRoot, filePath);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+function sendText(res, status, body) {
+  res.writeHead(status, {
+    'Cache-Control': 'no-store',
+    'Content-Type': 'text/plain; charset=utf-8',
+    'X-Content-Type-Options': 'nosniff',
+  });
+  res.end(body);
+}
+
+function resolveRequestPath(pathname) {
+  if (pathname === FALLBACK_BASE) {
+    return { redirectTo: `${FALLBACK_BASE}/` };
+  }
+
+  const strippedPath = pathname.startsWith(`${FALLBACK_BASE}/`) ? pathname.slice(FALLBACK_BASE.length) : pathname;
+  const normalizedPath = strippedPath === '/' ? '/index.html' : strippedPath;
+  let decodedPath;
+  try {
+    decodedPath = decodeURIComponent(normalizedPath);
+  } catch {
+    return { status: 400, message: 'Bad request: invalid URL encoding.' };
+  }
+
+  if (decodedPath.includes('\0')) {
+    return { status: 400, message: 'Bad request: null bytes are not allowed.' };
+  }
+
+  const filePath = resolve(websiteRoot, `.${decodedPath}`);
+  if (!isInsideWebsiteRoot(filePath)) {
+    return { status: 403, message: 'Forbidden.' };
+  }
+
+  return { filePath };
+}
+
+async function fileForRequest(pathname) {
+  const resolved = resolveRequestPath(pathname);
+  if (!resolved.filePath) {
+    return resolved;
+  }
+
+  try {
+    const info = await stat(resolved.filePath);
+    if (info.isDirectory()) {
+      const indexPath = join(resolved.filePath, 'index.html');
+      if (!isInsideWebsiteRoot(indexPath)) {
+        return { status: 403, message: 'Forbidden.' };
+      }
+      return { filePath: indexPath };
+    }
+    if (!info.isFile()) {
+      return { status: 404, message: 'Not found.' };
+    }
+    return resolved;
+  } catch (err) {
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+      return { status: 404, message: 'Not found.' };
+    }
+    throw err;
+  }
+}
+
+async function handleRequest(req, res, host) {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    res.writeHead(405, { Allow: 'GET, HEAD' });
+    res.end();
+    return;
+  }
+
+  const url = new URL(req.url ?? '/', `http://${host}`);
+  const result = await fileForRequest(url.pathname);
+
+  if (result.redirectTo) {
+    res.writeHead(301, { Location: result.redirectTo });
+    res.end();
+    return;
+  }
+  if (!result.filePath) {
+    sendText(res, result.status ?? 500, result.message ?? 'Internal server error.');
+    return;
+  }
+
+  const body = await readFile(result.filePath);
+  res.writeHead(200, {
+    'Cache-Control': 'no-store',
+    'Content-Length': body.length,
+    'Content-Type': contentTypeFor(result.filePath),
+    'X-Content-Type-Options': 'nosniff',
+  });
+  res.end(req.method === 'HEAD' ? undefined : body);
+}
+
+function startServer({ host, port }) {
+  const server = createServer((req, res) => {
+    handleRequest(req, res, host).catch((err) => {
+      process.stderr.write(`Website server error: ${err instanceof Error ? err.message : String(err)}\n`);
+      if (res.headersSent) {
+        res.destroy();
+        return;
+      }
+      sendText(res, 500, 'Internal server error.');
+    });
+  });
+
+  server.on('error', (err) => {
+    process.stderr.write(`Unable to start website server: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exitCode = 1;
+  });
+
+  server.listen(port, host, () => {
+    process.stdout.write(`Serving ${websiteRoot}\n`);
+    process.stdout.write(`  Local URL: http://${host}:${port}/\n`);
+    process.stdout.write(`  Pages fallback path: http://${host}:${port}${FALLBACK_BASE}/\n`);
+    process.stdout.write('Press Ctrl+C to stop.\n');
+  });
+}
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  if (options) {
+    startServer(options);
+  }
+} catch (err) {
+  process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n\n${usage()}`);
+  process.exitCode = 1;
+}

--- a/website/CNAME
+++ b/website/CNAME
@@ -1,0 +1,1 @@
+arborist.tools

--- a/website/assets/arborist-app-shell.svg
+++ b/website/assets/arborist-app-shell.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 760" role="img" aria-labelledby="title desc">
+  <title id="title">Arborist app shell illustration</title>
+  <desc id="desc">A static illustration of the Arborist sidebar, worktree tabs, child sessions, and terminal workflow.</desc>
+  <defs>
+    <linearGradient id="window" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#111827" />
+      <stop offset="1" stop-color="#020617" />
+    </linearGradient>
+    <linearGradient id="terminal" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#0f172a" />
+      <stop offset="1" stop-color="#111827" />
+    </linearGradient>
+    <filter id="shadow" x="-8%" y="-10%" width="116%" height="124%">
+      <feDropShadow dx="0" dy="22" stdDeviation="24" flood-color="#020617" flood-opacity="0.28" />
+    </filter>
+  </defs>
+  <rect width="1200" height="760" rx="38" fill="#ecfeff" />
+  <rect x="60" y="58" width="1080" height="644" rx="30" fill="url(#window)" filter="url(#shadow)" />
+  <rect x="60" y="58" width="1080" height="52" rx="30" fill="#1f2937" />
+  <circle cx="99" cy="84" r="8" fill="#f87171" />
+  <circle cx="126" cy="84" r="8" fill="#fbbf24" />
+  <circle cx="153" cy="84" r="8" fill="#34d399" />
+  <text x="188" y="91" fill="#d1d5db" font-family="ui-sans-serif, Segoe UI, Arial, sans-serif" font-size="17" font-weight="700">
+    Arborist - mcaden/arborist
+  </text>
+
+  <rect x="60" y="110" width="274" height="592" fill="#0f172a" />
+  <text x="91" y="157" fill="#f8fafc" font-family="ui-sans-serif, Segoe UI, Arial, sans-serif" font-size="24" font-weight="800">
+    Worktrees
+  </text>
+  <rect x="88" y="184" width="218" height="74" rx="15" fill="#115e59" />
+  <text x="112" y="215" fill="#ecfeff" font-family="ui-sans-serif, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700">
+    github-pages
+  </text>
+  <text x="112" y="240" fill="#99f6e4" font-family="ui-sans-serif, Segoe UI, Arial, sans-serif" font-size="14">branch: pages-site</text>
+  <rect x="111" y="275" width="172" height="48" rx="12" fill="#1e293b" />
+  <circle cx="133" cy="299" r="7" fill="#86efac" />
+  <text x="151" y="305" fill="#e2e8f0" font-family="ui-sans-serif, Segoe UI, Arial, sans-serif" font-size="15">Copilot CLI</text>
+  <rect x="111" y="334" width="172" height="48" rx="12" fill="#1e293b" />
+  <circle cx="133" cy="358" r="7" fill="#fcd34d" />
+  <text x="151" y="364" fill="#e2e8f0" font-family="ui-sans-serif, Segoe UI, Arial, sans-serif" font-size="15">Terminal</text>
+  <rect x="88" y="408" width="218" height="68" rx="15" fill="#111827" stroke="#334155" />
+  <text x="112" y="438" fill="#cbd5e1" font-family="ui-sans-serif, Segoe UI, Arial, sans-serif" font-size="17" font-weight="700">release-notes</text>
+  <text x="112" y="461" fill="#64748b" font-family="ui-sans-serif, Segoe UI, Arial, sans-serif" font-size="14">2 background sessions</text>
+  <rect x="88" y="501" width="218" height="44" rx="12" fill="#0f766e" opacity="0.28" />
+  <text x="117" y="529" fill="#ccfbf1" font-family="ui-sans-serif, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700">+ Open or create worktree</text>
+
+  <rect x="334" y="110" width="806" height="592" fill="#f8fafc" />
+  <rect x="366" y="146" width="742" height="86" rx="22" fill="#ffffff" stroke="#e2e8f0" />
+  <text x="398" y="184" fill="#0f172a" font-family="ui-sans-serif, Segoe UI, Arial, sans-serif" font-size="28" font-weight="800">
+    github-pages
+  </text>
+  <text x="398" y="211" fill="#475569" font-family="ui-sans-serif, Segoe UI, Arial, sans-serif" font-size="16">
+    Worktree dashboard and persistent child sessions stay restorable across launches.
+  </text>
+  <rect x="928" y="166" width="154" height="42" rx="12" fill="#0f766e" />
+  <text x="959" y="193" fill="#ecfeff" font-family="ui-sans-serif, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700">Launch AI</text>
+
+  <rect x="366" y="259" width="742" height="382" rx="22" fill="url(#terminal)" />
+  <rect x="366" y="259" width="742" height="48" rx="22" fill="#1f2937" />
+  <text x="394" y="289" fill="#e2e8f0" font-family="ui-sans-serif, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700">
+    Copilot CLI - running in cwd .arborist/.worktrees/github-pages
+  </text>
+  <text x="395" y="348" fill="#86efac" font-family="ui-monospace, SFMono-Regular, Consolas, monospace" font-size="18">$ git status --short --branch</text>
+  <text x="395" y="382" fill="#cbd5e1" font-family="ui-monospace, SFMono-Regular, Consolas, monospace" font-size="18">## github-pages</text>
+  <text x="395" y="430" fill="#86efac" font-family="ui-monospace, SFMono-Regular, Consolas, monospace" font-size="18">
+    $ copilot "implement the next task"
+  </text>
+  <text x="395" y="464" fill="#93c5fd" font-family="ui-monospace, SFMono-Regular, Consolas, monospace" font-size="18">
+    Working in the selected worktree. Background PTYs keep running.
+  </text>
+  <text x="395" y="518" fill="#f8fafc" font-family="ui-monospace, SFMono-Regular, Consolas, monospace" font-size="18">
+    Session output streams directly to xterm.js when this tab is active.
+  </text>
+  <rect x="395" y="570" width="14" height="26" fill="#5eead4" />
+
+  <rect x="394" y="657" width="178" height="14" rx="7" fill="#99f6e4" />
+  <rect x="592" y="657" width="112" height="14" rx="7" fill="#cbd5e1" />
+  <rect x="724" y="657" width="146" height="14" rx="7" fill="#cbd5e1" />
+</svg>

--- a/website/assets/favicon.svg
+++ b/website/assets/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
+  <title id="title">Arborist icon</title>
+  <desc id="desc">A stylized tree made from terminal branch lines.</desc>
+  <rect width="128" height="128" rx="28" fill="#0f172a" />
+  <path d="M64 101V43" stroke="#d9f99d" stroke-width="8" stroke-linecap="round" />
+  <path d="M64 62 40 38M64 76l26-27M64 89 37 73M64 51l21-18" stroke="#5eead4" stroke-width="8" stroke-linecap="round" />
+  <circle cx="40" cy="38" r="10" fill="#14b8a6" />
+  <circle cx="85" cy="33" r="10" fill="#22c55e" />
+  <circle cx="90" cy="49" r="10" fill="#84cc16" />
+  <circle cx="37" cy="73" r="10" fill="#2dd4bf" />
+  <circle cx="64" cy="43" r="12" fill="#bef264" />
+  <path d="M38 105h52" stroke="#d9f99d" stroke-width="8" stroke-linecap="round" />
+</svg>

--- a/website/assets/social-card.svg
+++ b/website/assets/social-card.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Arborist social card</title>
+  <desc id="desc">Arborist manages AI coding-assistant sessions across Git worktrees.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#0f172a" />
+      <stop offset="0.58" stop-color="#0f766e" />
+      <stop offset="1" stop-color="#365314" />
+    </linearGradient>
+    <linearGradient id="panel" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.18" />
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0.06" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <circle cx="1010" cy="80" r="260" fill="#bef264" opacity="0.14" />
+  <circle cx="160" cy="560" r="260" fill="#2dd4bf" opacity="0.16" />
+  <rect x="80" y="78" width="1040" height="474" rx="42" fill="url(#panel)" stroke="#ccfbf1" stroke-opacity="0.32" />
+  <g transform="translate(130 140)">
+    <rect width="150" height="150" rx="34" fill="#0f172a" />
+    <path d="M75 121V52" stroke="#d9f99d" stroke-width="9" stroke-linecap="round" />
+    <path d="M75 72 47 44M75 88l31-32M75 103 44 84M75 61l25-22" stroke="#5eead4" stroke-width="9" stroke-linecap="round" />
+    <circle cx="47" cy="44" r="11" fill="#14b8a6" />
+    <circle cx="100" cy="39" r="11" fill="#22c55e" />
+    <circle cx="106" cy="56" r="11" fill="#84cc16" />
+    <circle cx="44" cy="84" r="11" fill="#2dd4bf" />
+    <circle cx="75" cy="52" r="13" fill="#bef264" />
+    <path d="M45 124h61" stroke="#d9f99d" stroke-width="9" stroke-linecap="round" />
+  </g>
+  <text x="330" y="212" fill="#f8fafc" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="84" font-weight="800">Arborist</text>
+  <text x="334" y="292" fill="#ccfbf1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="34" font-weight="600">
+    Manage AI coding-assistant sessions
+  </text>
+  <text x="334" y="340" fill="#ccfbf1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="34" font-weight="600">
+    across Git worktrees.
+  </text>
+  <text x="132" y="492" fill="#e2e8f0" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="28">
+    Tauri desktop app - persistent PTYs - Claude CLI - GitHub Copilot CLI - custom processes
+  </text>
+</svg>

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,260 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Arborist - Manage AI coding-assistant sessions across Git worktrees</title>
+    <meta name="description" content="Arborist is a cross-platform Tauri desktop app for developers using local Git worktrees and AI coding CLIs." />
+    <meta name="theme-color" content="#0f766e" />
+    <link rel="canonical" href="https://arborist.tools/" />
+    <link rel="icon" href="./assets/favicon.svg" type="image/svg+xml" />
+    <link rel="manifest" href="./site.webmanifest" />
+    <link rel="stylesheet" href="./styles.css" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Arborist" />
+    <meta property="og:title" content="Arborist - Manage AI coding-assistant sessions across Git worktrees" />
+    <meta
+      property="og:description"
+      content="A cross-platform Tauri desktop app for keeping worktree-scoped Claude CLI, GitHub Copilot CLI, terminal, and custom-process sessions organized."
+    />
+    <meta property="og:url" content="https://arborist.tools/" />
+    <meta property="og:image" content="https://arborist.tools/assets/social-card.svg" />
+    <meta property="og:image:alt" content="Arborist social card" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Arborist - Manage AI coding-assistant sessions across Git worktrees" />
+    <meta name="twitter:description" content="A cross-platform Tauri desktop app for keeping local Git worktree sessions organized and restorable." />
+    <meta name="twitter:image" content="https://arborist.tools/assets/social-card.svg" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <nav class="nav" aria-label="Main navigation">
+        <a class="brand" href="./" aria-label="Arborist home">
+          <img src="./assets/favicon.svg" width="36" height="36" alt="" />
+          <span>Arborist</span>
+        </a>
+        <div class="nav-links">
+          <a href="#features">Features</a>
+          <a href="#install">Install</a>
+          <a href="#run-from-source">Run from source</a>
+          <a href="#docs">Docs</a>
+          <a href="https://github.com/mcaden/arborist">GitHub</a>
+        </div>
+      </nav>
+    </header>
+
+    <main id="main">
+      <section class="hero" aria-labelledby="hero-title">
+        <div>
+          <p class="eyebrow">Public desktop app for local developer workflows</p>
+          <h1 id="hero-title">Arborist</h1>
+          <p class="hero-copy">
+            Manage AI coding-assistant sessions across Git worktrees. Arborist is a cross-platform Tauri desktop app for developers using local Git
+            worktrees, Claude CLI, GitHub Copilot CLI, terminals, and configured custom processes.
+          </p>
+          <div class="cta-row" aria-label="Primary calls to action">
+            <a class="button primary" href="https://github.com/mcaden/arborist/releases">Download from GitHub Releases</a>
+            <a class="button secondary" href="#run-from-source">Run from source</a>
+            <a class="button secondary" href="https://github.com/mcaden/arborist/blob/main/docs/index.md">Read the docs</a>
+          </div>
+        </div>
+        <figure class="hero-card">
+          <img
+            src="./assets/arborist-app-shell.svg"
+            width="1200"
+            height="760"
+            alt="Static illustration of the Arborist app shell showing worktree tabs, child AI sessions, and a terminal pane."
+          />
+          <figcaption>Static interface illustration based on the current Arborist shell, sidebar, and terminal workflow.</figcaption>
+        </figure>
+      </section>
+
+      <section class="page-section" aria-labelledby="value-title">
+        <div class="section-heading">
+          <h2 id="value-title">One workspace, many focused sessions.</h2>
+          <p>
+            Arborist keeps multiple worktree-scoped Claude CLI, GitHub Copilot CLI, terminal, and custom-process sessions organized and restorable
+            without replacing the tools you already use.
+          </p>
+        </div>
+        <div class="grid three">
+          <article class="card">
+            <h3>Worktree-scoped context</h3>
+            <p>Each session runs from the selected worktree path, so prompts, shells, and tools operate in the right checkout.</p>
+          </article>
+          <article class="card">
+            <h3>Persistent PTYs</h3>
+            <p>Every terminal-backed session owns a PTY in the Rust backend and continues running across sidebar tab switches.</p>
+          </article>
+          <article class="card">
+            <h3>CLI-native by design</h3>
+            <p>Arborist launches external tools and preserves their chat, auth, and update flows instead of becoming another chat UI.</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="features" class="page-section" aria-labelledby="features-title">
+        <div class="section-heading">
+          <h2 id="features-title">Key features</h2>
+          <p>Built around local Git worktrees, safe process launch, and long-running assistant sessions.</p>
+        </div>
+        <ul class="feature-list">
+          <li><strong>Workspace-first model:</strong> one app instance binds to one primary Git clone.</li>
+          <li><strong>Managed worktree tabs:</strong> Arborist-created worktrees live under <code>&lt;repo&gt;/.arborist/.worktrees/</code>.</li>
+          <li><strong>AI sessions:</strong> launch Claude CLI and GitHub Copilot CLI from a worktree context.</li>
+          <li><strong>Custom processes:</strong> run shells, editors, file browsers, and other configured commands.</li>
+          <li><strong>Restore on launch:</strong> open worktree tabs and terminal-backed sessions are persisted and restored.</li>
+          <li>
+            <strong>Safe command composition:</strong> worktree paths are passed as process <code>cwd</code>, not interpolated into shell strings.
+          </li>
+          <li><strong>No credential storage:</strong> authentication remains with the invoked CLIs and tools.</li>
+          <li><strong>Cross-platform target:</strong> Windows, macOS, and Linux desktop builds.</li>
+        </ul>
+      </section>
+
+      <section id="install" class="page-section" aria-labelledby="install-title">
+        <div class="section-heading">
+          <h2 id="install-title">Install and runtime requirements</h2>
+          <p>Signed packaged builds are published on GitHub Releases. Source builds remain available for contributors and maintainers.</p>
+        </div>
+        <div class="grid two">
+          <article class="card">
+            <h3>Download builds</h3>
+            <p>
+              Use the <a href="https://github.com/mcaden/arborist/releases">GitHub Releases page</a> for signed installers, release notes, and
+              downloadable artifacts for supported platforms.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Runtime requirements</h3>
+            <ul class="plain-list">
+              <li><code>git</code> on <code>PATH</code>.</li>
+              <li>At least one authenticated AI CLI for AI sessions: Claude CLI or GitHub Copilot CLI.</li>
+              <li>Windows WebView2 runtime if it is not already installed.</li>
+              <li>Optional Linux <code>wmctrl</code> for X11 application sub-tab focusing.</li>
+            </ul>
+          </article>
+        </div>
+        <div class="callout" role="note" aria-label="Release trust and signing status">
+          <h3>Release trust and signing status</h3>
+          <p>
+            Release artifacts are OS-signed and notarized where each platform supports it. Published release assets include GitHub build attestations
+            and can be verified with
+            <code>gh attestation verify &lt;downloaded-file&gt; --repo mcaden/arborist</code>.
+          </p>
+        </div>
+      </section>
+
+      <section id="run-from-source" class="page-section" aria-labelledby="source-title">
+        <div class="section-heading">
+          <h2 id="source-title">Contributor path</h2>
+          <p>
+            Public contribution guidance lives in <a href="https://github.com/mcaden/arborist/blob/main/CONTRIBUTING.md">CONTRIBUTING.md</a>.
+            Development and testing docs cover the full setup, but the shortest source-run path is:
+          </p>
+        </div>
+        <pre><code>git clone https://github.com/mcaden/arborist.git
+cd arborist
+nvm use
+pnpm install
+pnpm dev</code></pre>
+        <div class="grid two">
+          <article class="card">
+            <h3>Project workflow</h3>
+            <p>
+              Use GitHub issue templates for bugs and feature requests, follow the support policy for help, and report security vulnerabilities
+              through the private security process.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Read next</h3>
+            <p>
+              See <a href="https://github.com/mcaden/arborist/blob/main/docs/development.md">development</a> and
+              <a href="https://github.com/mcaden/arborist/blob/main/docs/testing.md">testing</a> docs for prerequisites, verification commands, and
+              test seams.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section id="docs" class="page-section" aria-labelledby="docs-title">
+        <div class="section-heading">
+          <h2 id="docs-title">Curated documentation links</h2>
+          <p>The website is a public landing page. Detailed engineering docs stay in the repository.</p>
+        </div>
+        <div class="docs-grid">
+          <a class="doc-link" href="https://github.com/mcaden/arborist#readme"><strong>README</strong><span>Project overview and setup.</span></a>
+          <a class="doc-link" href="https://github.com/mcaden/arborist/blob/main/docs/product.md"
+            ><strong>Product contract</strong><span>Scope and requirements.</span></a
+          >
+          <a class="doc-link" href="https://github.com/mcaden/arborist/blob/main/docs/architecture.md"
+            ><strong>Architecture</strong><span>Codebase map and API.</span></a
+          >
+          <a class="doc-link" href="https://github.com/mcaden/arborist/blob/main/docs/runtime-flows.md"
+            ><strong>Runtime flows</strong><span>Boot and session flows.</span></a
+          >
+          <a class="doc-link" href="https://github.com/mcaden/arborist/blob/main/docs/configuration.md"
+            ><strong>Configuration</strong><span>Config and store layout.</span></a
+          >
+          <a class="doc-link" href="https://github.com/mcaden/arborist/blob/main/docs/worktrees.md"
+            ><strong>Worktrees</strong><span>Workspace rules.</span></a
+          >
+          <a class="doc-link" href="https://github.com/mcaden/arborist/blob/main/docs/development.md"
+            ><strong>Development</strong><span>Local workflow.</span></a
+          >
+          <a class="doc-link" href="https://github.com/mcaden/arborist/blob/main/docs/testing.md"
+            ><strong>Testing</strong><span>Quality and test seams.</span></a
+          >
+          <a class="doc-link" href="https://github.com/mcaden/arborist/blob/main/docs/releasing.md"
+            ><strong>Releasing</strong><span>Artifacts and attestations.</span></a
+          >
+          <a class="doc-link" href="https://github.com/mcaden/arborist/blob/main/CONTRIBUTING.md"
+            ><strong>Contributing</strong><span>Contributor workflow.</span></a
+          >
+          <a class="doc-link" href="https://github.com/mcaden/arborist/blob/main/SECURITY.md"
+            ><strong>Security</strong><span>Disclosure and boundaries.</span></a
+          >
+          <a class="doc-link" href="https://github.com/mcaden/arborist/blob/main/SUPPORT.md"
+            ><strong>Support</strong><span>Where to get help.</span></a
+          >
+          <a class="doc-link" href="https://github.com/mcaden/arborist/blob/main/docs/roadmap.md"
+            ><strong>Roadmap</strong><span>Known gaps and plans.</span></a
+          >
+          <a class="doc-link" href="https://github.com/mcaden/arborist/issues/new/choose"
+            ><strong>Issue templates</strong><span>Bug and feature forms.</span></a
+          >
+          <a class="doc-link" href="https://github.com/mcaden/arborist/blob/main/CODE_OF_CONDUCT.md"
+            ><strong>Code of conduct</strong><span>Community expectations.</span></a
+          >
+        </div>
+      </section>
+
+      <section class="page-section" aria-labelledby="metadata-title">
+        <div class="section-heading">
+          <h2 id="metadata-title">Project metadata and trust</h2>
+          <p>Arborist is a public open-source project with signed releases and explicit support boundaries.</p>
+        </div>
+        <div class="metadata">
+          <dl>
+            <dt>License</dt>
+            <dd>MIT</dd>
+            <dt>Repository</dt>
+            <dd><a href="https://github.com/mcaden/arborist">https://github.com/mcaden/arborist</a></dd>
+            <dt>Website</dt>
+            <dd><a href="https://arborist.tools">https://arborist.tools</a></dd>
+            <dt>Status</dt>
+            <dd>Public open-source desktop app for local Git worktree and AI CLI workflows.</dd>
+            <dt>Distribution</dt>
+            <dd>Signed installers are distributed through GitHub Releases; package-manager distribution and automatic updates are not supported.</dd>
+          </dl>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>Arborist is maintained at <a href="https://github.com/mcaden/arborist">github.com/mcaden/arborist</a>.</p>
+    </footer>
+  </body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -38,6 +38,7 @@
         <div class="nav-links">
           <a href="#features">Features</a>
           <a href="#install">Install</a>
+          <a href="#tips">Tips</a>
           <a href="#run-from-source">Run from source</a>
           <a href="#docs">Docs</a>
           <a href="https://github.com/mcaden/arborist">GitHub</a>
@@ -174,6 +175,36 @@ pnpm dev</code></pre>
               See <a href="https://github.com/mcaden/arborist/blob/main/docs/development.md">development</a> and
               <a href="https://github.com/mcaden/arborist/blob/main/docs/testing.md">testing</a> docs for prerequisites, verification commands, and
               test seams.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section id="tips" class="page-section" aria-labelledby="tips-title">
+        <div class="section-heading">
+          <h2 id="tips-title">Workflow tips</h2>
+          <p>Patterns that work well once you have multiple worktrees and sessions running.</p>
+        </div>
+        <div class="grid three">
+          <article class="card">
+            <h3>Prefix PRs with the worktree name</h3>
+            <p>
+              Use <code>[worktree-name] Summary</code> as your PR title convention. It makes the PR list scannable and ties each change back to the
+              worktree that produced it. AI agents can be instructed to follow this convention automatically.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Launch your app as a custom process</h3>
+            <p>
+              Configure your app's dev server (or any long-running command) as a custom-process session type. Arborist will start it in the worktree's
+              directory and keep it running alongside your AI and terminal sessions.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Use worktree prep commands</h3>
+            <p>
+              Set up prep commands like <code>pnpm install</code> and <code>git merge main</code> to run automatically when a worktree is created or
+              switched to. This keeps dependencies fresh and the branch up to date without manual steps.
             </p>
           </article>
         </div>

--- a/website/robots.txt
+++ b/website/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://arborist.tools/sitemap.xml

--- a/website/site.webmanifest
+++ b/website/site.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "Arborist",
+  "short_name": "Arborist",
+  "description": "Manage AI coding-assistant sessions across Git worktrees.",
+  "start_url": "./",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#0f766e",
+  "icons": [
+    {
+      "src": "./assets/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://arborist.tools/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/website/styles.css
+++ b/website/styles.css
@@ -1,0 +1,489 @@
+:root {
+  color-scheme: light;
+  --bg: #f8fafc;
+  --bg-soft: #ecfeff;
+  --panel: #ffffff;
+  --panel-strong: #0f172a;
+  --text: #0f172a;
+  --text-muted: #475569;
+  --brand: #0f766e;
+  --brand-dark: #115e59;
+  --brand-soft: #ccfbf1;
+  --accent: #65a30d;
+  --border: #dbeafe;
+  --shadow: 0 24px 70px rgb(15 23 42 / 14%);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background:
+    radial-gradient(circle at top left, rgb(20 184 166 / 16%), transparent 34rem),
+    radial-gradient(circle at 86% 14%, rgb(132 204 22 / 16%), transparent 30rem), var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+a {
+  color: var(--brand-dark);
+  font-weight: 700;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.18em;
+}
+
+a:hover {
+  color: #134e4a;
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 3px solid #0ea5e9;
+  outline-offset: 4px;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+code {
+  border-radius: 0.35rem;
+  background: #e2e8f0;
+  padding: 0.12rem 0.35rem;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+  font-size: 0.92em;
+}
+
+pre {
+  overflow-x: auto;
+  border-radius: 1rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 1.2rem;
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 10%);
+}
+
+pre code {
+  background: transparent;
+  color: inherit;
+  padding: 0;
+}
+
+.skip-link {
+  position: absolute;
+  left: 1rem;
+  top: 1rem;
+  z-index: 20;
+  transform: translateY(-150%);
+  border-radius: 999px;
+  background: #0f172a;
+  color: #ffffff;
+  padding: 0.6rem 1rem;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  border-bottom: 1px solid rgb(15 23 42 / 8%);
+  background: rgb(248 250 252 / 88%);
+  backdrop-filter: blur(18px);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 1rem 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  color: var(--text);
+  font-size: 1.2rem;
+  font-weight: 850;
+  text-decoration: none;
+}
+
+.brand img {
+  width: 2.25rem;
+  height: 2.25rem;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 1rem;
+  font-size: 0.95rem;
+}
+
+.page-section,
+.hero {
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 0.95fr);
+  align-items: center;
+  gap: 3rem;
+  padding: 5.5rem 0 4.5rem;
+}
+
+.eyebrow {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  border: 1px solid rgb(15 118 110 / 26%);
+  border-radius: 999px;
+  background: rgb(204 251 241 / 72%);
+  color: #134e4a;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 800;
+  letter-spacing: 0.01em;
+}
+
+.hero h1 {
+  max-width: 12ch;
+  margin: 1.15rem 0 1rem;
+  font-size: clamp(3.1rem, 9vw, 6.4rem);
+  line-height: 0.9;
+  letter-spacing: -0.07em;
+}
+
+.hero-copy {
+  max-width: 46rem;
+  color: var(--text-muted);
+  font-size: clamp(1.13rem, 1.8vw, 1.32rem);
+}
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-top: 2rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.78rem 1.05rem;
+  font-weight: 850;
+  text-decoration: none;
+}
+
+.button.primary {
+  background: var(--brand);
+  color: #ffffff;
+  box-shadow: 0 14px 30px rgb(15 118 110 / 26%);
+}
+
+.button.primary:hover {
+  background: #0f5f59;
+  color: #ffffff;
+}
+
+.button.secondary {
+  border: 1px solid rgb(15 23 42 / 14%);
+  background: #ffffff;
+  color: var(--text);
+}
+
+.button.secondary:hover {
+  border-color: rgb(15 118 110 / 32%);
+  color: var(--brand-dark);
+}
+
+.hero-card {
+  margin: 0;
+  border: 1px solid rgb(15 23 42 / 10%);
+  border-radius: 2rem;
+  background: #ffffff;
+  padding: 0.85rem;
+  box-shadow: var(--shadow);
+}
+
+.hero-card img {
+  border-radius: 1.35rem;
+}
+
+.hero-card figcaption {
+  margin: 0.8rem 0.55rem 0.25rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.page-section {
+  padding: 4rem 0;
+}
+
+.section-heading {
+  max-width: 52rem;
+  margin-bottom: 2rem;
+}
+
+.section-heading h2 {
+  margin: 0 0 0.65rem;
+  font-size: clamp(2rem, 4vw, 3.15rem);
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.section-heading p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 1.12rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.grid.two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.grid.three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.card {
+  border: 1px solid rgb(15 23 42 / 10%);
+  border-radius: 1.4rem;
+  background: var(--panel);
+  padding: 1.35rem;
+  box-shadow: 0 10px 34px rgb(15 23 42 / 7%);
+}
+
+.card h3 {
+  margin: 0 0 0.55rem;
+  font-size: 1.15rem;
+  line-height: 1.25;
+}
+
+.card p,
+.card li {
+  color: var(--text-muted);
+}
+
+.card p {
+  margin: 0;
+}
+
+.feature-list,
+.link-list,
+.plain-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.feature-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.feature-list li {
+  position: relative;
+  border: 1px solid rgb(15 23 42 / 10%);
+  border-radius: 1rem;
+  background: #ffffff;
+  padding: 1rem 1rem 1rem 2.35rem;
+}
+
+.feature-list li::before {
+  position: absolute;
+  left: 1rem;
+  top: 1.12rem;
+  width: 0.72rem;
+  height: 0.72rem;
+  border-radius: 999px;
+  background: var(--accent);
+  content: '';
+}
+
+.callout {
+  border: 1px solid rgb(15 118 110 / 18%);
+  border-radius: 1.4rem;
+  background: linear-gradient(135deg, rgb(204 251 241 / 86%), rgb(236 252 203 / 72%));
+  padding: 1.35rem;
+}
+
+.callout h3 {
+  margin: 0 0 0.55rem;
+}
+
+.callout p {
+  margin: 0;
+  color: #134e4a;
+}
+
+.plain-list {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.plain-list li {
+  padding-left: 1.4rem;
+  position: relative;
+}
+
+.plain-list li::before {
+  position: absolute;
+  left: 0;
+  color: var(--brand);
+  content: '-';
+  font-weight: 900;
+}
+
+.docs-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.doc-link {
+  min-height: 6.7rem;
+  border: 1px solid rgb(15 23 42 / 10%);
+  border-radius: 1rem;
+  background: #ffffff;
+  padding: 1rem;
+  text-decoration: none;
+}
+
+.doc-link strong,
+.doc-link span {
+  display: block;
+}
+
+.doc-link strong {
+  color: var(--text);
+}
+
+.doc-link span {
+  margin-top: 0.35rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.doc-link:hover {
+  border-color: rgb(15 118 110 / 35%);
+  color: var(--brand-dark);
+  transform: translateY(-1px);
+}
+
+.metadata {
+  border-radius: 1.6rem;
+  background: var(--panel-strong);
+  color: #e2e8f0;
+  padding: 1.6rem;
+}
+
+.metadata dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.8rem 1.2rem;
+  margin: 0;
+}
+
+.metadata dt {
+  color: #99f6e4;
+  font-weight: 850;
+}
+
+.metadata dd {
+  margin: 0;
+}
+
+.metadata a {
+  color: #ccfbf1;
+}
+
+.site-footer {
+  border-top: 1px solid rgb(15 23 42 / 10%);
+  padding: 2rem 1rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+@media (max-width: 920px) {
+  .hero,
+  .grid.two,
+  .grid.three {
+    grid-template-columns: 1fr;
+  }
+
+  .docs-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 680px) {
+  .nav {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .nav-links {
+    justify-content: flex-start;
+  }
+
+  .hero {
+    padding-top: 3.25rem;
+  }
+
+  .feature-list,
+  .docs-grid,
+  .metadata dl {
+    grid-template-columns: 1fr;
+  }
+
+  .metadata dt {
+    margin-top: 0.35rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Summary

Implements #128 — creates a static GitHub Pages site for https://arborist.tools.

## What's included

- **`website/`** — Static landing page (HTML/CSS/SVG) with hero, features, install, tips, contributor, and docs sections
- **`.github/workflows/pages.yml`** — Deployment workflow with validation (no scripts, no remote resource-loading assets)
- **`scripts/serve-website.mjs`** — Zero-dependency local preview server (`pnpm run website:dev`)
- **SVG assets** — Favicon, social card, and app-shell illustration
- **SEO/social metadata** — OG tags, Twitter card, canonical URL, sitemap, robots.txt, web manifest
- **Accessibility** — Skip-link, landmarks, alt text, focus styles, prefers-reduced-motion
- **Docs updates** — releasing.md Pages policy, README website link, signed-release language

## Post-merge setup required

1. Make the repo public (or upgrade plan) — Pages requires it
2. Go to Settings → Pages → Source: **GitHub Actions**
3. Configure DNS: `arborist.tools` CNAME → `mcaden.github.io`
4. Wait for certificate provisioning (~15 min after DNS propagates)

## Local preview

```sh
pnpm run website:dev
# → http://127.0.0.1:4173/
```

## Verification

- `pnpm run lint` ✅
- `pnpm test --run` ✅
- No remote resource-loading assets in website/
- Relative URLs work at both `/` and `/arborist/` subpath
