### PR TITLE
[release-troubleshoot] Fix release workflow cache key and add release-prep tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,6 +208,20 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Verify version matches tag
+        shell: bash
+        env:
+          TAG: ${{ needs.verify.outputs.tag }}
+        run: |
+          set -euo pipefail
+          expected="${TAG#v}"
+          actual=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('src-tauri/tauri.conf.json','utf8')).version)")
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Version mismatch: tag=${TAG} expects ${expected}, but tauri.conf.json has ${actual}. Run 'pnpm run release:prep ${expected}' to fix."
+            exit 1
+          fi
+          echo "Version check passed: ${actual} matches tag ${TAG}"
+
       - name: Build Tauri app
         shell: bash
         run: pnpm tauri build ${{ matrix.platform.args }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,12 +215,27 @@ jobs:
         run: |
           set -euo pipefail
           expected="${TAG#v}"
-          actual=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('src-tauri/tauri.conf.json','utf8')).version)")
-          if [ "$actual" != "$expected" ]; then
-            echo "::error::Version mismatch: tag=${TAG} expects ${expected}, but tauri.conf.json has ${actual}. Run 'pnpm run release:prep ${expected}' to fix."
+
+          # Check all four manifest files that release-prep maintains
+          tauri_ver=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('src-tauri/tauri.conf.json','utf8')).version)")
+          pkg_ver=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('package.json','utf8')).version)")
+          cargo_ver=$(sed -n 's/^version = "\(.*\)"/\1/p' src-tauri/Cargo.toml | head -1)
+          types_ver=$(sed -n 's/^version = "\(.*\)"/\1/p' crates/arborist-types/Cargo.toml | head -1)
+
+          ok=true
+          for pair in "src-tauri/tauri.conf.json:${tauri_ver}" "package.json:${pkg_ver}" "src-tauri/Cargo.toml:${cargo_ver}" "crates/arborist-types/Cargo.toml:${types_ver}"; do
+            file="${pair%%:*}"
+            ver="${pair#*:}"
+            if [ "$ver" != "$expected" ]; then
+              echo "::error::Version mismatch in ${file}: expected ${expected} (from tag ${TAG}), got ${ver}."
+              ok=false
+            fi
+          done
+          if [ "$ok" = false ]; then
+            echo "::error::Run 'pnpm run release:prep ${expected}' to fix all manifests."
             exit 1
           fi
-          echo "Version check passed: ${actual} matches tag ${TAG}"
+          echo "Version check passed: all manifests at ${expected} match tag ${TAG}"
 
       - name: Build Tauri app
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,8 +219,8 @@ jobs:
           # Check all four manifest files that release-prep maintains
           tauri_ver=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('src-tauri/tauri.conf.json','utf8')).version)")
           pkg_ver=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('package.json','utf8')).version)")
