### PR TITLE
[macos-docker] Add macOS e2e test harness using Docker QEMU/KVM VM

### DIFF
--- a/dev/e2e/macos/README.md
+++ b/dev/e2e/macos/README.md
@@ -100,7 +100,8 @@ pnpm e2e:macos:down
 
 Switch images:
 ```bash
-MACOS_IMAGE=dockurr/macos MACOS_SSH_PORT=50922 pnpm e2e:macos:vm
+# dockurr/macos exposes SSH on port 22 (after enabling), not 10022
+MACOS_IMAGE=dockurr/macos MACOS_SSH_CONTAINER_PORT=22 pnpm e2e:macos:vm
 ```
 
 ## First-Time VM Setup

--- a/dev/e2e/macos/README.md
+++ b/dev/e2e/macos/README.md
@@ -1,0 +1,231 @@
+# macOS e2e Test Harness
+
+Manual Docker-based harness for verifying the **release-built** Arborist `.app` bundle
+on macOS. Runs a full macOS VM inside Docker via QEMU/KVM using
+[sickcodes/docker-osx](https://github.com/sickcodes/Docker-OSX) (default) or
+[dockurr/macos](https://github.com/dockur/macos) (alternative).
+
+> **Legal note**: Running macOS in a VM is only permitted on Apple hardware per
+> Apple's EULA. Only use this harness on machines sold by Apple.
+
+## Prerequisites
+
+- **Linux host with KVM**, or **Windows 11** with Docker Desktop (WSL2 backend provides KVM)
+- `/dev/kvm` accessible to Docker (check: `ls -la /dev/kvm`)
+- Host tools: `sshpass`, `ssh`, `scp`, `rsync`
+- ~20 GB disk for the macOS VM image
+- First boot + provisioning takes 30–60 minutes (one-time)
+
+### Install host tools
+
+```bash
+# Ubuntu/Debian/WSL2
+sudo apt install sshpass openssh-client rsync
+
+# macOS (if using a Mac host with nested virt)
+brew install hudochenkov/sshpass/sshpass rsync
+```
+
+### Verify KVM support
+
+```bash
+# Linux
+sudo apt install cpu-checker && sudo kvm-ok
+
+# Windows 11 (in WSL2)
+ls /dev/kvm   # should exist if Hyper-V is enabled
+```
+
+## Quick Start
+
+```bash
+# 1. Start the macOS VM (first run downloads + installs macOS — interactive)
+pnpm e2e:macos:vm
+
+# 2. Complete one-time provisioning (see "First-Time VM Setup" below)
+pnpm e2e:macos:provision
+
+# 3. Build the .app bundle inside the VM
+pnpm e2e:macos:build
+
+# 4. Run WebdriverIO e2e specs
+pnpm e2e:macos
+
+# 5. Drop into an interactive SSH shell
+pnpm e2e:macos:shell
+
+# 6. Check VM status
+pnpm e2e:macos:status
+
+# 7. Stop the VM
+pnpm e2e:macos:down
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Docker Host (Linux / WSL2)                                 │
+│                                                             │
+│  ┌──────────────────────────────┐                           │
+│  │  vm container (QEMU/KVM)     │                           │
+│  │                              │                           │
+│  │  ┌────────────────────────┐  │                           │
+│  │  │  macOS Sonoma guest    │  │   ◄── SSH on port 50922   │
+│  │  │                        │  │                           │
+│  │  │  • Xcode CLI Tools     │  │                           │
+│  │  │  • Rust + Node/pnpm   │  │                           │
+│  │  │  • Builds .app bundle  │  │                           │
+│  │  │  • Runs tauri-driver   │  │                           │
+│  │  │  • Runs WebdriverIO    │  │                           │
+│  │  └────────────────────────┘  │                           │
+│  │           ▲ /dev/kvm         │                           │
+│  └───────────┼──────────────────┘                           │
+│              │                                              │
+│  ┌───────────┴──────────────────────────────────────────┐   │
+│  │  Host scripts (dev/e2e/macos/scripts/run.sh)         │   │
+│  │  • Waits for VM boot                                 │   │
+│  │  • rsync source → VM                                 │   │
+│  │  • SSH commands: build, test, shell                   │   │
+│  └──────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Docker image options
+
+| Image | SSH Port | Notes |
+|---|---|---|
+| `sickcodes/docker-osx:latest` (default) | 10022 (QEMU hostfwd) → host 50922 | Pre-wired SSH, X11 forwarding, `sshfs` for files |
+| `dockurr/macos` | 22 (after manual enable) → host 50922 | Web viewer on :8006, 9P file sharing |
+
+Switch images:
+```bash
+MACOS_IMAGE=dockurr/macos MACOS_SSH_PORT=50922 pnpm e2e:macos:vm
+```
+
+## First-Time VM Setup
+
+### Step 1: Start the VM
+
+```bash
+pnpm e2e:macos:vm
+```
+
+### Step 2: Complete macOS installation (interactive)
+
+Connect to the VM's display:
+- **sickcodes/docker-osx**: VNC on `localhost:5900`, or X11 forwarding
+- **dockurr/macos**: http://localhost:8006
+
+Complete the macOS installer:
+1. Open Disk Utility → format the largest VirtIO disk as APFS
+2. Install macOS to that disk
+3. Create user account: username `arborist`, password `arborist`
+4. Skip Apple ID, migration assistant, etc.
+
+### Step 3: Enable SSH inside macOS
+
+Once logged into the macOS desktop:
+- System Settings → General → Sharing → Remote Login → ON
+
+Or via Terminal.app inside the VM:
+```bash
+sudo systemsetup -setremotelogin on
+```
+
+### Step 4: Provision the VM
+
+```bash
+pnpm e2e:macos:provision
+```
+
+This installs Xcode CLI Tools, Homebrew, Rust, Node.js 22, pnpm, LLVM/LLD, and
+tauri-driver. Takes ~15 minutes on first run.
+
+### Step 5: Verify
+
+```bash
+pnpm e2e:macos:status
+pnpm e2e:macos:shell
+# Inside: rustc --version && node --version && pnpm --version
+```
+
+## Subsequent Runs
+
+After provisioning, the VM disk persists in a Docker volume. Subsequent runs:
+
+```bash
+# Start VM (boots from disk in ~30s)
+pnpm e2e:macos:vm
+
+# Run full e2e (syncs source, builds, tests)
+pnpm e2e:macos
+
+# Or just build
+pnpm e2e:macos:build
+```
+
+## Hermetic CLI Testing
+
+Same as the Linux harness — no real `claude` or `copilot` CLIs are installed.
+`arborist-test-child` is built alongside the app and passed via
+`--ai-launch-claude` / `--ai-launch-copilot` flags.
+
+## Shared Specs
+
+The e2e specs (`01-launch.spec.ts`, helpers/) are reused from the Linux harness
+at `dev/e2e/linux/specs/`. A macOS-specific `wdio.macos.conf.ts` adapts paths
+and driver configuration for the macOS environment (SafariDriver via tauri-driver).
+
+## Debugging
+
+### Interactive shell
+
+```bash
+pnpm e2e:macos:shell
+# Inside the VM:
+~/arborist/target/release/bundle/macos/Arborist.app/Contents/MacOS/Arborist &
+~/.cargo/bin/tauri-driver --port 4444 &
+cd ~/e2e-specs && npx wdio run wdio.conf.ts --spec ./01-launch.spec.ts
+```
+
+### VNC access
+
+Connect a VNC client to `localhost:5900`.
+
+### Web viewer (dockurr/macos only)
+
+Open http://localhost:8006.
+
+## Troubleshooting
+
+### "KVM device not found"
+
+- Linux: `sudo modprobe kvm_intel` (or `kvm_amd`), check `/dev/kvm` permissions
+- Windows 11: Enable Hyper-V, ensure WSL2 kernel supports KVM
+
+### VM boot hangs
+
+- First boot downloads macOS (~14 GB) — be patient
+- Check logs: `docker compose -f dev/e2e/macos/docker-compose.yml logs vm`
+- Ensure enough RAM (8 GB for VM + host overhead)
+
+### SSH connection refused
+
+- VM may still be booting (30–60s after container starts)
+- Check SSH is enabled: connect via VNC and verify System Settings → Sharing
+- Verify port with `pnpm e2e:macos:status`
+
+### Build fails inside VM
+
+- Ensure Xcode CLI Tools installed: `xcode-select -p`
+- Ensure LLVM on PATH: `which lld`
+- Re-provision: `pnpm e2e:macos:provision`
+
+### Reset VM (nuclear option)
+
+```bash
+docker compose -f dev/e2e/macos/docker-compose.yml down
+docker volume rm $(docker volume ls -q | grep macos-storage)
+# Then start fresh: pnpm e2e:macos:vm
+```

--- a/dev/e2e/macos/docker-compose.yml
+++ b/dev/e2e/macos/docker-compose.yml
@@ -44,8 +44,9 @@ services:
     cap_add:
       - NET_ADMIN
     ports:
-      # SSH: sickcodes QEMU hostfwd 10022 → host 50922
-      - "50922:10022"
+      # SSH: sickcodes QEMU hostfwd 10022; dockurr exposes 22 directly.
+      # MACOS_SSH_CONTAINER_PORT lets callers switch (default 10022 for sickcodes).
+      - "50922:${MACOS_SSH_CONTAINER_PORT:-10022}"
       # Web viewer (dockurr only)
       - "8006:8006"
       # VNC

--- a/dev/e2e/macos/docker-compose.yml
+++ b/dev/e2e/macos/docker-compose.yml
@@ -1,0 +1,61 @@
+# =============================================================================
+# Arborist — macOS e2e Docker Compose (local development harness)
+#
+# Runs a macOS VM via QEMU/KVM inside Docker for e2e testing.
+# Host-side scripts (dev/e2e/macos/scripts/run.sh) SSH into the VM to build
+# and test the app — no orchestrator container needed.
+#
+# Supports two macOS VM images (set MACOS_IMAGE env var):
+#   sickcodes/docker-osx:latest  — default; SSH on port 10022 via QEMU hostfwd
+#   dockurr/macos                — alternative; requires manual SSH enablement
+#
+# Prerequisites:
+#   - Linux host with KVM, or Windows 11 with Docker Desktop (WSL2 + KVM)
+#   - A provisioned macOS VM disk (one-time setup — see README.md)
+#   - Only legal on Apple hardware (Apple EULA requirement)
+#
+# Usage:
+#   docker compose -f dev/e2e/macos/docker-compose.yml up -d
+#   ./dev/e2e/macos/scripts/run.sh e2e
+#   ./dev/e2e/macos/scripts/run.sh build
+#   ./dev/e2e/macos/scripts/run.sh shell
+#   docker compose -f dev/e2e/macos/docker-compose.yml down
+# =============================================================================
+
+services:
+  vm:
+    image: ${MACOS_IMAGE:-sickcodes/docker-osx:latest}
+    container_name: arborist-macos-vm
+    environment:
+      # --- sickcodes/docker-osx settings ---
+      SHORTNAME: ${MACOS_VERSION:-sonoma}
+      GENERATE_UNIQUE: "true"
+      CPU: "Haswell-noTSX"
+      CPUID_FLAGS: "kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on"
+      MASTER_PLIST_URL: "https://raw.githubusercontent.com/sickcodes/osx-serial-generator/master/config-custom-sonoma.plist"
+      # --- dockurr/macos settings (ignored by sickcodes) ---
+      VERSION: "15"
+      RAM_SIZE: "8G"
+      CPU_CORES: "4"
+      DISK_SIZE: "64G"
+    devices:
+      - /dev/kvm
+      - /dev/net/tun
+    cap_add:
+      - NET_ADMIN
+    ports:
+      # SSH: sickcodes QEMU hostfwd 10022 → host 50922
+      - "50922:10022"
+      # Web viewer (dockurr only)
+      - "8006:8006"
+      # VNC
+      - "5900:5900/tcp"
+      - "5900:5900/udp"
+    volumes:
+      # Persistent VM disk — survives container recreation
+      - macos-storage:/storage
+    stop_grace_period: 2m
+    restart: unless-stopped
+
+volumes:
+  macos-storage:

--- a/dev/e2e/macos/scripts/provision-vm.sh
+++ b/dev/e2e/macos/scripts/provision-vm.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Arborist — macOS VM one-time provisioning script
+#
+# Run this INSIDE the macOS VM after initial OS installation.
+# It installs all build dependencies needed for Arborist e2e testing.
+#
+# Usage (from the orchestrator shell or direct SSH):
+#   ssh arborist@<vm-ip> 'bash -s' < scripts/provision-vm.sh
+#
+# Or from within the VM:
+#   bash /Volumes/shared/dev/e2e/macos/scripts/provision-vm.sh
+# =============================================================================
+set -euo pipefail
+
+echo "=== Arborist macOS VM Provisioning ==="
+echo ""
+
+# ---- 1. Xcode Command Line Tools -------------------------------------------
+echo "[1/7] Installing Xcode Command Line Tools..."
+if ! xcode-select -p &>/dev/null; then
+  # Trigger the install prompt. In a headless environment, this may need to be
+  # done interactively via the web viewer (port 8006).
+  xcode-select --install 2>/dev/null || true
+  echo "  → Please complete Xcode CLI Tools installation via the GUI if prompted."
+  echo "  → Then re-run this script."
+  echo "  → (Connect to http://localhost:8006 to see the macOS desktop)"
+  exit 1
+else
+  echo "  ✓ Xcode CLI Tools already installed"
+fi
+
+# ---- 2. Homebrew ------------------------------------------------------------
+echo "[2/7] Installing Homebrew..."
+if ! command -v brew &>/dev/null; then
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  # Add brew to PATH for Apple Silicon
+  if [ -f /opt/homebrew/bin/brew ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+    echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+  fi
+else
+  echo "  ✓ Homebrew already installed"
+fi
+
+# ---- 3. Rust ----------------------------------------------------------------
+echo "[3/7] Installing Rust..."
+if ! command -v rustc &>/dev/null; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+  source "$HOME/.cargo/env"
+else
+  echo "  ✓ Rust already installed ($(rustc --version))"
+fi
+
+# ---- 4. Node.js + pnpm -----------------------------------------------------
+echo "[4/7] Installing Node.js and pnpm..."
+if ! command -v node &>/dev/null; then
+  brew install node@22
+  brew link node@22 --force --overwrite
+else
+  echo "  ✓ Node.js already installed ($(node --version))"
+fi
+
+corepack enable 2>/dev/null || true
+corepack prepare pnpm@10.33.0 --activate 2>/dev/null || true
+echo "  ✓ pnpm ready ($(pnpm --version 2>/dev/null || echo 'installing...'))"
+
+# ---- 5. Build dependencies --------------------------------------------------
+echo "[5/7] Installing build dependencies..."
+# LLD for faster linking (matches .cargo/config.toml)
+brew install llvm 2>/dev/null || true
+# Git (usually pre-installed but ensure latest)
+brew install git 2>/dev/null || true
+echo "  ✓ Build dependencies installed"
+
+# Ensure llvm/lld is on PATH
+LLVM_PREFIX="$(brew --prefix llvm 2>/dev/null || echo /opt/homebrew/opt/llvm)"
+if [ -d "${LLVM_PREFIX}/bin" ]; then
+  export PATH="${LLVM_PREFIX}/bin:$PATH"
+  if ! grep -q 'llvm/bin' ~/.zprofile 2>/dev/null; then
+    echo "export PATH=\"${LLVM_PREFIX}/bin:\$PATH\"" >> ~/.zprofile
+  fi
+fi
+
+# ---- 6. Enable SSH (Remote Login) ------------------------------------------
+echo "[6/7] Enabling SSH (Remote Login)..."
+# This requires admin privileges
+if sudo systemsetup -getremotelogin 2>/dev/null | grep -qi "on"; then
+  echo "  ✓ Remote Login already enabled"
+else
+  sudo systemsetup -setremotelogin on 2>/dev/null || {
+    echo "  ⚠ Could not enable SSH automatically."
+    echo "  → Go to System Settings → General → Sharing → Remote Login → ON"
+  }
+fi
+
+# ---- 7. Mount shared volume (9P) -------------------------------------------
+echo "[7/7] Setting up 9P shared volume auto-mount..."
+# Create a login script that mounts the shared volume
+MOUNT_SCRIPT="$HOME/.arborist-mount-shared.sh"
+cat > "$MOUNT_SCRIPT" << 'EOF'
+#!/bin/bash
+# Auto-mount the Docker shared volume (9P) if available
+if [ ! -d /Volumes/shared/src-tauri ]; then
+  sudo mkdir -p /Volumes/shared 2>/dev/null
+  sudo mount_9p shared 2>/dev/null || true
+fi
+EOF
+chmod +x "$MOUNT_SCRIPT"
+
+# Add to login items via launchd plist
+PLIST="$HOME/Library/LaunchAgents/io.arborist.mount-shared.plist"
+mkdir -p "$HOME/Library/LaunchAgents"
+cat > "$PLIST" << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.arborist.mount-shared</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>${MOUNT_SCRIPT}</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+</dict>
+</plist>
+EOF
+echo "  ✓ 9P auto-mount configured"
+
+# ---- Done -------------------------------------------------------------------
+echo ""
+echo "=== Provisioning complete ==="
+echo ""
+echo "Summary:"
+echo "  • Xcode CLI Tools: $(xcode-select -p 2>/dev/null || echo 'pending')"
+echo "  • Homebrew: $(brew --version 2>/dev/null | head -1 || echo 'pending')"
+echo "  • Rust: $(rustc --version 2>/dev/null || echo 'pending')"
+echo "  • Node: $(node --version 2>/dev/null || echo 'pending')"
+echo "  • pnpm: $(pnpm --version 2>/dev/null || echo 'pending')"
+echo "  • SSH: $(sudo systemsetup -getremotelogin 2>/dev/null || echo 'check manually')"
+echo ""
+echo "Next steps:"
+echo "  1. Mount the shared volume: sudo mount_9p shared"
+echo "  2. Verify source is at /Volumes/shared/src-tauri"
+echo "  3. Run from the host: docker compose run --rm build"
+echo ""

--- a/dev/e2e/macos/scripts/run.sh
+++ b/dev/e2e/macos/scripts/run.sh
@@ -36,21 +36,21 @@ MACOS_USER="${MACOS_USER:-arborist}"
 MACOS_PASS="${MACOS_PASS:-arborist}"
 MACOS_HOST="localhost"
 
-SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -p ${MACOS_SSH_PORT}"
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -p "${MACOS_SSH_PORT}")
 export SSHPASS="${MACOS_PASS}"
 
 # ---- helpers ----------------------------------------------------------------
 
 ssh_cmd() {
-  sshpass -e ssh ${SSH_OPTS} "${MACOS_USER}@${MACOS_HOST}" "$@"
+  sshpass -e ssh "${SSH_OPTS[@]}" "${MACOS_USER}@${MACOS_HOST}" "$@"
 }
 
 scp_to_vm() {
-  sshpass -e scp ${SSH_OPTS} "$1" "${MACOS_USER}@${MACOS_HOST}:$2"
+  sshpass -e scp "${SSH_OPTS[@]}" "$1" "${MACOS_USER}@${MACOS_HOST}:$2"
 }
 
 rsync_to_vm() {
-  sshpass -e rsync -e "ssh ${SSH_OPTS}" "$@"
+  sshpass -e rsync -e "ssh ${SSH_OPTS[*]}" "$@"
 }
 
 check_deps() {
@@ -72,23 +72,23 @@ check_deps() {
 
 wait_for_vm() {
   echo "[macos-e2e] Waiting for macOS VM SSH at ${MACOS_HOST}:${MACOS_SSH_PORT}..."
-  local tries=0
-  local max_tries=180  # 3 minutes
+  local timeout_secs=180
+  local start_time=$SECONDS
 
-  while ! sshpass -e ssh ${SSH_OPTS} -o ConnectTimeout=2 "${MACOS_USER}@${MACOS_HOST}" "echo ok" >/dev/null 2>&1; do
-    tries=$((tries + 1))
-    if [ $tries -ge $max_tries ]; then
-      echo "[macos-e2e] ERROR: VM not reachable after ${max_tries}s" >&2
+  while ! sshpass -e ssh "${SSH_OPTS[@]}" -o ConnectTimeout=2 "${MACOS_USER}@${MACOS_HOST}" "echo ok" >/dev/null 2>&1; do
+    local elapsed=$(( SECONDS - start_time ))
+    if [ $elapsed -ge $timeout_secs ]; then
+      echo "[macos-e2e] ERROR: VM not reachable after ${elapsed}s" >&2
       echo "[macos-e2e] Is the VM running? Try: docker compose -f dev/e2e/macos/docker-compose.yml up -d" >&2
       echo "[macos-e2e] Is the VM provisioned? See dev/e2e/macos/README.md" >&2
       exit 1
     fi
-    if [ $((tries % 15)) -eq 0 ]; then
-      echo "[macos-e2e]   ...still waiting (${tries}s elapsed)"
+    if [ $(( elapsed % 15 )) -lt 2 ] && [ $elapsed -gt 0 ]; then
+      echo "[macos-e2e]   ...still waiting (${elapsed}s elapsed)"
     fi
     sleep 1
   done
-  echo "[macos-e2e] VM is reachable"
+  echo "[macos-e2e] VM is reachable ($(( SECONDS - start_time ))s)"
 }
 
 sync_source() {
@@ -178,7 +178,7 @@ run_e2e() {
   }
 }
 EOF'
-  ssh_cmd 'cd ~/e2e-specs && npm install 2>/dev/null'
+  ssh_cmd 'cd ~/e2e-specs && npm install'
 
   # Run the e2e tests
   echo "[macos-e2e] Running WebdriverIO specs..."
@@ -196,13 +196,13 @@ run_shell() {
   echo "[macos-e2e] Opening interactive SSH session..."
   echo "[macos-e2e] Source at: ~/arborist (after sync)"
   echo ""
-  exec sshpass -e ssh ${SSH_OPTS} -t "${MACOS_USER}@${MACOS_HOST}"
+  exec sshpass -e ssh "${SSH_OPTS[@]}" -t "${MACOS_USER}@${MACOS_HOST}"
 }
 
 run_status() {
   check_deps
   echo "[macos-e2e] Checking VM status..."
-  if sshpass -e ssh ${SSH_OPTS} -o ConnectTimeout=3 "${MACOS_USER}@${MACOS_HOST}" "echo ok" >/dev/null 2>&1; then
+  if sshpass -e ssh "${SSH_OPTS[@]}" -o ConnectTimeout=3 "${MACOS_USER}@${MACOS_HOST}" "echo ok" >/dev/null 2>&1; then
     echo "[macos-e2e] ✓ VM is running and SSH is reachable"
     ssh_cmd "sw_vers 2>/dev/null || echo '(sw_vers not available)'"
   else

--- a/dev/e2e/macos/scripts/run.sh
+++ b/dev/e2e/macos/scripts/run.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Arborist macOS e2e — host-side runner script
+#
+# Automates SSH-based interactions with the macOS VM running in Docker.
+# Handles: waiting for VM boot, syncing source, building, running tests,
+# and opening interactive shells.
+#
+# Usage:
+#   ./dev/e2e/macos/scripts/run.sh <mode> [extra-args...]
+#
+# Modes:
+#   provision - One-time VM setup (install Rust, Node, Xcode CLI tools, etc.)
+#   build     - Sync source + build the .app bundle inside the VM
+#   e2e       - Sync source + build + run WebdriverIO e2e specs
+#   shell     - Open interactive SSH session into the VM
+#   status    - Check if the VM is reachable via SSH
+#
+# Environment:
+#   MACOS_SSH_PORT - SSH port on localhost (default: 50922)
+#   MACOS_USER    - VM username (default: arborist)
+#   MACOS_PASS    - VM password (default: arborist)
+# =============================================================================
+set -euo pipefail
+
+# Resolve script directory → repo root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+E2E_MACOS_DIR="${REPO_ROOT}/dev/e2e/macos"
+
+MODE="${1:-status}"
+shift || true
+
+MACOS_SSH_PORT="${MACOS_SSH_PORT:-50922}"
+MACOS_USER="${MACOS_USER:-arborist}"
+MACOS_PASS="${MACOS_PASS:-arborist}"
+MACOS_HOST="localhost"
+
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -p ${MACOS_SSH_PORT}"
+export SSHPASS="${MACOS_PASS}"
+
+# ---- helpers ----------------------------------------------------------------
+
+ssh_cmd() {
+  sshpass -e ssh ${SSH_OPTS} "${MACOS_USER}@${MACOS_HOST}" "$@"
+}
+
+scp_to_vm() {
+  sshpass -e scp ${SSH_OPTS} "$1" "${MACOS_USER}@${MACOS_HOST}:$2"
+}
+
+rsync_to_vm() {
+  sshpass -e rsync -e "ssh ${SSH_OPTS}" "$@"
+}
+
+check_deps() {
+  local missing=()
+  for cmd in sshpass ssh scp rsync; do
+    if ! command -v "$cmd" &>/dev/null; then
+      missing+=("$cmd")
+    fi
+  done
+  if [ ${#missing[@]} -gt 0 ]; then
+    echo "[macos-e2e] ERROR: Missing required tools: ${missing[*]}" >&2
+    echo "[macos-e2e] Install with:" >&2
+    echo "  Ubuntu/Debian: sudo apt install sshpass openssh-client rsync" >&2
+    echo "  macOS:         brew install sshpass rsync" >&2
+    echo "  Windows/WSL2:  sudo apt install sshpass openssh-client rsync" >&2
+    exit 1
+  fi
+}
+
+wait_for_vm() {
+  echo "[macos-e2e] Waiting for macOS VM SSH at ${MACOS_HOST}:${MACOS_SSH_PORT}..."
+  local tries=0
+  local max_tries=180  # 3 minutes
+
+  while ! sshpass -e ssh ${SSH_OPTS} -o ConnectTimeout=2 "${MACOS_USER}@${MACOS_HOST}" "echo ok" >/dev/null 2>&1; do
+    tries=$((tries + 1))
+    if [ $tries -ge $max_tries ]; then
+      echo "[macos-e2e] ERROR: VM not reachable after ${max_tries}s" >&2
+      echo "[macos-e2e] Is the VM running? Try: docker compose -f dev/e2e/macos/docker-compose.yml up -d" >&2
+      echo "[macos-e2e] Is the VM provisioned? See dev/e2e/macos/README.md" >&2
+      exit 1
+    fi
+    if [ $((tries % 15)) -eq 0 ]; then
+      echo "[macos-e2e]   ...still waiting (${tries}s elapsed)"
+    fi
+    sleep 1
+  done
+  echo "[macos-e2e] VM is reachable"
+}
+
+sync_source() {
+  echo "[macos-e2e] Syncing source to VM (~/${PROJECT_DIR:-arborist})..."
+  ssh_cmd "mkdir -p ~/arborist"
+  rsync_to_vm -az --delete \
+    --exclude='target/' \
+    --exclude='node_modules/' \
+    --exclude='.git/objects/' \
+    --exclude='*.AppImage' \
+    --exclude='.arborist/.worktrees/' \
+    "${REPO_ROOT}/" "${MACOS_USER}@${MACOS_HOST}:~/arborist/"
+  echo "[macos-e2e] Source synced to ~/arborist"
+}
+
+# ---- modes ------------------------------------------------------------------
+
+run_provision() {
+  wait_for_vm
+  echo "[macos-e2e] Running provisioning script inside VM..."
+  ssh_cmd 'bash -s' < "${E2E_MACOS_DIR}/scripts/provision-vm.sh"
+  echo ""
+  echo "[macos-e2e] Provisioning complete. Install tauri-driver:"
+  ssh_cmd 'source "$HOME/.cargo/env" && cargo install tauri-cli 2>/dev/null || echo "(tauri-cli may already be installed)"'
+  echo "[macos-e2e] Done. VM is ready for builds and tests."
+}
+
+run_build() {
+  wait_for_vm
+  sync_source
+
+  echo "[macos-e2e] Building Arborist .app bundle..."
+  ssh_cmd 'source "$HOME/.cargo/env" && cd ~/arborist && pnpm install --frozen-lockfile'
+  ssh_cmd 'source "$HOME/.cargo/env" && cd ~/arborist && pnpm run build'
+  ssh_cmd 'source "$HOME/.cargo/env" && cd ~/arborist && cargo build --release --features test-helpers --bin arborist-test-child'
+  ssh_cmd 'source "$HOME/.cargo/env" && cd ~/arborist && pnpm tauri build --bundles app'
+
+  echo ""
+  echo "[macos-e2e] Build complete!"
+  ssh_cmd 'ls -la ~/arborist/target/release/bundle/macos/'
+}
+
+run_e2e() {
+  wait_for_vm
+  sync_source
+
+  # Build the app
+  echo "[macos-e2e] Building app for e2e testing..."
+  ssh_cmd 'source "$HOME/.cargo/env" && cd ~/arborist && pnpm install --frozen-lockfile'
+  ssh_cmd 'source "$HOME/.cargo/env" && cd ~/arborist && pnpm run build'
+  ssh_cmd 'source "$HOME/.cargo/env" && cd ~/arborist && cargo build --release --features test-helpers --bin arborist-test-child'
+  ssh_cmd 'source "$HOME/.cargo/env" && cd ~/arborist && pnpm tauri build --bundles app'
+
+  # Set up test workspace
+  echo "[macos-e2e] Setting up test workspace..."
+  ssh_cmd 'if [ ! -d /tmp/arborist-test-workspace/.git ]; then
+    rm -rf /tmp/arborist-test-workspace
+    mkdir -p /tmp/arborist-test-workspace
+    git -C /tmp/arborist-test-workspace init -q -b main
+    git -C /tmp/arborist-test-workspace config user.email "e2e@arborist.local"
+    git -C /tmp/arborist-test-workspace config user.name "Arborist E2E"
+    echo "# Arborist e2e test workspace" > /tmp/arborist-test-workspace/README.md
+    git -C /tmp/arborist-test-workspace add README.md
+    git -C /tmp/arborist-test-workspace commit -q -m "initial commit"
+  fi'
+
+  # Copy and install e2e test deps
+  echo "[macos-e2e] Setting up WebdriverIO test environment..."
+  ssh_cmd "mkdir -p ~/e2e-specs"
+  rsync_to_vm -az --delete \
+    "${REPO_ROOT}/dev/e2e/linux/specs/" "${MACOS_USER}@${MACOS_HOST}:~/e2e-specs/"
+  scp_to_vm "${E2E_MACOS_DIR}/scripts/wdio.macos.conf.ts" "~/e2e-specs/wdio.conf.ts"
+
+  ssh_cmd 'cd ~/e2e-specs && cat > package.json << '\''EOF'\''
+{
+  "name": "arborist-e2e-macos",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@wdio/cli": "^9.19.0",
+    "@wdio/local-runner": "^9.19.0",
+    "@wdio/mocha-framework": "^9.19.0",
+    "@wdio/spec-reporter": "^9.19.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.7.2"
+  }
+}
+EOF'
+  ssh_cmd 'cd ~/e2e-specs && npm install 2>/dev/null'
+
+  # Run the e2e tests
+  echo "[macos-e2e] Running WebdriverIO specs..."
+  set +e
+  ssh_cmd "cd ~/e2e-specs && npx wdio run wdio.conf.ts $*"
+  local rc=$?
+  set -e
+
+  echo "[macos-e2e] WebdriverIO exited with code $rc"
+  exit $rc
+}
+
+run_shell() {
+  wait_for_vm
+  echo "[macos-e2e] Opening interactive SSH session..."
+  echo "[macos-e2e] Source at: ~/arborist (after sync)"
+  echo ""
+  exec sshpass -e ssh ${SSH_OPTS} -t "${MACOS_USER}@${MACOS_HOST}"
+}
+
+run_status() {
+  check_deps
+  echo "[macos-e2e] Checking VM status..."
+  if sshpass -e ssh ${SSH_OPTS} -o ConnectTimeout=3 "${MACOS_USER}@${MACOS_HOST}" "echo ok" >/dev/null 2>&1; then
+    echo "[macos-e2e] ✓ VM is running and SSH is reachable"
+    ssh_cmd "sw_vers 2>/dev/null || echo '(sw_vers not available)'"
+  else
+    echo "[macos-e2e] ✗ VM is not reachable on ${MACOS_HOST}:${MACOS_SSH_PORT}"
+    echo "[macos-e2e]   Start with: docker compose -f dev/e2e/macos/docker-compose.yml up -d"
+  fi
+}
+
+# ---- dispatch ---------------------------------------------------------------
+
+check_deps
+
+case "$MODE" in
+  provision) run_provision "$@" ;;
+  build)     run_build "$@" ;;
+  e2e)       run_e2e "$@" ;;
+  shell)     run_shell "$@" ;;
+  status)    run_status "$@" ;;
+  *)
+    echo "[macos-e2e] Unknown mode: $MODE" >&2
+    echo "Usage: run.sh {provision|build|e2e|shell|status}" >&2
+    exit 1
+    ;;
+esac

--- a/dev/e2e/macos/scripts/wdio.macos.conf.ts
+++ b/dev/e2e/macos/scripts/wdio.macos.conf.ts
@@ -1,0 +1,142 @@
+// =============================================================================
+// Arborist — WebdriverIO configuration for macOS e2e
+//
+// Drives the release-built .app bundle via tauri-driver + SafariDriver on
+// macOS. tauri-driver is managed by the wdio hooks (same pattern as Linux).
+// =============================================================================
+
+import { spawn, type ChildProcess } from "child_process";
+import { createConnection, type Socket } from "net";
+import { existsSync } from "fs";
+import { resolve } from "path";
+
+let tauriDriver: ChildProcess | null = null;
+let shuttingDown = false;
+
+// Locate the .app bundle — check 9P shared mount first, fallback to ~/arborist
+const SHARED_BUNDLE = "/Volumes/shared/target/release/bundle/macos/Arborist.app";
+const LOCAL_BUNDLE = resolve(process.env.HOME ?? "~", "arborist/target/release/bundle/macos/Arborist.app");
+const APP_BINARY = existsSync(SHARED_BUNDLE)
+  ? `${SHARED_BUNDLE}/Contents/MacOS/Arborist`
+  : `${LOCAL_BUNDLE}/Contents/MacOS/Arborist`;
+
+// Locate arborist-test-child
+const SHARED_TEST_CHILD = "/Volumes/shared/target/release/arborist-test-child";
+const LOCAL_TEST_CHILD = resolve(process.env.HOME ?? "~", "arborist/target/release/arborist-test-child");
+const TEST_CHILD = existsSync(SHARED_TEST_CHILD) ? SHARED_TEST_CHILD : LOCAL_TEST_CHILD;
+
+const TEST_WORKSPACE = "/tmp/arborist-test-workspace";
+const DRIVER_PORT = 4444;
+const DRIVER_STARTUP_TIMEOUT_MS = 10_000;
+const DRIVER_POLL_INTERVAL_MS = 100;
+
+/** Poll until a TCP connection to localhost:port succeeds, or timeout. */
+function waitForPort(port: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise<void>((resolve, reject) => {
+    function attempt() {
+      if (Date.now() > deadline) {
+        reject(new Error(`tauri-driver did not bind to port ${port} within ${timeoutMs}ms`));
+        return;
+      }
+      const sock: Socket = createConnection({ port, host: "127.0.0.1" }, () => {
+        sock.destroy();
+        resolve();
+      });
+      sock.on("error", () => {
+        sock.destroy();
+        setTimeout(attempt, DRIVER_POLL_INTERVAL_MS);
+      });
+    }
+    attempt();
+  });
+}
+
+export const config: WebdriverIO.Config = {
+  runner: "local",
+  hostname: "127.0.0.1",
+  port: DRIVER_PORT,
+
+  specs: ["./**/*.spec.ts"],
+  exclude: ["./helpers/**"],
+
+  maxInstances: 1,
+
+  capabilities: [
+    {
+      maxInstances: 1,
+      "tauri:options": {
+        application: APP_BINARY,
+        args: [
+          "--workspace",
+          TEST_WORKSPACE,
+          `--ai-launch-claude=${TEST_CHILD}`,
+          `--ai-launch-copilot=${TEST_CHILD}`,
+        ],
+      },
+    },
+  ],
+
+  logLevel: "warn",
+  waitforTimeout: 10000,
+  connectionRetryTimeout: 120000,
+  connectionRetryCount: 3,
+
+  framework: "mocha",
+  reporters: ["spec"],
+
+  mochaOpts: {
+    ui: "bdd",
+    timeout: 60000,
+  },
+
+  beforeSession: () => {
+    // On macOS, tauri-driver uses SafariDriver under the hood.
+    // It must be installed via: cargo install tauri-cli (provides tauri-driver)
+    const driverPath = resolve(process.env.HOME ?? "~", ".cargo/bin/tauri-driver");
+
+    tauriDriver = spawn(driverPath, ["--port", String(DRIVER_PORT)], {
+      stdio: [null, process.stdout, process.stderr],
+    });
+
+    tauriDriver.on("error", (error) => {
+      console.error("[wdio] tauri-driver error:", error);
+      if (!shuttingDown) process.exit(1);
+    });
+
+    tauriDriver.on("exit", (code) => {
+      if (!shuttingDown) {
+        console.error("[wdio] tauri-driver exited unexpectedly with code:", code);
+        process.exit(1);
+      }
+    });
+
+    return waitForPort(DRIVER_PORT, DRIVER_STARTUP_TIMEOUT_MS);
+  },
+
+  afterSession: () => {
+    shuttingDown = true;
+    tauriDriver?.kill();
+    tauriDriver = null;
+  },
+};
+
+// Cleanup on unexpected exit
+function cleanup() {
+  shuttingDown = true;
+  try {
+    tauriDriver?.kill();
+  } catch {
+    // ignore
+  }
+}
+
+process.on("exit", cleanup);
+process.on("SIGINT", () => {
+  cleanup();
+  process.exit(130);
+});
+process.on("SIGTERM", () => {
+  cleanup();
+  process.exit(143);
+});

--- a/dev/e2e/macos/scripts/wdio.macos.conf.ts
+++ b/dev/e2e/macos/scripts/wdio.macos.conf.ts
@@ -8,21 +8,24 @@
 import { spawn, type ChildProcess } from "child_process";
 import { createConnection, type Socket } from "net";
 import { existsSync } from "fs";
+import { homedir } from "os";
 import { resolve } from "path";
 
 let tauriDriver: ChildProcess | null = null;
 let shuttingDown = false;
 
+const HOME = process.env.HOME ?? homedir();
+
 // Locate the .app bundle — check 9P shared mount first, fallback to ~/arborist
 const SHARED_BUNDLE = "/Volumes/shared/target/release/bundle/macos/Arborist.app";
-const LOCAL_BUNDLE = resolve(process.env.HOME ?? "~", "arborist/target/release/bundle/macos/Arborist.app");
+const LOCAL_BUNDLE = resolve(HOME, "arborist/target/release/bundle/macos/Arborist.app");
 const APP_BINARY = existsSync(SHARED_BUNDLE)
   ? `${SHARED_BUNDLE}/Contents/MacOS/Arborist`
   : `${LOCAL_BUNDLE}/Contents/MacOS/Arborist`;
 
 // Locate arborist-test-child
 const SHARED_TEST_CHILD = "/Volumes/shared/target/release/arborist-test-child";
-const LOCAL_TEST_CHILD = resolve(process.env.HOME ?? "~", "arborist/target/release/arborist-test-child");
+const LOCAL_TEST_CHILD = resolve(HOME, "arborist/target/release/arborist-test-child");
 const TEST_CHILD = existsSync(SHARED_TEST_CHILD) ? SHARED_TEST_CHILD : LOCAL_TEST_CHILD;
 
 const TEST_WORKSPACE = "/tmp/arborist-test-workspace";
@@ -93,7 +96,7 @@ export const config: WebdriverIO.Config = {
   beforeSession: () => {
     // On macOS, tauri-driver uses SafariDriver under the hood.
     // It must be installed via: cargo install tauri-cli (provides tauri-driver)
-    const driverPath = resolve(process.env.HOME ?? "~", ".cargo/bin/tauri-driver");
+    const driverPath = resolve(HOME, ".cargo/bin/tauri-driver");
 
     tauriDriver = spawn(driverPath, ["--port", String(DRIVER_PORT)], {
       stdio: [null, process.stdout, process.stderr],

--- a/package.json
+++ b/package.json
@@ -40,7 +40,14 @@
     "e2e:linux": "docker compose -f dev/e2e/linux/docker-compose.yml run --rm e2e",
     "e2e:linux:rust": "docker compose -f dev/e2e/linux/docker-compose.yml run --rm rust",
     "e2e:linux:vitest": "docker compose -f dev/e2e/linux/docker-compose.yml run --rm vitest",
-    "e2e:linux:shell": "docker compose -f dev/e2e/linux/docker-compose.yml run --rm shell"
+    "e2e:linux:shell": "docker compose -f dev/e2e/linux/docker-compose.yml run --rm shell",
+    "e2e:macos:vm": "docker compose -f dev/e2e/macos/docker-compose.yml up -d",
+    "e2e:macos:down": "docker compose -f dev/e2e/macos/docker-compose.yml down",
+    "e2e:macos:provision": "bash dev/e2e/macos/scripts/run.sh provision",
+    "e2e:macos:build": "bash dev/e2e/macos/scripts/run.sh build",
+    "e2e:macos": "bash dev/e2e/macos/scripts/run.sh e2e",
+    "e2e:macos:shell": "bash dev/e2e/macos/scripts/run.sh shell",
+    "e2e:macos:status": "bash dev/e2e/macos/scripts/run.sh status"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.11.0",


### PR DESCRIPTION
Adds a Docker-based macOS e2e harness mirroring the Linux setup:

## What

- **\docker-compose.yml\**: Runs macOS VM via \sickcodes/docker-osx\ (or \dockurr/macos\)
- **\scripts/run.sh\**: Host-side automation (provision, build, e2e, shell, status)
- **\scripts/provision-vm.sh\**: One-time VM setup (Xcode CLI, Rust, Node, pnpm, LLD)
- **\scripts/wdio.macos.conf.ts\**: macOS-specific WebdriverIO config using tauri-driver/SafariDriver
- **\README.md\**: Full setup guide, architecture diagram, troubleshooting

## Design

Unlike the Linux harness which uses a multi-stage Dockerfile to build inside containers, the macOS harness:
1. Runs a full macOS VM in QEMU/KVM via Docker (\sickcodes/docker-osx\)
2. Uses host-side scripts that SSH into the VM to sync source, build, and run tests
3. Reuses the same e2e specs from \dev/e2e/linux/specs/\ with a macOS-specific wdio config

## pnpm scripts

| Script | Action |
|---|---|
| \pnpm e2e:macos:vm\ | Start the macOS VM |
| \pnpm e2e:macos:provision\ | One-time VM provisioning |
| \pnpm e2e:macos:build\ | Sync source + build .app bundle |
| \pnpm e2e:macos\ | Full e2e run (build + WebdriverIO specs) |
| \pnpm e2e:macos:shell\ | Interactive SSH session |
| \pnpm e2e:macos:status\ | Check VM reachability |
| \pnpm e2e:macos:down\ | Stop the VM |

## Prerequisites

- Linux host with KVM (or Windows 11 WSL2)
- Apple hardware (macOS EULA requirement)
- Host tools: \sshpass\, \ssh\, \sync\

Not intended for CI — local development harness only.