### PR TITLE
[sonar-security] Suppress S3735 (void operator) in SonarCloud

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,9 @@
+# SonarCloud project configuration
+sonar.projectKey=mcaden_arborist
+sonar.organization=mcaden
+
+# Suppress S3735 (void operator) — deliberate fire-and-forget pattern for
+# discarding Promise return values, satisfying @typescript-eslint/no-floating-promises.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S3735
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.ts*


### PR DESCRIPTION
Adds \sonar-project.properties\ to suppress the S3735 rule (void operator usage) project-wide.

## Rationale

The \oid\ operator is used deliberately throughout the codebase as an idiomatic TypeScript pattern for fire-and-forget promises, satisfying \@typescript-eslint/no-floating-promises\. SonarCloud flags these as HIGH severity code smells, but they are intentional — 19 instances across stores, hooks, and tests.

## What this does

Configures SonarCloud to ignore \	ypescript:S3735\ on all \.ts\/\.tsx\ files via the standard multicriteria ignore mechanism.