### PR TITLE
[v0-1-2-troubleshooting] fix: strip CRLF from Windows artifact paths in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,7 +263,7 @@ jobs:
             -o -name "*.dmg" -o -name "*.app.tar.gz" -o -name "*.app.tar.gz.sig" \
             -o -name "*.deb" -o -name "*.rpm" -o -name "*.AppImage" \
             -o -name "*.AppImage.tar.gz" -o -name "*.AppImage.tar.gz.sig" \
-          \) | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          \) | tr -d '\r' | jq -R -s -c 'split("\n") | map(select(length > 0))')
           if [ "$(echo "$artifacts" | jq length)" -eq 0 ]; then
             echo "::error::No Tauri release artifacts found"
             exit 1
@@ -279,7 +279,7 @@ jobs:
           ARTIFACT_PATHS: ${{ steps.tauri.outputs.artifactPaths }}
         run: |
           set -euo pipefail
-          echo "$ARTIFACT_PATHS" | jq -r '.[]' | while IFS= read -r f; do
+          echo "$ARTIFACT_PATHS" | jq -r '.[]' | tr -d '\r' | while IFS= read -r f; do
             echo "Uploading: $f"
             gh release upload "$TAG" "$f" --clobber
           done


### PR DESCRIPTION
## Problem

The v0.1.2 release workflow failed on the Windows runner at the upload step:

\\\
no matches found for \	arget/release/bundle/msi/Arborist_0.1.2_x64_en-US.msi
\
\\\

The build itself succeeded — both MSI and NSIS bundles were produced. The failure is in the \Find release artifacts\ → \Upload artifacts to release\ pipeline.

## Root cause

On Windows runners, Git Bash's \ind\ outputs paths with CRLF (\\r\n\) line endings. The \jq\ command splits by \\n\, leaving a trailing \\r\ embedded in each path string. When \gh release upload\ receives a path like \	arget/release/bundle/msi/Arborist_0.1.2_x64_en-US.msi\r\, it can't find the file.

## Fix

Add \	r -d '\r'\ to strip carriage returns:
1. In the artifact discovery step (before \jq\ builds the JSON array)
2. In the upload loop (defense-in-depth, in case \\\ roundtrip reintroduces \\r\)

Linux and macOS are unaffected since \	r -d '\r'\ is a no-op when there are no \\r\ characters.

## Ref

Failed run: https://github.com/mcaden/arborist/actions/runs/25900943393/job/76124002526