### PR TITLE
[ci-pnpm-fix] ci: replace pnpm/action-setup with corepack enable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # pnpm/action-setup@v6.0.8
+      - run: corepack enable
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
         with:
           node-version: '22'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
         with:
           ref: refs/tags/${{ needs.verify.outputs.tag }}
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # pnpm/action-setup@v6.0.8
+      - run: corepack enable
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
         with:
           node-version: '22'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # pnpm/action-setup@v6.0.8
+      - run: corepack enable
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
         with:
           node-version: '22'

--- a/website/index.html
+++ b/website/index.html
@@ -279,8 +279,8 @@ pnpm dev</code></pre>
             <dd>Public open-source desktop app for local Git worktree and AI CLI workflows.</dd>
             <dt>Distribution</dt>
             <dd>
-              Installers are distributed through GitHub Releases (not yet code-signed — signing is planned); package-manager distribution and automatic
-              updates are not supported.
+              Installers are distributed through GitHub Releases (not yet code-signed — signing is planned); package-manager distribution and
+              automatic updates are not supported.
             </dd>
           </dl>
         </div>


### PR DESCRIPTION
The `pnpm/action-setup` action is not in the repo's trusted actions allow-list, causing `startup_failure` on all CI runs that use it.

**Fix:** Replace `pnpm/action-setup` with `corepack enable` which activates pnpm from the `packageManager` field in `package.json` (pnpm@10.33.0). Node 22 ships with corepack built-in, so no external action is needed.

**Affected workflows:** ci.yml, rust.yml, release.yml