### PR TITLE
[copilot-agent-resume] Fix persisted AI metrics wiped during app-boot restore

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -426,6 +426,7 @@ describe('App dark mode', () => {
       worktreePrepCommands: [],
       aiLaunchCommands: { commands: {}, iconDataUris: {} },
       pluginSettings: { ai: {}, customProcess: {}, dashboardWidget: {} },
+      repoCommandTrust: { records: {} },
       lastOpenSessions: [],
       tabOrder: [],
       activeSessionId: null,
@@ -446,13 +447,12 @@ describe('App dark mode', () => {
     mediaMatches = true; // OS says dark
     configGet.mockResolvedValue({
       configVersion: 10,
-      defaultInstructionSets: { claude: '', copilot: '' },
-      instructionSetsDir: '',
       workspaceRoot: '/mock/workspace',
       worktreeRoots: [],
       worktreePrepCommands: [],
       aiLaunchCommands: { commands: {}, iconDataUris: {} },
       pluginSettings: { ai: {}, customProcess: {}, dashboardWidget: {} },
+      repoCommandTrust: { records: {} },
       lastOpenSessions: [],
       tabOrder: [],
       activeSessionId: null,
@@ -473,13 +473,12 @@ describe('App dark mode', () => {
     mediaMatches = false;
     configGet.mockResolvedValue({
       configVersion: 10,
-      defaultInstructionSets: { claude: '', copilot: '' },
-      instructionSetsDir: '',
       workspaceRoot: '/mock/workspace',
       worktreeRoots: [],
       worktreePrepCommands: [],
       aiLaunchCommands: { commands: {}, iconDataUris: {} },
       pluginSettings: { ai: {}, customProcess: {}, dashboardWidget: {} },
+      repoCommandTrust: { records: {} },
       lastOpenSessions: [],
       tabOrder: [],
       activeSessionId: null,

--- a/src/components/TabContextMenu.tsx
+++ b/src/components/TabContextMenu.tsx
@@ -102,6 +102,7 @@ export function TabContextMenu({ parentSessionId, anchor, onClose, restoreFocusT
 
   const handleRestart = (): void => {
     const dims = getTerminalDimensions(parentSessionId) ?? measureInitialPtyDimensions();
+    sessionActions.prepareForRestart(parentSessionId);
     void (async () => {
       const trusted = await ensureShellCommandTrusted({ kind: 'sessionRestart', sessionId: parentSessionId });
       if (!trusted) return;

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -10,7 +10,7 @@ import { useEffect, useRef } from 'react';
 import { ensureShellCommandTrusted } from '@/lib/shell-command-trust';
 import { formatError, sessionRestart } from '@/lib/tauri-bridge';
 import { measureInitialPtyDimensions, useTerminal } from '@/hooks/use-terminal';
-import { useSessionById, useStatusMessage } from '@/store/session-store';
+import { useSessionById, useSessionActions, useStatusMessage } from '@/store/session-store';
 import { selectIsSwitching, useWorkspaceSwitchUiStore } from '@/store/workspace-switch-ui-store';
 import type { SessionId } from '@/types/arborist';
 
@@ -29,6 +29,7 @@ export function TerminalView({ sessionId, isActive }: TerminalViewProps): JSX.El
   const containerRef = useRef<HTMLDivElement | null>(null);
   const session = useSessionById(sessionId);
   const statusMessage = useStatusMessage(sessionId);
+  const sessionActions = useSessionActions();
   const { attach, detach, focus, refit, getDimensions } = useTerminal(sessionId);
   const isSwitching = useWorkspaceSwitchUiStore(selectIsSwitching);
 
@@ -72,11 +73,8 @@ export function TerminalView({ sessionId, isActive }: TerminalViewProps): JSX.El
   const showOverlay = status === 'error' || status === 'exited';
 
   const handleRestart = (): void => {
-    // Reuse the existing terminal's measured cols/rows so the new PTY
-    // child paints its splash at the size xterm currently shows. If
-    // somehow the terminal entry is gone (very rare — overlay hides
-    // before the entry is disposed), fall back to a fresh measurement.
     const dims = getDimensions() ?? measureInitialPtyDimensions();
+    sessionActions.prepareForRestart(sessionId);
     void (async () => {
       const trusted = await ensureShellCommandTrusted({ kind: 'sessionRestart', sessionId });
       if (!trusted) return;

--- a/src/lib/tauri-bridge.test.ts
+++ b/src/lib/tauri-bridge.test.ts
@@ -237,6 +237,7 @@ describe('repo command trust commands', () => {
       worktreeTabs: [],
       worktreeTabOrder: [],
       activeWorktreeTabId: null,
+      theme: 'dark',
     };
     invokeMock.mockResolvedValueOnce(config);
     const args = { intent: { kind: 'sessionRestart' as const, sessionId: 'sid-1' } };

--- a/src/store/session-store.test.ts
+++ b/src/store/session-store.test.ts
@@ -789,7 +789,7 @@ describe('applyMetrics', () => {
 });
 
 describe('applyStatus + applyMetrics interaction', () => {
-  it('clears stale metrics when a session transitions back to starting (restart)', () => {
+  it('preserves metrics when a session transitions to starting (restore)', () => {
     useSessionStore.setState({
       sessions: [makeView({ id: 'a' })],
       metrics: {
@@ -798,7 +798,7 @@ describe('applyStatus + applyMetrics interaction', () => {
     });
     const evt: SessionStatusEvent = { sessionId: 'a', status: 'starting' };
     useSessionStore.getState().actions.applyStatus(evt);
-    expect(useSessionStore.getState().metrics['a']).toBeUndefined();
+    expect(useSessionStore.getState().metrics['a']).toBeDefined();
   });
 
   it('preserves metrics across non-starting status transitions', () => {
@@ -811,6 +811,41 @@ describe('applyStatus + applyMetrics interaction', () => {
     const evt: SessionStatusEvent = { sessionId: 'a', status: 'running' };
     useSessionStore.getState().actions.applyStatus(evt);
     expect(useSessionStore.getState().metrics['a']).toBeDefined();
+  });
+});
+
+describe('prepareForRestart', () => {
+  it('clears stale metrics and turn markers for the restarted session', () => {
+    useSessionStore.setState({
+      sessions: [makeView({ id: 'a' }), makeView({ id: 'b' })],
+      metrics: {
+        a: { sessionId: 'a', contextUsedPct: 50, observedAt: 1 },
+        b: { sessionId: 'b', contextUsedPct: 30, observedAt: 2 },
+      },
+      lastTurnEndAt: { a: 100, b: 200 },
+      lastTurnDurationMs: { a: 5000, b: 3000 },
+    });
+    useSessionStore.getState().actions.prepareForRestart('a');
+    const state = useSessionStore.getState();
+    expect(state.metrics['a']).toBeUndefined();
+    expect(state.metrics['b']).toBeDefined();
+    expect(state.lastTurnEndAt['a']).toBeUndefined();
+    expect(state.lastTurnEndAt['b']).toBe(200);
+    expect(state.lastTurnDurationMs['a']).toBeUndefined();
+    expect(state.lastTurnDurationMs['b']).toBe(3000);
+  });
+
+  it('is a no-op when the session has no cached metrics or turn markers', () => {
+    useSessionStore.setState({
+      sessions: [makeView({ id: 'a' })],
+      metrics: {},
+      lastTurnEndAt: {},
+      lastTurnDurationMs: {},
+    });
+    const before = useSessionStore.getState();
+    useSessionStore.getState().actions.prepareForRestart('a');
+    const after = useSessionStore.getState();
+    expect(after.metrics).toBe(before.metrics);
   });
 });
 

--- a/src/store/session-store.ts
+++ b/src/store/session-store.ts
@@ -219,6 +219,15 @@ export interface SessionStoreActions {
    * against races with `close`.
    */
   applyMetrics: (evt: SessionMetricsEvent) => void;
+  /**
+   * Clear metrics and turn-end markers for a session about to be
+   * restarted. Called eagerly from the frontend restart call sites so
+   * stale numbers don't linger in the sidebar while the new run
+   * accumulates its first turn. Separated from `applyStatus` so that
+   * app-boot restore (which also transitions to `starting`) does NOT
+   * wipe the persisted `lastMetrics` seeded during hydrate.
+   */
+  prepareForRestart: (id: SessionId) => void;
 }
 
 type Store = SessionStoreState & { actions: SessionStoreActions };
@@ -595,7 +604,7 @@ export const useSessionStore = create<Store>((set, get) => {
       // Track the optional status message keyed by session id. We
       // overwrite (not merge) so a status transition without a message
       // clears any stale annotation from a prior transition.
-      const { statusMessages, metrics } = get();
+      const { statusMessages } = get();
       const nextMessages = { ...statusMessages };
       if (evt.message !== undefined && evt.message.length > 0) {
         nextMessages[evt.sessionId] = evt.message;
@@ -606,16 +615,13 @@ export const useSessionStore = create<Store>((set, get) => {
         sessions: nextSessions,
         statusMessages: nextMessages,
       };
-      // On restart (back to `starting`), drop any stale metrics so the
-      // sidebar doesn't show numbers from the previous run. Same logic
-      // applies to the turn-end markers — a new run hasn't completed any
-      // turns yet, so the sidebar should fall back to `idle`.
+      // On restart (back to `starting`), drop stale turn-end markers so
+      // the sidebar falls back to `idle` until the new run finishes its
+      // first turn. Metrics are NOT cleared here — that's handled by the
+      // explicit `prepareForRestart` action at the restart call site.
+      // Clearing here would also wipe persisted `lastMetrics` seeded
+      // during app-boot restore (Issue #140 fix).
       if (evt.status === 'starting') {
-        if (evt.sessionId in metrics) {
-          const nextMetrics = { ...metrics };
-          delete nextMetrics[evt.sessionId];
-          patch.metrics = nextMetrics;
-        }
         const { lastTurnEndAt, lastTurnDurationMs } = get();
         if (evt.sessionId in lastTurnEndAt) {
           const next = { ...lastTurnEndAt };
@@ -827,6 +833,27 @@ export const useSessionStore = create<Store>((set, get) => {
       // the rate the backend emits (≤ once per ~2s per session).
       if (prev && JSON.stringify(prev) === JSON.stringify(evt)) return;
       set({ metrics: { ...metrics, [evt.sessionId]: evt } });
+    },
+
+    prepareForRestart: (id) => {
+      const { metrics, lastTurnEndAt, lastTurnDurationMs } = get();
+      const patch: Partial<SessionStoreState> = {};
+      if (id in metrics) {
+        const next = { ...metrics };
+        delete next[id];
+        patch.metrics = next;
+      }
+      if (id in lastTurnEndAt) {
+        const next = { ...lastTurnEndAt };
+        delete next[id];
+        patch.lastTurnEndAt = next;
+      }
+      if (id in lastTurnDurationMs) {
+        const next = { ...lastTurnDurationMs };
+        delete next[id];
+        patch.lastTurnDurationMs = next;
+      }
+      if (Object.keys(patch).length > 0) set(patch);
     },
   };
 


### PR DESCRIPTION
## Problem

PR #149 added lastMetrics persistence so dashboard AI stats survive app restarts. However, Copilot session metrics were always blank after relaunch — only Claude metrics restored correctly.

## Root Cause

The session store's \pplyStatus\ handler cleared metrics whenever a session transitioned to \'starting'\. During app-boot restore, \estore_all_sessions\ emits \session://status(Starting)\ for every session, which wiped the metrics that \hydrate()\ had just seeded from \lastMetrics\.

**Why Claude was unaffected:** Claude's watcher re-reads the existing transcript JSONL on resume (mtime triggers a re-read from offset 0), so metrics re-emit within one poll cycle (~2s).

**Why Copilot was affected:** Copilot's OTel file is reset/truncated during spawn prep. The watcher starts with an empty file and no metrics emit until the first completed turn.

## Fix

Moved metrics-clearing into a dedicated \prepareForRestart\ store action, called explicitly from UI restart call sites (\TabContextMenu\, \TerminalView\). The \pplyStatus\ handler no longer clears metrics on \starting\ — this cleanly separates user-initiated restart (fresh metrics) from app-boot restore (preserve persisted metrics).

## Also fixes

Pre-existing type errors in \App.test.tsx\ and \	auri-bridge.test.ts\ (missing \epoCommandTrust\/\	heme\ fields, stale \defaultInstructionSets\ property).

Closes #140