### PR TITLE
[pin-dependencies] Pin GitHub Actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,17 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   frontend:
     name: Frontend (lint + test)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # actions/checkout@v5
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # pnpm/action-setup@v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # actions/setup-node@v5
         with:
           node-version: '22'
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     name: Verify tag is on main
@@ -45,7 +48,7 @@ jobs:
           fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "Normalized tag: '${tag}' (raw: '${RAW}')"
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
@@ -98,21 +101,22 @@ jobs:
       # Check out the exact tag the user requested (normalized by the verify
       # job) so the built binaries correspond to the release tag rather than
       # the default branch HEAD.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # actions/checkout@v5
         with:
           ref: refs/tags/${{ needs.verify.outputs.tag }}
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # pnpm/action-setup@v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # actions/setup-node@v5
         with:
           node-version: '22'
           cache: pnpm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # dtolnay/rust-toolchain@master
         with:
+          toolchain: stable
           targets: ${{ matrix.platform.rust-targets }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # Swatinem/rust-cache@v2
         with:
           workspaces: . -> target
 
@@ -144,7 +148,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: tauri-apps/tauri-action@v0
+      - uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # tauri-apps/tauri-action@v0
         id: tauri
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -188,6 +192,6 @@ jobs:
       # artifacts are produced (because we set `tagName`), which fails the
       # job and causes this step to be skipped automatically.
       - name: Attest build provenance for release artifacts
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # actions/attest-build-provenance@v2
         with:
           subject-path: ${{ join(fromJSON(steps.tauri.outputs.artifactPaths), ',') }}

--- a/.github/workflows/rust-gate.yml
+++ b/.github/workflows/rust-gate.yml
@@ -12,10 +12,6 @@ on:
   pull_request_review:
     types: [submitted]
 
-permissions:
-  actions: write   # required for `gh workflow run` to create workflow_dispatch
-  contents: read
-
 jobs:
   dispatch-rust:
     # Skip non-approving reviews and fork PRs. Fork PRs are skipped because
@@ -27,6 +23,9 @@ jobs:
       github.event.review.state == 'approved' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    permissions:
+      actions: write # required for `gh workflow run` to create workflow_dispatch
+      contents: read
     steps:
       - name: Dispatch Rust workflow against PR head branch
         env:
@@ -50,6 +49,7 @@ jobs:
       github.event.review.state == 'approved' &&
       github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Log fork-PR skip
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,9 @@ concurrency:
   group: rust-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   rust:
     name: Rust (${{ matrix.os }})
@@ -29,16 +32,17 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # actions/checkout@v5
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # pnpm/action-setup@v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # actions/setup-node@v5
         with:
           node-version: '22'
           cache: pnpm
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # dtolnay/rust-toolchain@master
         with:
+          toolchain: stable
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # Swatinem/rust-cache@v2
       # Tauri's Linux build needs system libraries even for `cargo check`/test
       # because the `tauri` crate links against webkit2gtk + friends. `lld` +
       # `clang` are required by the workspace `.cargo/config.toml` for the

--- a/docs/development.md
+++ b/docs/development.md
@@ -106,6 +106,10 @@ Do not bypass hooks on `main`. If you must use `--no-verify` on a personal WIP b
 
 The Rust workflow is approval-gated because it is heavier and multi-platform. Reviewers should ensure it ran against the head SHA they approved.
 
+Workflow `uses:` dependencies are pinned to full commit SHAs. Each pin keeps an inline comment with the intended upstream action ref, and Dependabot is
+configured to open weekly `github-actions` update PRs. Review those PRs like code changes: confirm the new SHA belongs to the commented upstream ref,
+keep the comment accurate, and run the relevant workflow before merging.
+
 ## Debugging
 
 ### Frontend

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -91,6 +91,10 @@ Attestations prove the artifact was produced by the repository workflow for the 
 
 Use a throwaway tag to validate workflow changes. Delete the draft release and tag afterward.
 
+Run a dry release whenever release workflow action pins change, especially for Tauri publishing or build-attestation actions. The workflow pins every
+`uses:` dependency to a full commit SHA with an inline comment naming the upstream action ref; Dependabot opens update PRs, but maintainers should verify
+the new SHA and comment before merging.
+
 ## Out of scope today
 
 - Apple notarization.


### PR DESCRIPTION
## Summary
- Pin every GitHub Actions `uses:` entry in CI, Rust, and release workflows to full commit SHAs with source-ref comments.
- Add weekly Dependabot updates for GitHub Actions pins.
- Tighten workflow permissions where practical and document the pinned-action update / dry-release process.

Fixes #136

## Validation
- pnpm run lint
- pnpm run build
- pre-push hook: pnpm test --run; cargo test --workspace --features test-helpers