### PR TITLE
[golive] security: pin GitHub Actions to SHA in pages.yml

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,9 +25,9 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Validate static website
         run: |
@@ -61,10 +61,10 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: website
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 # Arborist
 
+[![CI](https://github.com/mcaden/arborist/actions/workflows/ci.yml/badge.svg)](https://github.com/mcaden/arborist/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![GitHub release](https://img.shields.io/github/v/release/mcaden/arborist?include_prereleases&sort=semver)](https://github.com/mcaden/arborist/releases)
+
 **Arborist is a cross-platform desktop app for managing AI coding-assistant sessions across Git worktrees.**
 
 It gives each worktree its own persistent terminal-backed context for Claude CLI, GitHub Copilot CLI, and configured custom processes. Worktree tabs


### PR DESCRIPTION
## Changes

- Pin all GitHub Actions in \pages.yml\ to commit SHAs for supply-chain hardening
- Repository settings updated (not in this diff):
  - \equire_last_push_approval: true\ — new commits after approval require re-review
  - Actions restricted to GitHub-owned + verified marketplace creators only