### PR TITLE
[linting-workflow] Fix pre-commit hook diff check and doc accuracy

### DIFF
--- a/.github/skills/quality-workflow-gate/SKILL.md
+++ b/.github/skills/quality-workflow-gate/SKILL.md
@@ -101,6 +101,7 @@ Hooks live under `.husky/`. Bypassing with `--no-verify` is allowed only for bra
 
 - **pre-commit**:
   - `lint-staged` runs `eslint --fix` + Prettier on staged JS/TS
+  - **Re-stage safety net**: after lint-staged, any fully-staged file that acquired new unstaged changes (indicating the fix was written to disk but not re-staged) is automatically re-added to the index. Partially-staged files are warned but not auto-staged (to avoid committing unintended hunks).
   - `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` on the Rust workspace if any `.rs` file is staged
 - **pre-push**:
   - `pnpm test --run` (vitest in CI mode)

--- a/.github/skills/quality-workflow-gate/SKILL.md
+++ b/.github/skills/quality-workflow-gate/SKILL.md
@@ -101,7 +101,7 @@ Hooks live under `.husky/`. Bypassing with `--no-verify` is allowed only for bra
 
 - **pre-commit**:
   - `lint-staged` runs `eslint --fix` + Prettier on staged JS/TS
-  - **Re-stage safety net**: after lint-staged, any fully-staged file that acquired new unstaged changes (indicating the fix was written to disk but not re-staged) is automatically re-added to the index. Partially-staged files are warned but not auto-staged (to avoid committing unintended hunks).
+  - **Re-stage safety net**: after lint-staged, any fully-staged file that acquired new unstaged changes (indicating the fix was written to disk but not re-staged) is automatically re-added to the index. Partially-staged files are skipped (to avoid committing unintended hunks).
   - `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` on the Rust workspace if any `.rs` file is staged
 - **pre-push**:
   - `pnpm test --run` (vitest in CI mode)

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -26,7 +26,7 @@ pnpm exec lint-staged || exit 1
 # Re-stage fully-staged files where lint-staged wrote fixes but failed to stage them.
 if [ -n "$FULLY_STAGED" ]; then
   echo "$FULLY_STAGED" | while read -r file; do
-    if [ -n "$file" ] && [ -n "$(git diff -- "$file" 2>/dev/null)" ]; then
+    if [ -n "$file" ] && ! git diff --quiet -- "$file" 2>/dev/null; then
       echo "[husky] Re-staging lint fix for fully-staged file: $file"
       git add -- "$file"
     fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,39 @@
 #!/usr/bin/env sh
 
+# --- JS/TS lint-staged with re-stage safety net ---
+# lint-staged runs eslint --fix + prettier --write, which should re-stage fixes.
+# On Windows (and some partial-staging edge cases) the fix can land in the
+# working tree without being re-staged, so the commit ships unfixed code.
+# Fix: after lint-staged, re-stage fully-staged files that acquired new diffs.
+
+# Identify files that are fully staged (in index, NO pre-existing unstaged changes).
+# These are safe to re-stage unconditionally after lint-staged fixes them.
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+UNSTAGED_BEFORE=$(git diff --name-only)
+
+# Files that are fully staged = staged AND not in the unstaged list
+FULLY_STAGED=""
+if [ -n "$STAGED_FILES" ]; then
+  FULLY_STAGED=$(echo "$STAGED_FILES" | while read -r f; do
+    if [ -n "$f" ] && ! echo "$UNSTAGED_BEFORE" | grep -qxF "$f"; then
+      echo "$f"
+    fi
+  done)
+fi
+
 pnpm exec lint-staged || exit 1
 
-# Run Rust formatting + clippy only when Rust files are staged.
+# Re-stage fully-staged files where lint-staged wrote fixes but failed to stage them.
+if [ -n "$FULLY_STAGED" ]; then
+  echo "$FULLY_STAGED" | while read -r file; do
+    if [ -n "$file" ] && [ -n "$(git diff -- "$file" 2>/dev/null)" ]; then
+      echo "[husky] Re-staging lint fix for fully-staged file: $file"
+      git add -- "$file"
+    fi
+  done
+fi
+
+# --- Rust checks (staged .rs files only) ---
 RS_STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.rs$' || true)
 if [ -n "$RS_STAGED" ]; then
   echo "[husky] Rust files staged — running cargo fmt --check and clippy"


### PR DESCRIPTION
- Use \git diff --quiet\ instead of capturing full diff output (minor perf improvement)
- Fix SKILL.md: partially-staged files are silently skipped, not warned (matches actual behavior)