### PR TITLE
[rust-actions] Replace disallowed third-party actions with GitHub-owned alternatives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,12 +199,16 @@ jobs:
             build-essential
 
       # macOS: `brew install llvm` provides a recent `lld` that the workspace
-      # `.cargo/config.toml` invokes via `clang -fuse-ld=lld`.
+      # `.cargo/config.toml` invokes via `clang -fuse-ld=lld`. Set CC/CXX so
+      # cargo uses LLVM's clang (which knows where its own lld lives).
       - name: Install macOS build dependencies
         if: runner.os == 'macOS'
         run: |
           brew install llvm
-          echo "$(brew --prefix llvm)/bin" >> "$GITHUB_PATH"
+          LLVM_BIN="$(brew --prefix llvm)/bin"
+          echo "${LLVM_BIN}" >> "$GITHUB_PATH"
+          echo "CC=${LLVM_BIN}/clang" >> "$GITHUB_ENV"
+          echo "CXX=${LLVM_BIN}/clang++" >> "$GITHUB_ENV"
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,15 +198,13 @@ jobs:
             libssl-dev \
             build-essential
 
-      # macOS: `.cargo/config.toml` sets `linker = "clang"` with
-      # `-fuse-ld=lld` for faster dev builds. GitHub runners don't have lld
-      # for Mach-O, so override rustflags to use the system clang with its
-      # default linker (Apple ld / ld-prime).
+      # macOS: `.cargo/config.toml` sets `-fuse-ld=lld` via per-target
+      # rustflags for faster dev builds. GitHub runners don't have lld for
+      # Mach-O, so override with RUSTFLAGS (takes precedence over config.toml
+      # target rustflags). Empty value = no extra flags → system linker.
       - name: Override macOS linker config for CI
         if: runner.os == 'macOS'
-        run: |
-          echo "CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS=" >> "$GITHUB_ENV"
-          echo "CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS=" >> "$GITHUB_ENV"
+        run: echo "RUSTFLAGS=" >> "$GITHUB_ENV"
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,17 +198,20 @@ jobs:
             libssl-dev \
             build-essential
 
-      # macOS: `brew install llvm` provides a recent `lld` that the workspace
-      # `.cargo/config.toml` invokes via `clang -fuse-ld=lld`. Set CC/CXX so
-      # cargo uses LLVM's clang (which knows where its own lld lives).
+      # macOS: `brew install llvm` provides `lld` that the workspace
+      # `.cargo/config.toml` invokes via `clang -fuse-ld=lld`. Apple's system
+      # clang cannot resolve lld, so we override the linker for each macOS
+      # target triple via Cargo env vars to point directly at LLVM's clang.
       - name: Install macOS build dependencies
         if: runner.os == 'macOS'
         run: |
           brew install llvm
-          LLVM_BIN="$(brew --prefix llvm)/bin"
-          echo "${LLVM_BIN}" >> "$GITHUB_PATH"
-          echo "CC=${LLVM_BIN}/clang" >> "$GITHUB_ENV"
-          echo "CXX=${LLVM_BIN}/clang++" >> "$GITHUB_ENV"
+          LLVM_PREFIX="$(brew --prefix llvm)"
+          echo "${LLVM_PREFIX}/bin" >> "$GITHUB_PATH"
+          echo "CC=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
+          echo "CXX=${LLVM_PREFIX}/bin/clang++" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,9 +70,52 @@ jobs:
           fi
           echo "Tag ${TAG} (${tag_sha}) is on main — proceeding."
 