-          cargo_ver=$(sed -n 's/^version = "\(.*\)"/\1/p' src-tauri/Cargo.toml | head -1)
-          types_ver=$(sed -n 's/^version = "\(.*\)"/\1/p' crates/arborist-types/Cargo.toml | head -1)
+          cargo_ver=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)"/\1/p' src-tauri/Cargo.toml | head -1)
+          types_ver=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)"/\1/p' crates/arborist-types/Cargo.toml | head -1)
 
           ok=true
           for pair in "src-tauri/tauri.conf.json:${tauri_ver}" "package.json:${pkg_ver}" "src-tauri/Cargo.toml:${cargo_ver}" "crates/arborist-types/Cargo.toml:${types_ver}"; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,9 +176,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-release-${{ matrix.platform.rust-targets || 'default' }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-release-${{ matrix.platform.name }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-release-${{ matrix.platform.rust-targets || 'default' }}-cargo-
+            ${{ runner.os }}-release-${{ matrix.platform.name }}-cargo-
 
       # Tauri's Linux build needs system libraries (must match ci.yml). `lld`
       # + `clang` are required by the workspace `.cargo/config.toml` for the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arborist"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "arborist-types",
  "base64 0.22.1",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "arborist-types"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "pretty_assertions",
  "serde",

--- a/crates/arborist-types/Cargo.toml
+++ b/crates/arborist-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arborist-types"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 description = "Shared serializable wire-contract types for Arborist's frontend/backend boundary."
 authors = ["Aaron Moore", "Arborist contributors"]

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -66,6 +66,7 @@ pnpm run release:prep 0.1.3
 ```
 
 The script:
+
 1. Reads the current version from manifests (e.g. `0.1.2`) — this is the version being released.
 2. Validates: on `main`, clean tree, tag `v0.1.2` doesn't exist, all 4 manifests agree.
 3. Tags current HEAD as `v0.1.2` and pushes the tag (no commits to `main`).

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -67,6 +67,8 @@ pnpm run release:prep 0.1.2
 
 This bumps all version files, updates `Cargo.lock`, commits, tags, and pushes in one step. It validates that you're on `main` and that the tag doesn't already exist locally or on origin.
 
+> **Note:** The script commits the version bump directly to `main` and pushes without a PR. This is intentional for release mechanics — the commit is a pure version bump with no behavioral changes. If your workflow requires PR review for every commit to `main`, use the manual path below instead.
+
 After the script completes, update `CHANGELOG.md` in a follow-up commit if desired, then trigger the workflow:
 
 ```sh

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -65,6 +65,12 @@ git pull
 pnpm run release:prep 0.1.3
 ```
 
+If the script fails _after_ the tag was pushed (e.g. network blip during the bump PR), replay only the bump:
+
+```sh
+pnpm run release:prep --skip-tag 0.1.3
+```
+
 The script:
 
 1. Reads the current version from manifests (e.g. `0.1.2`) — this is the version being released.
@@ -84,7 +90,7 @@ Then merge the version-bump PR once CI passes.
 <details>
 <summary>Manual steps (if not using release:prep)</summary>
 
-1. Ensure the version in manifests on `main` is the version you want to release.
+1. Ensure the version in manifests on `main` is the version you want to release (the repo convention keeps the _upcoming_ version in code).
 2. Tag the HEAD commit:
 
    ```sh
@@ -95,13 +101,16 @@ Then merge the version-bump PR once CI passes.
    ```
 
 3. Trigger **Actions -> Release -> Run workflow** from `main` and provide the tag.
-4. Create a PR to bump manifests to the next version.
+4. Create a branch from `main`, bump all 4 manifests to the next version (e.g. `0.1.3`), run `cargo update -p arborist -p arborist-types`, commit, push,
+   and open a PR targeting `main`.
 
 </details>
 
-5. Review the draft release and artifacts.
-6. Smoke-test installers on clean machines or VMs.
-7. Publish the draft release.
+## After the workflow runs
+
+1. Review the draft release and artifacts.
+2. Smoke-test installers on clean machines or VMs.
+3. Publish the draft release.
 
 ## Artifacts
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -13,7 +13,7 @@ GitHub Release and generates GitHub build attestations.
   - `src-tauri/Cargo.toml`
   - `crates/arborist-types/Cargo.toml`
 
-After changing the Rust crate version, run a Cargo command that updates `Cargo.lock` if needed.
+The `pnpm run release:prep <version>` script handles all of the above automatically. If bumping manually, run `cargo update -p arborist -p arborist-types` after changing the Rust crate versions to update `Cargo.lock` without upgrading unrelated transitive dependencies.
 
 ## Metadata policy
 
@@ -57,6 +57,25 @@ updates because signed installers are distributed through GitHub Releases.
 
 ## Cut a release
 
+The automated way (recommended):
+
+```sh
+git checkout main
+git pull
+pnpm run release:prep 0.1.2
+```
+
+This bumps all version files, updates `Cargo.lock`, commits, tags, and pushes in one step. It validates that you're on `main` and that the tag doesn't already exist locally or on origin.
+
+After the script completes, update `CHANGELOG.md` in a follow-up commit if desired, then trigger the workflow:
+
+```sh
+gh workflow run release.yml -f tag=v0.1.2
+```
+
+<details>
+<summary>Manual steps (if not using release:prep)</summary>
+
 1. Land the version bump through PR.
 2. Update `CHANGELOG.md`.
 3. Tag the merge commit:
@@ -64,20 +83,17 @@ updates because signed installers are distributed through GitHub Releases.
    ```sh
    git checkout main
    git pull
-   git tag v0.1.1
-   git push origin v0.1.1
+   git tag v0.1.2
+   git push origin v0.1.2
    ```
 
 4. Trigger **Actions -> Release -> Run workflow** from `main` and provide the tag.
+
+</details>
+
 5. Review the draft release and artifacts.
 6. Smoke-test installers on clean machines or VMs.
 7. Publish the draft release.
-
-CLI equivalent for the workflow dispatch:
-
-```sh
-gh workflow run release.yml -f tag=v0.1.1
-```
 
 ## Artifacts
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -3,17 +3,19 @@
 Arborist releases are built by the manual `Release` GitHub Actions workflow from an existing tag on `main`. The workflow uploads artifacts to a draft
 GitHub Release and generates GitHub build attestations.
 
+## Version convention
+
+The version in manifests on `main` is always the **upcoming** release version. When you're ready to release, the `release:prep` script tags the current
+HEAD (closing out that version), then branches to bump manifests to the next development version and opens a PR.
+
 ## Release prerequisites
 
-- The release commit is merged to `main`.
-- The tag already exists on the repository and is reachable from `main`.
-- Version numbers match in:
+- All manifests on `main` agree on the version to be released:
   - `package.json`
   - `src-tauri/tauri.conf.json`
   - `src-tauri/Cargo.toml`
   - `crates/arborist-types/Cargo.toml`
-
-The `pnpm run release:prep <version>` script handles all of the above automatically. If bumping manually, run `cargo update -p arborist -p arborist-types` after changing the Rust crate versions to update `Cargo.lock` without upgrading unrelated transitive dependencies.
+- The working tree is clean and you're on `main`.
 
 ## Metadata policy
 
@@ -57,39 +59,42 @@ updates because signed installers are distributed through GitHub Releases.
 
 ## Cut a release
 
-The automated way (recommended):
-
 ```sh
 git checkout main
 git pull
-pnpm run release:prep 0.1.2
+pnpm run release:prep 0.1.3
 ```
 
-This bumps all version files, updates `Cargo.lock`, commits, tags, and pushes in one step. It validates that you're on `main` and that the tag doesn't already exist locally or on origin.
+The script:
+1. Reads the current version from manifests (e.g. `0.1.2`) — this is the version being released.
+2. Validates: on `main`, clean tree, tag `v0.1.2` doesn't exist, all 4 manifests agree.
+3. Tags current HEAD as `v0.1.2` and pushes the tag (no commits to `main`).
+4. Creates branch `chore/bump-0.1.3`, bumps all manifests to `0.1.3`, commits, pushes, opens a PR.
+5. Returns to `main`.
 
-> **Note:** The script commits the version bump directly to `main` and pushes without a PR. This is intentional for release mechanics — the commit is a pure version bump with no behavioral changes. If your workflow requires PR review for every commit to `main`, use the manual path below instead.
-
-After the script completes, update `CHANGELOG.md` in a follow-up commit if desired, then trigger the workflow:
+After the script completes, trigger the release build:
 
 ```sh
 gh workflow run release.yml -f tag=v0.1.2
 ```
 
+Then merge the version-bump PR once CI passes.
+
 <details>
 <summary>Manual steps (if not using release:prep)</summary>
 
-1. Land the version bump through PR.
-2. Update `CHANGELOG.md`.
-3. Tag the merge commit:
+1. Ensure the version in manifests on `main` is the version you want to release.
+2. Tag the HEAD commit:
 
    ```sh
    git checkout main
    git pull
-   git tag v0.1.2
+   git tag -a v0.1.2 -m "Release v0.1.2"
    git push origin v0.1.2
    ```
 
-4. Trigger **Actions -> Release -> Run workflow** from `main` and provide the tag.
+3. Trigger **Actions -> Release -> Run workflow** from `main` and provide the tag.
+4. Create a PR to bump manifests to the next version.
 
 </details>
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/mcaden/arborist/issues"
   },
   "homepage": "https://arborist.tools",
+  "engines": {
+    "node": ">=21.2.0"
+  },
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "e2e:macos:build": "bash dev/e2e/macos/scripts/run.sh build",
     "e2e:macos": "bash dev/e2e/macos/scripts/run.sh e2e",
     "e2e:macos:shell": "bash dev/e2e/macos/scripts/run.sh shell",
-    "e2e:macos:status": "bash dev/e2e/macos/scripts/run.sh status"
+    "e2e:macos:status": "bash dev/e2e/macos/scripts/run.sh status",
+    "release:prep": "node scripts/release-prep.mjs"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arborist",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Cross-platform desktop app for managing AI coding-assistant sessions across Git worktrees.",
   "license": "MIT",
   "author": "Aaron Moore",

--- a/scripts/release-prep.mjs
+++ b/scripts/release-prep.mjs
@@ -37,6 +37,8 @@ if (!SEMVER_RE.test(version)) {
 
 const tag = `v${version}`;
 
+// --- Preflight checks (all before any file modification) ---
+
 // Check for uncommitted changes
 try {
   const status = execSync('git status --porcelain', { encoding: 'utf8' }).trim();
@@ -47,6 +49,18 @@ try {
 } catch {
   console.error('Failed to check git status.');
   process.exit(1);
+}
+
+// Ensure we're on main to prevent accidental releases from feature branches
+const root = resolve(import.meta.dirname, '..');
+const branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: root, encoding: 'utf8' }).trim();
+if (branch !== 'main') {
+  console.error(`Current branch is '${branch}', but releases must be cut from 'main'.`);
+  console.error('Switch to main and try again, or use --allow-branch to override.');
+  if (!process.argv.includes('--allow-branch')) {
+    process.exit(1);
+  }
+  console.warn('⚠ --allow-branch override: proceeding on non-main branch.');
 }
 
 // Check that the tag doesn't already exist (locally or on origin)
@@ -62,8 +76,6 @@ try {
     process.exit(1);
   }
 }
-
-const root = resolve(import.meta.dirname, '..');
 
 // --- Update version files ---
 
@@ -105,15 +117,11 @@ execSync('cargo update -p arborist -p arborist-types', { cwd: root, stdio: 'pipe
 
 // --- Git operations ---
 
-// Ensure we're on main to prevent accidental releases from feature branches
-const branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: root, encoding: 'utf8' }).trim();
-if (branch !== 'main') {
-  console.error(`Current branch is '${branch}', but releases must be cut from 'main'.`);
-  console.error('Switch to main and try again, or use --allow-branch to override.');
-  if (!process.argv.includes('--allow-branch')) {
-    process.exit(1);
-  }
-  console.warn('⚠ --allow-branch override: proceeding on non-main branch.');
+// Detect no-op (e.g. re-running after a partial failure with the same version)
+const diff = execSync('git status --porcelain', { cwd: root, encoding: 'utf8' }).trim();
+if (!diff) {
+  console.error(`\nNo changes to commit — manifests already at ${version}. Nothing to release.`);
+  process.exit(1);
 }
 
 console.log(`\nCommitting and tagging ${tag}...\n`);

--- a/scripts/release-prep.mjs
+++ b/scripts/release-prep.mjs
@@ -9,13 +9,18 @@
  * Usage:
  *   node scripts/release-prep.mjs <next-version>
  *   pnpm run release:prep 0.1.3
+ *   pnpm run release:prep --skip-tag 0.1.3   # skip tagging (tag already pushed)
  *
  * The <next-version> is the version that will follow the current release. The script will:
  *  1. Read the current version from manifests (this is the version being released)
  *  2. Validate: on main, clean tree, tag doesn't exist, all 4 manifests agree
- *  3. Tag current HEAD as `v<current>` and push the tag
+ *  3. Tag current HEAD as `v<current>` and push the tag (unless --skip-tag)
  *  4. Create branch `chore/bump-<next>`, bump all manifests to <next-version>
  *  5. Commit, push, and open a PR for the version bump
+ *
+ * Flags:
+ *   --skip-tag   Skip tag creation/push (use when replaying after a partial failure
+ *                where the tag was already pushed successfully)
  *
  * Requires Node.js >= 21.2 (uses import.meta.dirname).
  */
@@ -26,11 +31,19 @@ import { resolve } from 'node:path';
 
 const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[\w.]+)?$/;
 
-const nextVersion = process.argv[2];
+// Parse flags
+const args = process.argv.slice(2);
+const skipTag = args.includes('--skip-tag');
+const positional = args.filter((a) => !a.startsWith('--'));
+
+const nextVersion = positional[0];
 if (!nextVersion) {
-  console.error('Usage: node scripts/release-prep.mjs <next-version>');
+  console.error('Usage: node scripts/release-prep.mjs [--skip-tag] <next-version>');
   console.error('Example: pnpm run release:prep 0.1.3');
+  console.error('         pnpm run release:prep --skip-tag 0.1.3');
   console.error('\nThis tags the current version in manifests and opens a PR to bump to <next-version>.');
+  console.error('\nFlags:');
+  console.error('  --skip-tag   Skip tag creation/push (for replaying after partial failure)');
   process.exit(1);
 }
 
@@ -100,78 +113,131 @@ if (branch !== 'main') {
   process.exit(1);
 }
 
-// Tag must not exist locally or on origin
-try {
-  exec(`git rev-parse --verify refs/tags/${tag}`);
-  console.error(`Tag ${tag} already exists locally. Delete it first or choose a different version.`);
+// Local main must be up-to-date with origin/main
+exec('git fetch origin main');
+const localSha = exec('git rev-parse HEAD');
+const remoteSha = exec('git rev-parse origin/main');
+if (localSha !== remoteSha) {
+  console.error(`Local main (${localSha.slice(0, 8)}) is not up-to-date with origin/main (${remoteSha.slice(0, 8)}).`);
+  console.error('Run `git pull` and retry.');
   process.exit(1);
-} catch {
+}
+
+// Tag must not exist locally or on origin (skip check if --skip-tag)
+if (!skipTag) {
+  try {
+    exec(`git rev-parse --verify refs/tags/${tag}`, { stdio: 'pipe' });
+    console.error(`Tag ${tag} already exists locally. Delete it first or choose a different version.`);
+    process.exit(1);
+  } catch {
+    const remote = exec(`git ls-remote --tags origin refs/tags/${tag}`);
+    if (remote) {
+      console.error(`Tag ${tag} already exists on origin. Delete it first or choose a different version.`);
+      process.exit(1);
+    }
+  }
+} else {
+  // When skipping tag, verify it actually exists (otherwise --skip-tag is being misused)
   const remote = exec(`git ls-remote --tags origin refs/tags/${tag}`);
-  if (remote) {
-    console.error(`Tag ${tag} already exists on origin. Delete it first or choose a different version.`);
+  if (!remote) {
+    console.error(`--skip-tag was passed but tag ${tag} does not exist on origin. Cannot skip what doesn't exist.`);
     process.exit(1);
   }
+  console.log(`ℹ️  --skip-tag: skipping tag creation (${tag} already exists on origin)\n`);
+}
+
+// Bump branch must not already exist
+const bumpBranch = `chore/bump-${nextVersion}`;
+try {
+  exec(`git rev-parse --verify refs/heads/${bumpBranch}`, { stdio: 'pipe' });
+  console.error(`Branch '${bumpBranch}' already exists locally. Delete it first or choose a different version.`);
+  process.exit(1);
+} catch {
+  // expected — branch doesn't exist
+}
+const remoteBump = exec(`git ls-remote --heads origin refs/heads/${bumpBranch}`);
+if (remoteBump) {
+  console.error(`Branch '${bumpBranch}' already exists on origin. Delete it first or choose a different version.`);
+  process.exit(1);
 }
 
 // --- Step 1: Tag current HEAD and push tag ---
 
