### PR TITLE
[pre-push-resiliency] Ensure dist/ stub exists so cargo test works without frontend build

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -88,10 +88,23 @@ fn sanitize_branch(raw: &str) -> String {
 fn ensure_frontend_dist() {
     let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").expect("cargo provides CARGO_MANIFEST_DIR"));
     let dist_dir = manifest_dir.join("..").join("dist");
-    if !dist_dir.exists() {
+
+    if dist_dir.exists() {
+        if !dist_dir.is_dir() {
+            panic!("expected frontend dist path to be a directory: {}", dist_dir.display());
+        }
+    } else {
         std::fs::create_dir_all(&dist_dir).expect("create dist/ stub directory");
-        let index = dist_dir.join("index.html");
-        std::fs::write(&index, "<!doctype html><html><head></head><body></body></html>\n").expect("write dist/index.html stub");
+    }
+
+    let index = dist_dir.join("index.html");
+    if index.exists() {
+        if !index.is_file() {
+            panic!("expected frontend dist entry to be a file: {}", index.display());
+        }
+    } else {
+        std::fs::write(&index, "<!doctype html><html><head></head><body></body></html>\n")
+            .expect("write dist/index.html stub");
     }
 }
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -78,7 +78,26 @@ fn sanitize_branch(raw: &str) -> String {
         .collect()
 }
 
+/// Ensure the frontend `dist/` directory exists with a minimal placeholder.
+///
+/// `tauri_build::build()` expects `frontendDist` (configured as `../dist`) to
+/// be present. In production the `beforeBuildCommand` runs `pnpm run build`
+/// first, but during `cargo test` or ad-hoc `cargo build` the directory may
+/// not exist yet. Creating a stub avoids a hard failure without affecting
+/// production bundles.
+fn ensure_frontend_dist() {
+    let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").expect("cargo provides CARGO_MANIFEST_DIR"));
+    let dist_dir = manifest_dir.join("..").join("dist");
+    if !dist_dir.exists() {
+        std::fs::create_dir_all(&dist_dir).expect("create dist/ stub directory");
+        let index = dist_dir.join("index.html");
+        std::fs::write(&index, "<!doctype html><html><head></head><body></body></html>\n").expect("write dist/index.html stub");
+    }
+}
+
 fn main() {
+    ensure_frontend_dist();
+
     let branch = sanitize_branch(&detect_branch());
 
     // Bake the branch into a generated file under OUT_DIR; lib.rs reads it via


### PR DESCRIPTION
## Problem

\cargo test\ (and the pre-push hook) fails in fresh worktrees or after a clean because \	auri_build::build()\ expects the \rontendDist\ directory (\../dist\) to exist. Since \dist/\ is gitignored and only created by \pnpm run build\, developers hit this frequently when they haven't built the frontend first.

## Solution

Added an \nsure_frontend_dist()\ function to \uild.rs\ that creates a minimal \dist/index.html\ placeholder when the directory is missing. This is a no-op when the frontend has already been built.

Production builds are unaffected since \eforeBuildCommand\ in \	auri.conf.json\ always runs \pnpm run build\ first, replacing any stub with the real bundle.

## Testing

- Verified \cargo test --workspace --features test-helpers\ passes without a prior \pnpm run build\
- Pre-push hook (vitest + cargo test) passed successfully on push