### PR TITLE
[sonar-badge] Add SonarCloud Quality Gate badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # Arborist
 
 [![CI](https://github.com/mcaden/arborist/actions/workflows/ci.yml/badge.svg)](https://github.com/mcaden/arborist/actions/workflows/ci.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=mcaden_arborist&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=mcaden_arborist)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![GitHub release](https://img.shields.io/github/v/release/mcaden/arborist?include_prereleases&sort=semver)](https://github.com/mcaden/arborist/releases)
 


### PR DESCRIPTION
Adds the SonarCloud Quality Gate status badge to the README, placed between the CI and License badges.