-console.log(`Tagging ${tag} on main...\n`);
-execSync(`git tag -a "${tag}" -m "Release ${tag}"`, { cwd: root });
-execSync(`git push origin refs/tags/${tag}`, { cwd: root, stdio: 'inherit' });
-console.log(`\n✅ Tag ${tag} pushed.\n`);
+if (!skipTag) {
+  console.log(`Tagging ${tag} on main...\n`);
+  execSync(`git tag -a "${tag}" -m "Release ${tag}"`, { cwd: root });
+  execSync(`git push origin refs/tags/${tag}`, { cwd: root, stdio: 'inherit' });
+  console.log(`\n✅ Tag ${tag} pushed.\n`);
+} else {
+  console.log(`⏭️  Skipping tag (--skip-tag). Tag ${tag} already on origin.\n`);
+}
 
 // --- Step 2: Branch, bump to next version, push, open PR ---
 
-const bumpBranch = `chore/bump-${nextVersion}`;
 console.log(`Creating branch '${bumpBranch}' for next-version bump...\n`);
 
-execSync(`git checkout -b "${bumpBranch}"`, { cwd: root, stdio: 'pipe' });
+try {
+  execSync(`git checkout -b "${bumpBranch}"`, { cwd: root, stdio: 'pipe' });
 
-// Bump all manifests to nextVersion
-function updateJson(relPath, key) {
-  const filePath = resolve(root, relPath);
-  const content = readFileSync(filePath, 'utf8');
-  const json = JSON.parse(content);
-  json[key] = nextVersion;
-  const indent = content.match(/^(\s+)"/m)?.[1] || '  ';
-  writeFileSync(filePath, JSON.stringify(json, null, indent) + '\n');
-  console.log(`  ${relPath}: ${currentVersion} → ${nextVersion}`);
-}
-
-function updateCargoToml(relPath) {
-  const filePath = resolve(root, relPath);
-  const content = readFileSync(filePath, 'utf8');
-  const updated = content.replace(/^(version\s*=\s*")([^"]+)(")/m, `$1${nextVersion}$3`);
-  if (updated === content) {
-    console.error(`  ${relPath}: no version field found!`);
-    process.exit(1);
+  // Bump all manifests to nextVersion
+  function updateJson(relPath, key) {
+    const filePath = resolve(root, relPath);
+    const content = readFileSync(filePath, 'utf8');
+    const json = JSON.parse(content);
+    json[key] = nextVersion;
+    const indent = content.match(/^(\s+)"/m)?.[1] || '  ';
+    writeFileSync(filePath, JSON.stringify(json, null, indent) + '\n');
+    console.log(`  ${relPath}: ${currentVersion} → ${nextVersion}`);
   }
-  writeFileSync(filePath, updated);
-  console.log(`  ${relPath}: ${currentVersion} → ${nextVersion}`);
+
+  function updateCargoToml(relPath) {
+    const filePath = resolve(root, relPath);
+    const content = readFileSync(filePath, 'utf8');
+    const updated = content.replace(/^(version\s*=\s*")([^"]+)(")/m, `$1${nextVersion}$3`);
+    if (updated === content) {
+      console.error(`  ${relPath}: no version field found!`);
+      process.exit(1);
+    }
+    writeFileSync(filePath, updated);
+    console.log(`  ${relPath}: ${currentVersion} → ${nextVersion}`);
+  }
+
+  updateJson('package.json', 'version');
+  updateJson('src-tauri/tauri.conf.json', 'version');
+  updateCargoToml('src-tauri/Cargo.toml');
+  updateCargoToml('crates/arborist-types/Cargo.toml');
+
+  // Update Cargo.lock for workspace crates only
+  console.log('\n  Updating Cargo.lock (workspace crates only)...');
+  execSync('cargo update -p arborist -p arborist-types', { cwd: root, stdio: 'pipe' });
+
+  // Commit and push
+  execSync('git add -A', { cwd: root });
+  execSync(`git commit -m "chore: bump version to ${nextVersion}"`, { cwd: root, stdio: 'inherit' });
+  execSync(`git push origin "${bumpBranch}"`, { cwd: root, stdio: 'inherit' });
+
+  // Open PR
+  console.log('\nOpening PR...\n');
+  const prTitle = `chore: bump version to ${nextVersion}`;
+  const prBody = `Automated version bump following the ${tag} release.\n\nBumps all manifests to ${nextVersion} in preparation for the next development cycle.`;
+  execSync(`gh pr create --title "${prTitle}" --body "${prBody}" --base main --head "${bumpBranch}"`, {
+    cwd: root,
+    stdio: 'inherit',
+  });
+} catch (err) {
+  console.error(`\n❌ Step 2 (version bump) failed: ${err.message}`);
+  if (!skipTag) {
+    console.error(`\n⚠️  Tag ${tag} was already pushed to origin.`);
+    console.error(`The release build can still be triggered with: gh workflow run release.yml -f tag=${tag}`);
+  }
+  console.error(`\nTo retry the version bump, rerun with --skip-tag:`);
+  console.error(`  pnpm run release:prep --skip-tag ${nextVersion}`);
+  console.error(`\nTo clean up and start over:`);
+  console.error(`  git checkout main`);
+  console.error(`  git branch -D ${bumpBranch} 2>/dev/null`);
+  console.error(`  git push origin :refs/heads/${bumpBranch} 2>/dev/null`);
+  process.exit(1);
 }
-
-updateJson('package.json', 'version');
-updateJson('src-tauri/tauri.conf.json', 'version');
-updateCargoToml('src-tauri/Cargo.toml');
-updateCargoToml('crates/arborist-types/Cargo.toml');
-
-// Update Cargo.lock for workspace crates only
-console.log('\n  Updating Cargo.lock (workspace crates only)...');
-execSync('cargo update -p arborist -p arborist-types', { cwd: root, stdio: 'pipe' });
-
-// Commit and push
-execSync('git add -A', { cwd: root });
-execSync(`git commit -m "chore: bump version to ${nextVersion}"`, { cwd: root, stdio: 'inherit' });
-execSync(`git push origin "${bumpBranch}"`, { cwd: root, stdio: 'inherit' });
-
-// Open PR
-console.log('\nOpening PR...\n');
-const prTitle = `chore: bump version to ${nextVersion}`;
-const prBody = `Automated version bump following the ${tag} release.\\n\\nBumps all manifests to ${nextVersion} in preparation for the next development cycle.`;
-execSync(`gh pr create --title "${prTitle}" --body "${prBody}" --base main --head "${bumpBranch}"`, {
-  cwd: root,
-  stdio: 'inherit',
-});
 
 // Return to main
 execSync('git checkout main', { cwd: root, stdio: 'pipe' });

--- a/scripts/release-prep.mjs
+++ b/scripts/release-prep.mjs
@@ -1,18 +1,21 @@
 #!/usr/bin/env node
 /**
- * release-prep.mjs — Bump version across all manifest files, commit, tag, and push.
+ * release-prep.mjs — Tag the current version on main and open a PR to bump to the next version.
+ *
+ * The repo follows a "next version in code" convention: the version in manifests on main
+ * is always the UPCOMING release. Running this script "closes out" that version by tagging,
+ * then branches to bump manifests to the next version and opens a PR.
  *
  * Usage:
- *   node scripts/release-prep.mjs <version>
- *   pnpm run release:prep 0.1.2
+ *   node scripts/release-prep.mjs <next-version>
+ *   pnpm run release:prep 0.1.3
  *
- * The version argument should be a bare semver (no "v" prefix). The script will:
- *  1. Validate the version string
- *  2. Update package.json, src-tauri/Cargo.toml, crates/arborist-types/Cargo.toml, src-tauri/tauri.conf.json
- *  3. Run `cargo update -p arborist -p arborist-types` to update Cargo.lock
- *  4. Commit the changes
- *  5. Create an annotated tag `v<version>`
- *  6. Push the commit and tag to origin
+ * The <next-version> is the version that will follow the current release. The script will:
+ *  1. Read the current version from manifests (this is the version being released)
+ *  2. Validate: on main, clean tree, tag doesn't exist, all 4 manifests agree
+ *  3. Tag current HEAD as `v<current>` and push the tag
+ *  4. Create branch `chore/bump-<next>`, bump all manifests to <next-version>
+ *  5. Commit, push, and open a PR for the version bump
  *
  * Requires Node.js >= 21.2 (uses import.meta.dirname).
  */
@@ -23,25 +26,64 @@ import { resolve } from 'node:path';
 
 const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[\w.]+)?$/;
 
-const version = process.argv[2];
-if (!version) {
-  console.error('Usage: node scripts/release-prep.mjs <version>');
-  console.error('Example: node scripts/release-prep.mjs 0.1.2');
+const nextVersion = process.argv[2];
+if (!nextVersion) {
+  console.error('Usage: node scripts/release-prep.mjs <next-version>');
+  console.error('Example: pnpm run release:prep 0.1.3');
+  console.error('\nThis tags the current version in manifests and opens a PR to bump to <next-version>.');
   process.exit(1);
 }
 
-if (!SEMVER_RE.test(version)) {
-  console.error(`Invalid semver: "${version}". Expected format: X.Y.Z or X.Y.Z-prerelease`);
+if (!SEMVER_RE.test(nextVersion)) {
+  console.error(`Invalid semver: "${nextVersion}". Expected format: X.Y.Z or X.Y.Z-prerelease`);
   process.exit(1);
 }
 
-const tag = `v${version}`;
+const root = resolve(import.meta.dirname, '..');
+const exec = (cmd, opts = {}) => execSync(cmd, { cwd: root, encoding: 'utf8', ...opts }).trim();
 
-// --- Preflight checks (all before any file modification) ---
+// --- Read current version from manifests ---
 
-// Check for uncommitted changes
+const currentVersion = JSON.parse(readFileSync(resolve(root, 'src-tauri/tauri.conf.json'), 'utf8')).version;
+const tag = `v${currentVersion}`;
+
+// Validate all 4 manifests agree
+const manifests = [
+  { path: 'package.json', version: JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')).version },
+  { path: 'src-tauri/tauri.conf.json', version: currentVersion },
+  {
+    path: 'src-tauri/Cargo.toml',
+    version: readFileSync(resolve(root, 'src-tauri/Cargo.toml'), 'utf8').match(/^version\s*=\s*"([^"]+)"/m)?.[1],
+  },
+  {
+    path: 'crates/arborist-types/Cargo.toml',
+    version: readFileSync(resolve(root, 'crates/arborist-types/Cargo.toml'), 'utf8').match(/^version\s*=\s*"([^"]+)"/m)?.[1],
+  },
+];
+
+const mismatches = manifests.filter((m) => m.version !== currentVersion);
+if (mismatches.length > 0) {
+  console.error('Version mismatch across manifests:');
+  for (const m of manifests) {
+    console.error(`  ${m.path}: ${m.version}${m.version !== currentVersion ? ' ← MISMATCH' : ''}`);
+  }
+  console.error('\nAll manifests must agree before releasing. Fix manually and retry.');
+  process.exit(1);
+}
+
+if (nextVersion === currentVersion) {
+  console.error(`Next version (${nextVersion}) is the same as current version (${currentVersion}). Nothing to do.`);
+  process.exit(1);
+}
+
+console.log(`Current version: ${currentVersion} (will be tagged as ${tag})`);
+console.log(`Next version:    ${nextVersion} (will be the PR bump target)\n`);
+
+// --- Preflight checks ---
+
+// Clean working tree
 try {
-  const status = execSync('git status --porcelain', { encoding: 'utf8' }).trim();
+  const status = exec('git status --porcelain');
   if (status) {
     console.error('Working tree is dirty. Commit or stash changes before running release-prep.');
     process.exit(1);
@@ -51,86 +93,90 @@ try {
   process.exit(1);
 }
 
-// Ensure we're on main to prevent accidental releases from feature branches
-const root = resolve(import.meta.dirname, '..');
-const branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: root, encoding: 'utf8' }).trim();
+// Must be on main
+const branch = exec('git rev-parse --abbrev-ref HEAD');
 if (branch !== 'main') {
   console.error(`Current branch is '${branch}', but releases must be cut from 'main'.`);
-  console.error('Switch to main and try again, or use --allow-branch to override.');
-  if (!process.argv.includes('--allow-branch')) {
-    process.exit(1);
-  }
-  console.warn('⚠ --allow-branch override: proceeding on non-main branch.');
+  process.exit(1);
 }
 
-// Check that the tag doesn't already exist (locally or on origin)
+// Tag must not exist locally or on origin
 try {
-  execSync(`git rev-parse --verify refs/tags/${tag}`, { stdio: 'pipe' });
+  exec(`git rev-parse --verify refs/tags/${tag}`);
   console.error(`Tag ${tag} already exists locally. Delete it first or choose a different version.`);
   process.exit(1);
 } catch {
-  // Tag doesn't exist locally — check remote
-  const remote = execSync(`git ls-remote --tags origin refs/tags/${tag}`, { encoding: 'utf8' }).trim();
+  const remote = exec(`git ls-remote --tags origin refs/tags/${tag}`);
   if (remote) {
     console.error(`Tag ${tag} already exists on origin. Delete it first or choose a different version.`);
     process.exit(1);
   }
 }
 
-// --- Update version files ---
+// --- Step 1: Tag current HEAD and push tag ---
 
+console.log(`Tagging ${tag} on main...\n`);
+execSync(`git tag -a "${tag}" -m "Release ${tag}"`, { cwd: root });
+execSync(`git push origin refs/tags/${tag}`, { cwd: root, stdio: 'inherit' });
+console.log(`\n✅ Tag ${tag} pushed.\n`);
+
+// --- Step 2: Branch, bump to next version, push, open PR ---
+
+const bumpBranch = `chore/bump-${nextVersion}`;
+console.log(`Creating branch '${bumpBranch}' for next-version bump...\n`);
+
+execSync(`git checkout -b "${bumpBranch}"`, { cwd: root, stdio: 'pipe' });
+
+// Bump all manifests to nextVersion
 function updateJson(relPath, key) {
   const filePath = resolve(root, relPath);
   const content = readFileSync(filePath, 'utf8');
   const json = JSON.parse(content);
-  const old = json[key];
-  json[key] = version;
-  // Preserve formatting: detect indent from original file
+  json[key] = nextVersion;
   const indent = content.match(/^(\s+)"/m)?.[1] || '  ';
   writeFileSync(filePath, JSON.stringify(json, null, indent) + '\n');
-  console.log(`  ${relPath}: ${old} → ${version}`);
+  console.log(`  ${relPath}: ${currentVersion} → ${nextVersion}`);
 }
 
 function updateCargoToml(relPath) {
   const filePath = resolve(root, relPath);
   const content = readFileSync(filePath, 'utf8');
-  const updated = content.replace(/^(version\s*=\s*")([^"]+)(")/m, `$1${version}$3`);
+  const updated = content.replace(/^(version\s*=\s*")([^"]+)(")/m, `$1${nextVersion}$3`);
   if (updated === content) {
     console.error(`  ${relPath}: no version field found!`);
     process.exit(1);
   }
-  const old = content.match(/^version\s*=\s*"([^"]+)"/m)?.[1];
   writeFileSync(filePath, updated);
-  console.log(`  ${relPath}: ${old} → ${version}`);
+  console.log(`  ${relPath}: ${currentVersion} → ${nextVersion}`);
 }
-
-console.log(`\nBumping to ${version}:\n`);
 
 updateJson('package.json', 'version');
 updateJson('src-tauri/tauri.conf.json', 'version');
 updateCargoToml('src-tauri/Cargo.toml');
 updateCargoToml('crates/arborist-types/Cargo.toml');
 
-// Update only workspace crate entries in Cargo.lock (avoids upgrading transitive deps)
+// Update Cargo.lock for workspace crates only
 console.log('\n  Updating Cargo.lock (workspace crates only)...');
 execSync('cargo update -p arborist -p arborist-types', { cwd: root, stdio: 'pipe' });
 
-// --- Git operations ---
-
-// Detect no-op (e.g. re-running after a partial failure with the same version)
-const diff = execSync('git status --porcelain', { cwd: root, encoding: 'utf8' }).trim();
-if (!diff) {
-  console.error(`\nNo changes to commit — manifests already at ${version}. Nothing to release.`);
-  process.exit(1);
-}
-
-console.log(`\nCommitting and tagging ${tag}...\n`);
-
+// Commit and push
 execSync('git add -A', { cwd: root });
-execSync(`git commit -m "chore: release ${tag}"`, { cwd: root, stdio: 'inherit' });
-execSync(`git tag -a "${tag}" -m "Release ${tag}"`, { cwd: root });
+execSync(`git commit -m "chore: bump version to ${nextVersion}"`, { cwd: root, stdio: 'inherit' });
+execSync(`git push origin "${bumpBranch}"`, { cwd: root, stdio: 'inherit' });
 
-console.log(`\nPushing to origin...\n`);
-execSync(`git push origin HEAD --follow-tags`, { cwd: root, stdio: 'inherit' });
+// Open PR
+console.log('\nOpening PR...\n');
+const prTitle = `chore: bump version to ${nextVersion}`;
+const prBody = `Automated version bump following the ${tag} release.\\n\\nBumps all manifests to ${nextVersion} in preparation for the next development cycle.`;
+execSync(`gh pr create --title "${prTitle}" --body "${prBody}" --base main --head "${bumpBranch}"`, {
+  cwd: root,
+  stdio: 'inherit',
+});
 
-console.log(`\n✅ Done! Tag ${tag} pushed. Trigger the Release workflow from the Actions tab.`);
+// Return to main
+execSync('git checkout main', { cwd: root, stdio: 'pipe' });
+
+console.log(`\n✅ Done!`);
+console.log(`   • Tagged ${tag} and pushed to origin`);
+console.log(`   • Opened PR to bump to ${nextVersion}`);
+console.log(`   • Trigger the Release workflow: gh workflow run release.yml -f tag=${tag}`);

--- a/scripts/release-prep.mjs
+++ b/scripts/release-prep.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * release-prep.mjs — Bump version across all manifest files, commit, tag, and push.
+ *
+ * Usage:
+ *   node scripts/release-prep.mjs <version>
+ *   pnpm run release:prep 0.1.2
+ *
+ * The version argument should be a bare semver (no "v" prefix). The script will:
+ *  1. Validate the version string
+ *  2. Update package.json, src-tauri/Cargo.toml, crates/arborist-types/Cargo.toml, src-tauri/tauri.conf.json
+ *  3. Run `cargo generate-lockfile` to update Cargo.lock
+ *  4. Commit the changes
+ *  5. Create an annotated tag `v<version>`
+ *  6. Push the commit and tag to origin
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[\w.]+)?$/;
+
+const version = process.argv[2];
+if (!version) {
+  console.error('Usage: node scripts/release-prep.mjs <version>');
+  console.error('Example: node scripts/release-prep.mjs 0.1.2');
+  process.exit(1);
+}
+
+if (!SEMVER_RE.test(version)) {
+  console.error(`Invalid semver: "${version}". Expected format: X.Y.Z or X.Y.Z-prerelease`);
+  process.exit(1);
+}
+
+const tag = `v${version}`;
+
+// Check for uncommitted changes
+try {
+  const status = execSync('git status --porcelain', { encoding: 'utf8' }).trim();
+  if (status) {
+    console.error('Working tree is dirty. Commit or stash changes before running release-prep.');
+    process.exit(1);
+  }
+} catch {
+  console.error('Failed to check git status.');
+  process.exit(1);
+}
+
+// Check that the tag doesn't already exist
+try {
+  execSync(`git rev-parse --verify refs/tags/${tag}`, { stdio: 'pipe' });
+  console.error(`Tag ${tag} already exists. Delete it first or choose a different version.`);
+  process.exit(1);
+} catch {
+  // Tag doesn't exist — good
+}
+
+const root = resolve(import.meta.dirname, '..');
+
+// --- Update version files ---
+
+function updateJson(relPath, key) {
+  const filePath = resolve(root, relPath);
+  const content = readFileSync(filePath, 'utf8');
+  const json = JSON.parse(content);
+  const old = json[key];
+  json[key] = version;
+  // Preserve formatting: detect indent from original file
+  const indent = content.match(/^(\s+)"/m)?.[1] || '  ';
+  writeFileSync(filePath, JSON.stringify(json, null, indent) + '\n');
+  console.log(`  ${relPath}: ${old} → ${version}`);
+}
+
+function updateCargoToml(relPath) {
+  const filePath = resolve(root, relPath);
+  const content = readFileSync(filePath, 'utf8');
+  const updated = content.replace(/^(version\s*=\s*")([^"]+)(")/m, `$1${version}$3`);
+  if (updated === content) {
+    console.error(`  ${relPath}: no version field found!`);
+    process.exit(1);
+  }
+  const old = content.match(/^version\s*=\s*"([^"]+)"/m)?.[1];
+  writeFileSync(filePath, updated);
+  console.log(`  ${relPath}: ${old} → ${version}`);
+}
+
+console.log(`\nBumping to ${version}:\n`);
+
+updateJson('package.json', 'version');
+updateJson('src-tauri/tauri.conf.json', 'version');
+updateCargoToml('src-tauri/Cargo.toml');
+updateCargoToml('crates/arborist-types/Cargo.toml');
+
+// Update Cargo.lock
+console.log('\n  Updating Cargo.lock...');
+execSync('cargo generate-lockfile', { cwd: root, stdio: 'pipe' });
+
+// --- Git operations ---
+
+console.log(`\nCommitting and tagging ${tag}...\n`);
+
+execSync('git add -A', { cwd: root });
+execSync(`git commit -m "chore: release ${tag}"`, { cwd: root, stdio: 'inherit' });
+execSync(`git tag -a "${tag}" -m "Release ${tag}"`, { cwd: root });
+
+console.log(`\nPushing to origin...\n`);
+execSync(`git push origin HEAD --follow-tags`, { cwd: root, stdio: 'inherit' });
+
+console.log(`\n✅ Done! Tag ${tag} pushed. Trigger the Release workflow from the Actions tab.`);

--- a/scripts/release-prep.mjs
+++ b/scripts/release-prep.mjs
@@ -9,10 +9,12 @@
  * The version argument should be a bare semver (no "v" prefix). The script will:
  *  1. Validate the version string
  *  2. Update package.json, src-tauri/Cargo.toml, crates/arborist-types/Cargo.toml, src-tauri/tauri.conf.json
- *  3. Run `cargo generate-lockfile` to update Cargo.lock
+ *  3. Run `cargo update -p arborist -p arborist-types` to update Cargo.lock
  *  4. Commit the changes
  *  5. Create an annotated tag `v<version>`
  *  6. Push the commit and tag to origin
+ *
+ * Requires Node.js >= 21.2 (uses import.meta.dirname).
  */
 
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -47,13 +49,18 @@ try {
   process.exit(1);
 }
 
-// Check that the tag doesn't already exist
+// Check that the tag doesn't already exist (locally or on origin)
 try {
   execSync(`git rev-parse --verify refs/tags/${tag}`, { stdio: 'pipe' });
-  console.error(`Tag ${tag} already exists. Delete it first or choose a different version.`);
+  console.error(`Tag ${tag} already exists locally. Delete it first or choose a different version.`);
   process.exit(1);
 } catch {
-  // Tag doesn't exist — good
+  // Tag doesn't exist locally — check remote
+  const remote = execSync(`git ls-remote --tags origin refs/tags/${tag}`, { encoding: 'utf8' }).trim();
+  if (remote) {
+    console.error(`Tag ${tag} already exists on origin. Delete it first or choose a different version.`);
+    process.exit(1);
+  }
 }
 
 const root = resolve(import.meta.dirname, '..');
@@ -92,11 +99,22 @@ updateJson('src-tauri/tauri.conf.json', 'version');
 updateCargoToml('src-tauri/Cargo.toml');
 updateCargoToml('crates/arborist-types/Cargo.toml');
 
-// Update Cargo.lock
-console.log('\n  Updating Cargo.lock...');
-execSync('cargo generate-lockfile', { cwd: root, stdio: 'pipe' });
+// Update only workspace crate entries in Cargo.lock (avoids upgrading transitive deps)
+console.log('\n  Updating Cargo.lock (workspace crates only)...');
+execSync('cargo update -p arborist -p arborist-types', { cwd: root, stdio: 'pipe' });
 
 // --- Git operations ---
+
+// Ensure we're on main to prevent accidental releases from feature branches
+const branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: root, encoding: 'utf8' }).trim();
+if (branch !== 'main') {
+  console.error(`Current branch is '${branch}', but releases must be cut from 'main'.`);
+  console.error('Switch to main and try again, or use --allow-branch to override.');
+  if (!process.argv.includes('--allow-branch')) {
+    process.exit(1);
+  }
+  console.warn('⚠ --allow-branch override: proceeding on non-main branch.');
+}
 
 console.log(`\nCommitting and tagging ${tag}...\n`);
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arborist"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 description = "Cross-platform desktop app for managing AI coding-assistant sessions across Git worktrees."
 authors = ["Aaron Moore", "Arborist contributors"]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Arborist",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "identifier": "io.github.mcaden.arborist",
   "build": {
     "beforeDevCommand": "pnpm run vite",


### PR DESCRIPTION
## Problem

1. **Cache key error**: The macOS matrix entry has \ust-targets='aarch64-apple-darwin,x86_64-apple-darwin'\ which contains a comma. GitHub Actions cache keys cannot contain commas, causing \Key Validation Error\ on release builds.

2. **Version mismatch**: Tag \0.1.1\ pointed to code with version \