### PR TITLE
[scrollbar-theme] Theme scrollbars to match application palette

### DIFF
--- a/src/components/CustomProcessesTab.tsx
+++ b/src/components/CustomProcessesTab.tsx
@@ -206,7 +206,7 @@ export function CustomProcessesTab({ onClose }: CustomProcessesTabProps): JSX.El
         processes.
       </p>
 
-      <div className="-mx-1 flex-1 space-y-3 overflow-y-auto px-1">
+      <div className="themed-scrollbar -mx-1 flex-1 space-y-3 overflow-y-auto px-1">
         {rows.length === 0 ? (
           <p
             data-testid="custom-processes-empty"

--- a/src/components/NewSessionDialog.tsx
+++ b/src/components/NewSessionDialog.tsx
@@ -296,7 +296,7 @@ export function NewSessionDialog(): JSX.Element | null {
                   elsewhere.
                 </p>
               ) : (
-                <ul className="mb-2 max-h-48 overflow-y-auto rounded border border-slate-200 dark:border-slate-700">
+                <ul className="themed-scrollbar mb-2 max-h-48 overflow-y-auto rounded border border-slate-200 dark:border-slate-700">
                   {worktrees.map((w) => (
                     <li key={w.path}>
                       <button

--- a/src/components/PluginsTab.tsx
+++ b/src/components/PluginsTab.tsx
@@ -137,7 +137,7 @@ export function PluginsTab({ onClose }: PluginsTabProps): JSX.Element {
         disabled.
       </p>
 
-      <div className="-mx-1 flex-1 space-y-4 overflow-y-auto px-1">
+      <div className="themed-scrollbar -mx-1 flex-1 space-y-4 overflow-y-auto px-1">
         <section>
           <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">AI agents</h3>
           <div className="space-y-3">

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -287,7 +287,7 @@ export function SettingsDialog({ onClose, initialTab = 'general' }: SettingsDial
               id={generalPanelId}
               aria-labelledby={generalTabId}
               data-testid="settings-panel-general"
-              className="min-h-0 flex-1 overflow-y-auto pr-2"
+              className="themed-scrollbar min-h-0 flex-1 overflow-y-auto pr-2"
             >
               <section className="mb-4">
                 <h3 className="mb-1 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Workspace</h3>
@@ -398,7 +398,7 @@ export function SettingsDialog({ onClose, initialTab = 'general' }: SettingsDial
               id={pluginsPanelId}
               aria-labelledby={pluginsTabId}
               data-testid="settings-panel-plugins"
-              className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pr-2"
+              className="themed-scrollbar min-h-0 flex-1 overflow-x-hidden overflow-y-auto pr-2"
             >
               <PluginsTab onClose={onClose} />
             </div>
@@ -408,7 +408,7 @@ export function SettingsDialog({ onClose, initialTab = 'general' }: SettingsDial
               id={customProcessesPanelId}
               aria-labelledby={customProcessesTabId}
               data-testid="settings-panel-custom-processes"
-              className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pr-2"
+              className="themed-scrollbar min-h-0 flex-1 overflow-x-hidden overflow-y-auto pr-2"
             >
               <CustomProcessesTab onClose={onClose} />
             </div>
@@ -418,7 +418,7 @@ export function SettingsDialog({ onClose, initialTab = 'general' }: SettingsDial
               id={aboutPanelId}
               aria-labelledby={aboutTabId}
               data-testid="settings-panel-about"
-              className="min-h-0 flex-1 overflow-y-auto pr-2"
+              className="themed-scrollbar min-h-0 flex-1 overflow-y-auto pr-2"
             >
               <section className="space-y-3 text-xs leading-5 text-slate-600 dark:text-slate-300">
                 <p data-testid="settings-about-attribution">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -326,7 +326,7 @@ export function Sidebar(): JSX.Element {
     >
       <WorkspaceIndicator />
       <NewSessionButton buttonRef={newSessionButtonRef} />
-      <ul className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto py-1">
+      <ul className="themed-scrollbar flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto py-1">
         {groups.map((group) => {
           if (group.tabId === null) {
             // Synthetic orphan group — no header; just render the sessions so they remain reachable. Boot self-heal will open a

--- a/src/components/WorktreeDashboard.tsx
+++ b/src/components/WorktreeDashboard.tsx
@@ -51,7 +51,7 @@ export function WorktreeDashboard({ tabId }: WorktreeDashboardProps): JSX.Elemen
       data-testid="worktree-dashboard"
       role="region"
       aria-labelledby="worktree-dashboard-title"
-      className="flex h-full min-w-0 flex-1 flex-col gap-6 overflow-y-auto bg-white px-8 py-6 text-slate-700 dark:bg-slate-950 dark:text-slate-200"
+      className="themed-scrollbar flex h-full min-w-0 flex-1 flex-col gap-6 overflow-y-auto bg-white px-8 py-6 text-slate-700 dark:bg-slate-950 dark:text-slate-200"
     >
       <header className="flex flex-col gap-1">
         <h1 id="worktree-dashboard-title" className="text-lg font-semibold">

--- a/src/index.css
+++ b/src/index.css
@@ -28,30 +28,31 @@ body {
 /* Standard properties (Firefox, future browsers) */
 .themed-scrollbar {
   scrollbar-width: thin;
-  scrollbar-color: rgb(203 213 225) transparent; /* slate-300 thumb */
+  scrollbar-color: #cbd5e1 transparent; /* slate-300 thumb */
 }
 .themed-scrollbar:where(.dark, .dark *) {
-  scrollbar-color: rgb(71 85 105) transparent; /* slate-600 thumb */
+  scrollbar-color: #475569 transparent; /* slate-600 thumb */
 }
 
 /* WebKit (Chromium, Safari, Tauri WebView) */
 .themed-scrollbar::-webkit-scrollbar {
   width: 6px;
+  height: 6px;
 }
 .themed-scrollbar::-webkit-scrollbar-track {
   background: transparent;
 }
 .themed-scrollbar::-webkit-scrollbar-thumb {
-  background-color: rgb(203 213 225); /* slate-300 */
+  background-color: #cbd5e1; /* slate-300 */
   border-radius: 3px;
 }
 .themed-scrollbar::-webkit-scrollbar-thumb:hover {
-  background-color: rgb(148 163 184); /* slate-400 */
+  background-color: #94a3b8; /* slate-400 */
 }
 
 .themed-scrollbar:where(.dark, .dark *)::-webkit-scrollbar-thumb {
-  background-color: rgb(71 85 105); /* slate-600 */
+  background-color: #475569; /* slate-600 */
 }
 .themed-scrollbar:where(.dark, .dark *)::-webkit-scrollbar-thumb:hover {
-  background-color: rgb(100 116 139); /* slate-500 */
+  background-color: #64748b; /* slate-500 */
 }

--- a/src/index.css
+++ b/src/index.css
@@ -21,3 +21,37 @@ body,
 body {
   margin: 0;
 }
+
+/* Themed scrollbar — apply .themed-scrollbar to any overflow container.
+   Matches the sidebar's slate palette in both light and dark modes. */
+
+/* Standard properties (Firefox, future browsers) */
+.themed-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: rgb(203 213 225) transparent; /* slate-300 thumb */
+}
+.themed-scrollbar:where(.dark, .dark *) {
+  scrollbar-color: rgb(71 85 105) transparent; /* slate-600 thumb */
+}
+
+/* WebKit (Chromium, Safari, Tauri WebView) */
+.themed-scrollbar::-webkit-scrollbar {
+  width: 6px;
+}
+.themed-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+.themed-scrollbar::-webkit-scrollbar-thumb {
+  background-color: rgb(203 213 225); /* slate-300 */
+  border-radius: 3px;
+}
+.themed-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: rgb(148 163 184); /* slate-400 */
+}
+
+.themed-scrollbar:where(.dark, .dark *)::-webkit-scrollbar-thumb {
+  background-color: rgb(71 85 105); /* slate-600 */
+}
+.themed-scrollbar:where(.dark, .dark *)::-webkit-scrollbar-thumb:hover {
+  background-color: rgb(100 116 139); /* slate-500 */
+}

--- a/src/plugins/dashboard-widget/git-status/widget.tsx
+++ b/src/plugins/dashboard-widget/git-status/widget.tsx
@@ -93,7 +93,7 @@ export function GitStatusWidget({ tabPath }: DashboardWidgetProps): JSX.Element 
           ) : (
             <ul
               data-testid="worktree-dashboard-git-files"
-              className="max-h-40 overflow-y-auto rounded-md border border-slate-200 bg-white p-2 font-mono text-[11px] dark:border-slate-700 dark:bg-slate-950"
+              className="themed-scrollbar max-h-40 overflow-y-auto rounded-md border border-slate-200 bg-white p-2 font-mono text-[11px] dark:border-slate-700 dark:bg-slate-950"
             >
               {status.files.map((f) => (
                 <li key={`${f.path}-${f.kind}`} className="flex items-center gap-2 truncate">


### PR DESCRIPTION
## Summary
Add a \.themed-scrollbar\ utility class with both WebKit and standard CSS scrollbar properties, themed to match the app's slate color palette in light and dark modes.

## Changes
- **src/index.css**: New \.themed-scrollbar\ class (thin 6px rounded thumb, slate-300/400 light, slate-600/500 dark)
- **Sidebar.tsx**: Apply to tab list
- **SettingsDialog.tsx**: Apply to all panel containers
- **WorktreeDashboard.tsx**: Apply to main scrollable area
- **PluginsTab.tsx / CustomProcessesTab.tsx**: Apply to inner scroll containers

Closes #141