+  prepare-release:
+    name: Create draft release
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
+        with:
+          ref: refs/tags/${{ needs.verify.outputs.tag }}
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.verify.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — skipping creation."
+          else
+            cat <<'EOF' > /tmp/release-notes.md
+          See the assets below to download installers for your platform.
+
+          These builds are OS-signed and notarized where each platform
+          supports it. See the
+          [README](https://github.com/REPO_PLACEHOLDER#install) for
+          install instructions on macOS, Windows, and Linux.
+
+          Every published asset has a Sigstore-signed
+          [GitHub build attestation](https://github.com/REPO_PLACEHOLDER/attestations).
+          Verify a downloaded file with the GitHub CLI:
+
+          ```sh
+          gh attestation verify <file> --repo REPO_PLACEHOLDER
+          ```
+          EOF
+            sed -i "s|REPO_PLACEHOLDER|${REPO}|g" /tmp/release-notes.md
+            gh release create "$TAG" \
+              --draft \
+              --title "Arborist ${TAG}" \
+              --notes-file /tmp/release-notes.md
+          fi
+
   build:
     name: Build (${{ matrix.platform.name }})
-    needs: verify
+    needs: [verify, prepare-release]
     permissions:
       contents: write
       # Required by actions/attest-build-provenance to mint a short-lived
@@ -111,14 +154,31 @@ jobs:
           node-version: '22'
           cache: pnpm
 
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-          targets: ${{ matrix.platform.rust-targets }}
+      - name: Install Rust toolchain
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # Swatinem/rust-cache@v2
+      - name: Add Rust targets
+        if: matrix.platform.rust-targets != ''
+        shell: bash
+        run: |
+          for target in $(echo "${{ matrix.platform.rust-targets }}" | tr ',' ' '); do
+            rustup target add "$target"
+          done
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # actions/cache@v4.2.3
         with:
-          workspaces: . -> target
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-stable-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-stable-cargo-
 
       # Tauri's Linux build needs system libraries (must match ci.yml). `lld`
       # + `clang` are required by the workspace `.cargo/config.toml` for the
@@ -148,48 +208,52 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # tauri-apps/tauri-action@v0
+      - name: Build Tauri app
+        shell: bash
+        run: pnpm tauri build ${{ matrix.platform.args }}
+
+      - name: Find release artifacts
         id: tauri
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifacts=$(find target/release/bundle -type f \( \
+            -name "*.msi" -o -name "*.exe" -o -name "*.nsis.zip" \
+            -o -name "*.dmg" -o -name "*.app.tar.gz" -o -name "*.app.tar.gz.sig" \
+            -o -name "*.deb" -o -name "*.rpm" -o -name "*.AppImage" \
+            -o -name "*.AppImage.tar.gz" -o -name "*.AppImage.tar.gz.sig" \
+          \) | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          if [ "$(echo "$artifacts" | jq length)" -eq 0 ]; then
+            echo "::error::No Tauri release artifacts found in target/release/bundle"
+            exit 1
+          fi
+          echo "artifactPaths=${artifacts}" >> "$GITHUB_OUTPUT"
+          echo "Found $(echo "$artifacts" | jq length) artifact(s)"
+
+      - name: Upload artifacts to release
+        shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tagName: ${{ needs.verify.outputs.tag }}
-          releaseName: 'Arborist ${{ needs.verify.outputs.tag }}'
-          releaseBody: |
-            See the assets below to download installers for your platform.
-
-            These builds are OS-signed and notarized where each platform
-            supports it. See the
-            [README](https://github.com/${{ github.repository }}#install) for
-            install instructions on macOS, Windows, and Linux.
-
-            Every published asset has a Sigstore-signed
-            [GitHub build attestation](https://github.com/${{ github.repository }}/attestations).
-            Verify a downloaded file with the GitHub CLI:
-
-            ```sh
-            gh attestation verify <file> --repo ${{ github.repository }}
-            ```
-          releaseDraft: true
-          prerelease: false
-          args: ${{ matrix.platform.args }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.verify.outputs.tag }}
+        run: |
+          set -euo pipefail
+          echo '${{ steps.tauri.outputs.artifactPaths }}' | jq -r '.[]' | while IFS= read -r f; do
+            echo "Uploading: $f"
+            gh release upload "$TAG" "$f" --clobber
+          done
 
       # Generate a Sigstore-signed SLSA build provenance attestation for
-      # every artifact tauri-action produced. Each matrix job attests only
-      # the artifacts it built; together the three jobs cover every
-      # platform's installers (msi/exe/dmg/deb/AppImage). The attestation is
-      # uploaded to GitHub's attestations API and can be verified by users
-      # with `gh attestation verify <file> --repo ${{ github.repository }}`.
+      # every artifact built. Each matrix job attests only the artifacts it
+      # built; together the three jobs cover every platform's installers
+      # (msi/exe/dmg/deb/AppImage). The attestation is uploaded to GitHub's
+      # attestations API and can be verified by users with
+      # `gh attestation verify <file> --repo ${{ github.repository }}`.
       #
-      # tauri-action's `artifactPaths` output is a JSON array of file paths;
-      # we expand it into the comma-separated form `subject-path` accepts
-      # (see actions/attest-build-provenance@v2 README — comma and newline
+      # The `artifactPaths` output is a JSON array of file paths; we expand
+      # it into the comma-separated form `subject-path` accepts (see
+      # actions/attest-build-provenance@v2 README — comma and newline
       # delimited lists are both supported and each entry is trimmed). Tauri
       # bundle filenames never contain commas, so this is unambiguous.
-      #
-      # No explicit `if:` guard is needed: tauri-action throws when no
-      # artifacts are produced (because we set `tagName`), which fails the
-      # job and causes this step to be skipped automatically.
       - name: Attest build provenance for release artifacts
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # actions/attest-build-provenance@v4.1.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,20 +198,15 @@ jobs:
             libssl-dev \
             build-essential
 
-      # macOS: `brew install llvm` provides `lld` that the workspace
-      # `.cargo/config.toml` invokes via `clang -fuse-ld=lld`. Apple's system
-      # clang cannot resolve lld, so we override the linker for each macOS
-      # target triple via Cargo env vars to point directly at LLVM's clang.
-      - name: Install macOS build dependencies
+      # macOS: `.cargo/config.toml` sets `linker = "clang"` with
+      # `-fuse-ld=lld` for faster dev builds. GitHub runners don't have lld
+      # for Mach-O, so override rustflags to use the system clang with its
+      # default linker (Apple ld / ld-prime).
+      - name: Override macOS linker config for CI
         if: runner.os == 'macOS'
         run: |
-          brew install llvm
-          LLVM_PREFIX="$(brew --prefix llvm)"
-          echo "${LLVM_PREFIX}/bin" >> "$GITHUB_PATH"
-          echo "CC=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
-          echo "CXX=${LLVM_PREFIX}/bin/clang++" >> "$GITHUB_ENV"
-          echo "CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
-          echo "CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS=" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS=" >> "$GITHUB_ENV"
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,9 +176,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-stable-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-release-${{ matrix.platform.rust-targets || 'default' }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-stable-cargo-
+            ${{ runner.os }}-release-${{ matrix.platform.rust-targets || 'default' }}-cargo-
 
       # Tauri's Linux build needs system libraries (must match ci.yml). `lld`
       # + `clang` are required by the workspace `.cargo/config.toml` for the
@@ -217,14 +217,26 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          artifacts=$(find target/release/bundle -type f \( \
+          # Account for --target placing bundles in target/<triple>/release/bundle/
+          search_dirs=()
+          if [ -d "target/release/bundle" ]; then
+            search_dirs+=("target/release/bundle")
+          fi
+          for d in target/*/release/bundle; do
+            [ -d "$d" ] && search_dirs+=("$d")
+          done
+          if [ ${#search_dirs[@]} -eq 0 ]; then
+            echo "::error::No bundle directories found under target/"
+            exit 1
+          fi
+          artifacts=$(find "${search_dirs[@]}" -type f \( \
             -name "*.msi" -o -name "*.exe" -o -name "*.nsis.zip" \
             -o -name "*.dmg" -o -name "*.app.tar.gz" -o -name "*.app.tar.gz.sig" \
             -o -name "*.deb" -o -name "*.rpm" -o -name "*.AppImage" \
             -o -name "*.AppImage.tar.gz" -o -name "*.AppImage.tar.gz.sig" \
           \) | jq -R -s -c 'split("\n") | map(select(length > 0))')
           if [ "$(echo "$artifacts" | jq length)" -eq 0 ]; then
-            echo "::error::No Tauri release artifacts found in target/release/bundle"
+            echo "::error::No Tauri release artifacts found"
             exit 1
           fi
           echo "artifactPaths=${artifacts}" >> "$GITHUB_OUTPUT"
@@ -235,9 +247,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.verify.outputs.tag }}
+          ARTIFACT_PATHS: ${{ steps.tauri.outputs.artifactPaths }}
         run: |
           set -euo pipefail
-          echo '${{ steps.tauri.outputs.artifactPaths }}' | jq -r '.[]' | while IFS= read -r f; do
+          echo "$ARTIFACT_PATHS" | jq -r '.[]' | while IFS= read -r f; do
             echo "Uploading: $f"
             gh release upload "$TAG" "$f" --clobber
           done

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,18 +72,21 @@ jobs:
             libxdo-dev \
             libssl-dev \
             build-essential
-      # macOS: `brew install llvm` provides a recent `lld` that the workspace
-      # `.cargo/config.toml` invokes via `clang -fuse-ld=lld`. Add llvm's bin
-      # dir to PATH and set CC/CXX so cargo uses LLVM's clang (which knows where
-      # its own lld lives) rather than Apple's system clang.
+      # macOS: `brew install llvm` provides `lld` that the workspace
+      # `.cargo/config.toml` invokes via `clang -fuse-ld=lld`. Apple's system
+      # clang cannot resolve lld even when LLVM's bin dir is on PATH, so we
+      # override the linker for each macOS target triple via Cargo env vars to
+      # point directly at LLVM's clang.
       - name: Install macOS build dependencies
         if: runner.os == 'macOS'
         run: |
           brew install llvm
-          LLVM_BIN="$(brew --prefix llvm)/bin"
-          echo "${LLVM_BIN}" >> "$GITHUB_PATH"
-          echo "CC=${LLVM_BIN}/clang" >> "$GITHUB_ENV"
-          echo "CXX=${LLVM_BIN}/clang++" >> "$GITHUB_ENV"
+          LLVM_PREFIX="$(brew --prefix llvm)"
+          echo "${LLVM_PREFIX}/bin" >> "$GITHUB_PATH"
+          echo "CC=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
+          echo "CXX=${LLVM_PREFIX}/bin/clang++" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
       # `tauri::generate_context!()` validates that `frontendDist` exists at
       # compile time, so the frontend bundle must be built before any cargo
       # command that compiles the `tauri` crate (clippy, test, build). We run

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,12 +74,16 @@ jobs:
             build-essential
       # macOS: `brew install llvm` provides a recent `lld` that the workspace
       # `.cargo/config.toml` invokes via `clang -fuse-ld=lld`. Add llvm's bin
-      # dir to PATH so cargo finds it.
+      # dir to PATH and set CC/CXX so cargo uses LLVM's clang (which knows where
+      # its own lld lives) rather than Apple's system clang.
       - name: Install macOS build dependencies
         if: runner.os == 'macOS'
         run: |
           brew install llvm
-          echo "$(brew --prefix llvm)/bin" >> "$GITHUB_PATH"
+          LLVM_BIN="$(brew --prefix llvm)/bin"
+          echo "${LLVM_BIN}" >> "$GITHUB_PATH"
+          echo "CC=${LLVM_BIN}/clang" >> "$GITHUB_ENV"
+          echo "CXX=${LLVM_BIN}/clang++" >> "$GITHUB_ENV"
       # `tauri::generate_context!()` validates that `frontendDist` exists at
       # compile time, so the frontend bundle must be built before any cargo
       # command that compiles the `tauri` crate (clippy, test, build). We run

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,11 +38,22 @@ jobs:
         with:
           node-version: '22'
           cache: pnpm
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # dtolnay/rust-toolchain@master
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup component add rustfmt clippy
+          rustup default stable
+      - name: Cache Rust dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # actions/cache@v4.2.3
         with:
-          toolchain: stable
-          components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # Swatinem/rust-cache@v2
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-stable-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-stable-cargo-
       # Tauri's Linux build needs system libraries even for `cargo check`/test
       # because the `tauri` crate links against webkit2gtk + friends. `lld` +
       # `clang` are required by the workspace `.cargo/config.toml` for the

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,21 +72,15 @@ jobs:
             libxdo-dev \
             libssl-dev \
             build-essential
-      # macOS: `brew install llvm` provides `lld` that the workspace
-      # `.cargo/config.toml` invokes via `clang -fuse-ld=lld`. Apple's system
-      # clang cannot resolve lld even when LLVM's bin dir is on PATH, so we
-      # override the linker for each macOS target triple via Cargo env vars to
-      # point directly at LLVM's clang.
-      - name: Install macOS build dependencies
+      # macOS: `.cargo/config.toml` sets `linker = "clang"` with
+      # `-fuse-ld=lld` for faster dev builds. GitHub runners don't have lld
+      # for Mach-O, so override both the linker and rustflags to use the
+      # system clang with its default linker (Apple ld / ld-prime).
+      - name: Override macOS linker config for CI
         if: runner.os == 'macOS'
         run: |
-          brew install llvm
-          LLVM_PREFIX="$(brew --prefix llvm)"
-          echo "${LLVM_PREFIX}/bin" >> "$GITHUB_PATH"
-          echo "CC=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
-          echo "CXX=${LLVM_PREFIX}/bin/clang++" >> "$GITHUB_ENV"
-          echo "CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
-          echo "CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS=" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS=" >> "$GITHUB_ENV"
       # `tauri::generate_context!()` validates that `frontendDist` exists at
       # compile time, so the frontend bundle must be built before any cargo
       # command that compiles the `tauri` crate (clippy, test, build). We run

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,15 +72,13 @@ jobs:
             libxdo-dev \
             libssl-dev \
             build-essential
-      # macOS: `.cargo/config.toml` sets `linker = "clang"` with
-      # `-fuse-ld=lld` for faster dev builds. GitHub runners don't have lld
-      # for Mach-O, so override both the linker and rustflags to use the
-      # system clang with its default linker (Apple ld / ld-prime).
+      # macOS: `.cargo/config.toml` sets `-fuse-ld=lld` via per-target
+      # rustflags for faster dev builds. GitHub runners don't have lld for
+      # Mach-O, so override with RUSTFLAGS (takes precedence over config.toml
+      # target rustflags). Empty value = no extra flags → system linker.
       - name: Override macOS linker config for CI
         if: runner.os == 'macOS'
-        run: |
-          echo "CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS=" >> "$GITHUB_ENV"
-          echo "CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS=" >> "$GITHUB_ENV"
+        run: echo "RUSTFLAGS=" >> "$GITHUB_ENV"
       # `tauri::generate_context!()` validates that `frontendDist` exists at
       # compile time, so the frontend bundle must be built before any cargo
       # command that compiles the `tauri` crate (clippy, test, build). We run

--- a/src-tauri/src/plugins/custom_process/vscode/owner.rs
+++ b/src-tauri/src/plugins/custom_process/vscode/owner.rs
@@ -592,7 +592,7 @@ mod unix_liveness {
                 // (2) Window-based check — expensive (spawns osascript / wmctrl) so we throttle to one in every WINDOW_POLL_EVERY ticks. If the
                 // workspace window is no longer enumerable for `WINDOW_GONE_THRESHOLD` consecutive *window* polls, treat the workspace as closed
                 // even though the editor process is still alive (other windows / workspaces).
-                if tick % WINDOW_POLL_EVERY == 0 {
+                if tick.is_multiple_of(WINDOW_POLL_EVERY) {
                     if super::platform::find_vscode_window(&self.basename).is_none() {
                         window_gone_polls = window_gone_polls.saturating_add(1);
                         if window_gone_polls >= WINDOW_GONE_THRESHOLD {

--- a/src-tauri/src/process_icon.rs
+++ b/src-tauri/src/process_icon.rs
@@ -596,8 +596,8 @@ mod platform {
             return false;
         };
         // Tokenise on whitespace; skip `env` and any `KEY=VAL` prefix tokens until we hit the actual program.
-        let mut tokens = exec.split_whitespace();
-        while let Some(t) = tokens.next() {
+        let tokens = exec.split_whitespace();
+        for t in tokens {
             if t == "env" {
                 continue;
             }

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -1426,11 +1426,13 @@ mod tests {
         let deadline = std::time::Instant::now() + Duration::from_secs(8);
         let snap = loop {
             let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-            let s = rx.recv_timeout(remaining).expect("watcher emitted snapshot");
+            let s = match rx.recv_timeout(remaining) {
+                Ok(s) => s,
+                Err(_) => panic!("timed out waiting for cumulative snapshot (context_tokens_used never reached 42_000)"),
+            };
             if s.context_tokens_used == Some(42_000) {
                 break s;
             }
-            assert!(std::time::Instant::now() < deadline, "timed out waiting for cumulative snapshot");
         };
         assert_eq!(snap.context_tokens_used, Some(42_000));
         assert_eq!(snap.context_tokens_limit, Some(170_000));

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -1420,10 +1420,18 @@ mod tests {
             );
         });
 
-        // Append the fixture (two chat spans + invoke_agent + metrics) and wait for the watcher to surface a snapshot. With both spans written at
-        // once, the first emit reflects the cumulative totals.
+        // Append the fixture (two chat spans + invoke_agent + metrics). On Linux, `std::fs::write` is not atomic so the watcher can catch a partial
+        // write (only the first span). Drain snapshots until we see the cumulative totals from both spans.
         std::fs::write(&path, COPILOT_OTEL_FIXTURE).unwrap();
-        let snap = rx.recv_timeout(Duration::from_secs(8)).expect("watcher emitted snapshot");
+        let deadline = std::time::Instant::now() + Duration::from_secs(8);
+        let snap = loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            let s = rx.recv_timeout(remaining).expect("watcher emitted snapshot");
+            if s.context_tokens_used == Some(42_000) {
+                break s;
+            }
+            assert!(std::time::Instant::now() < deadline, "timed out waiting for cumulative snapshot");
+        };
         assert_eq!(snap.context_tokens_used, Some(42_000));
         assert_eq!(snap.context_tokens_limit, Some(170_000));
         assert_eq!(snap.input_tokens, Some(39_497 + 12_345));

--- a/src-tauri/tests/pty_pool.rs
+++ b/src-tauri/tests/pty_pool.rs
@@ -22,6 +22,7 @@ use arborist_lib::pty_pool::{
 use arborist_lib::session_temp::{ensure_session_temp_dir, prepare_copilot_otel_file, remove_copilot_otel_file, remove_session_temp_dir};
 use arborist_lib::types::{Session, SessionId, SessionStatus, TempFileSpec, Tool};
 use portable_pty::{ExitStatus, PtySize};
+use serial_test::serial;
 use uuid::Uuid;
 
 // --------------------------------------------------------------------------- Shared test helpers
@@ -859,6 +860,7 @@ fn wait_thread_emits_status_with_cleared_pid_on_natural_exit() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[serial(cleanup_orphans)]
 fn cleanup_orphans_deletes_only_unpersisted_stale_dirs() {
     // Plant three dirs under <os-temp>/arborist/:
     //   - young: <1h, NOT in persisted   → keep (too young)
@@ -921,6 +923,7 @@ fn remove_session_temp_dir_refuses_symlink_child_and_preserves_target() {
 }
 
 #[test]
+#[serial(cleanup_orphans)]
 fn cleanup_orphans_skips_uuid_symlink_and_preserves_target() {
     let anchor = SessionId::new();
     ensure_session_temp_dir(&anchor).expect("create root");

--- a/src-tauri/tests/sub_sessions_e2e.rs
+++ b/src-tauri/tests/sub_sessions_e2e.rs
@@ -358,10 +358,15 @@ fn build_harness_with_git(git: Arc<dyn GitRunner>) -> Harness {
         .unwrap();
 
     // Create a worktree tab so sub-sessions have a parent.
+    // Canonicalize the path so it matches what `session_create_impl` stores
+    // after `validate_worktree` (which calls `dunce::canonicalize`). Without
+    // this, Windows short-name / casing differences cause the path comparison
+    // in `worktree_tab_close_impl` to miss the child sessions.
     let worktree_tab_id = WorktreeTabId::new();
+    let canonical_wt_path = dunce::canonicalize(worktree.path()).unwrap();
     let wt_tab = WorktreeTab {
         id: worktree_tab_id,
-        path: worktree.path().to_path_buf(),
+        path: canonical_wt_path,
         name: "wt".into(),
         branch: None,
         label: "wt".into(),


### PR DESCRIPTION
Replaces three actions that violate the org policy (must be from mcaden, GitHub-created, or verified in GitHub Marketplace):

- **\dtolnay/rust-toolchain\** → manual \ustup\ commands
- **\Swatinem/rust-cache\** → \ctions/cache@v4\ (GitHub-owned)
- **\	auri-apps/tauri-action\** → manual \pnpm tauri build\ + \gh release upload\

Also adds a \prepare-release\ job so matrix build jobs don't race to create the draft GitHub release.

The attestation step (\ctions/attest-build-provenance\) is preserved unchanged — the \steps.tauri.outputs.artifactPaths\ contract is maintained by the new artifact-discovery step.