### PR TITLE
[restrict-temp] Fix Linux E2E build fixtures

### DIFF
--- a/dev/e2e/linux/Dockerfile
+++ b/dev/e2e/linux/Dockerfile
@@ -64,8 +64,6 @@ COPY src-tauri/icons/ src-tauri/icons/
 COPY src/ src/
 COPY src-tauri/src/ src-tauri/src/
 COPY index.html tsconfig.json vite.config.ts vitest.config.ts postcss.config.js tailwind.config.js .prettierrc.json ./
-# Instructions dir (needed at runtime for instruction-set tests)
-COPY instructions/ instructions/
 
 # Build the frontend (needed before any cargo build — tauri::generate_context!()
 # requires ../dist to exist)
@@ -164,7 +162,6 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 COPY --from=builder /usr/local/cargo/bin/tauri-driver /usr/local/bin/tauri-driver
 COPY --from=builder /opt/arborist /opt/arborist
 COPY --from=builder /usr/local/bin/arborist-test-child /usr/local/bin/arborist-test-child
-COPY --from=builder /build/instructions /opt/arborist-instructions
 
 # Install WebdriverIO deps via pnpm (matches the rest of the repo — root
 # package.json pins `packageManager: pnpm@10.33.0` and the canonical lockfile

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -426,6 +426,7 @@ describe('App dark mode', () => {
       worktreePrepCommands: [],
       aiLaunchCommands: { commands: {}, iconDataUris: {} },
       pluginSettings: { ai: {}, customProcess: {}, dashboardWidget: {} },
+      repoCommandTrust: { records: {} },
       lastOpenSessions: [],
       tabOrder: [],
       activeSessionId: null,
@@ -446,13 +447,12 @@ describe('App dark mode', () => {
     mediaMatches = true; // OS says dark
     configGet.mockResolvedValue({
       configVersion: 10,
-      defaultInstructionSets: { claude: '', copilot: '' },
-      instructionSetsDir: '',
       workspaceRoot: '/mock/workspace',
       worktreeRoots: [],
       worktreePrepCommands: [],
       aiLaunchCommands: { commands: {}, iconDataUris: {} },
       pluginSettings: { ai: {}, customProcess: {}, dashboardWidget: {} },
+      repoCommandTrust: { records: {} },
       lastOpenSessions: [],
       tabOrder: [],
       activeSessionId: null,
@@ -473,13 +473,12 @@ describe('App dark mode', () => {
     mediaMatches = false;
     configGet.mockResolvedValue({
       configVersion: 10,
-      defaultInstructionSets: { claude: '', copilot: '' },
-      instructionSetsDir: '',
       workspaceRoot: '/mock/workspace',
       worktreeRoots: [],
       worktreePrepCommands: [],
       aiLaunchCommands: { commands: {}, iconDataUris: {} },
       pluginSettings: { ai: {}, customProcess: {}, dashboardWidget: {} },
+      repoCommandTrust: { records: {} },
       lastOpenSessions: [],
       tabOrder: [],
       activeSessionId: null,

--- a/src/lib/tauri-bridge.test.ts
+++ b/src/lib/tauri-bridge.test.ts
@@ -237,6 +237,7 @@ describe('repo command trust commands', () => {
       worktreeTabs: [],
       worktreeTabOrder: [],
       activeWorktreeTabId: null,
+      theme: 'system',
     };
     invokeMock.mockResolvedValueOnce(config);
     const args = { intent: { kind: 'sessionRestart' as const, sessionId: 'sid-1' } };


### PR DESCRIPTION
## Summary
- remove stale instructions directory copies from the Linux E2E Dockerfile
- update AppConfig literals in frontend tests for the current schema

## Validation
- pnpm run build
- pnpm run e2e:linux (passed before splitting these fixes onto this main-based branch)