### PR TITLE
[macos-troubleshoot-alpha1] Fix first-boot workspace picker hang

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1827,6 +1827,10 @@ pub async fn workspace_switch_impl(
 
 /// Testable inner of [`workspace_switch_impl`]. See module-level docs on the public wrapper for the full pipeline. Split out so unit tests can drive
 /// the swap with a tempdir-backed `app_data_dir` without standing up a real Tauri app.
+///
+/// **Supports unbound→bound transitions** (first-boot picker path). Steps that enumerate or mutate the *current* workspace's store (park, no-op
+/// fast-path) are guarded by `is_unbound()` checks — an unbound scope has no store and no sessions, so those steps are no-ops. Any future code that
+/// adds `ctx.store()` calls before step 8 (the scope swap) must respect this invariant.
 pub async fn workspace_switch_impl_inner(
     ctx: &Arc<AppContext>,
     sub_ctx: Option<Arc<crate::sub_sessions::SubAppContext>>,
@@ -1858,6 +1862,9 @@ pub async fn workspace_switch_impl_inner(
 
     // Step 3 — no-op fast path. We populate `config` and `sessions` from the *current* (unchanged) store so the wire payload is non-nullable; the
     // frontend short-circuits adoption on the `noOp` flag.
+    //
+    // Safe during unbound boot: `current_root` is `None` when unbound, so `None != Some(&canonical)` always skips this branch — we never reach the
+    // `ctx.store()` call.
     let current_root = ctx.workspace.read().expect("workspace lock poisoned").workspace_root.clone();
     if current_root.as_ref() == Some(&canonical) {
         let config = ctx.store().load_config();
@@ -1946,9 +1953,14 @@ pub async fn workspace_switch_impl_inner(
     //
     // Enumerate from the *current* store (still the old one until the swap in step 9). park_session_for_switch_impl uses ctx.store() which clones
     // from the old scope; safe.
-    let old_session_ids: Vec<SessionId> = ctx.store().load_sessions().keys().copied().collect();
-    for id in old_session_ids {
-        park_session_for_switch_impl(ctx, id).await;
+    //
+    // Guard: skip entirely when the current scope is unbound (first-boot picker path). There is no old store to enumerate and no sessions to park.
+    let is_unbound = ctx.workspace.read().expect("workspace lock poisoned").is_unbound();
+    if !is_unbound {
+        let old_session_ids: Vec<SessionId> = ctx.store().load_sessions().keys().copied().collect();
+        for id in old_session_ids {
+            park_session_for_switch_impl(ctx, id).await;
+        }
     }
 
     // Step 8 — swap WorkspaceScope. The OLD WorkspaceLockGuard inside the old scope is dropped at this assignment, releasing the OS lock on the old

--- a/src-tauri/tests/workspace_command.rs
+++ b/src-tauri/tests/workspace_command.rs
@@ -576,6 +576,41 @@ async fn workspace_switch_parks_old_sessions_preserving_records() {
     assert_eq!(cfg_back.active_session_id, Some(s1.id));
 }
 
+/// Regression: workspace_switch from unbound boot (first install). The switch must not panic when ctx.store() is unavailable (no prior workspace is
+/// bound). This exercises the exact path taken when the user selects a workspace from the first-boot picker.
+#[tokio::test]
+async fn workspace_switch_from_unbound_boot_succeeds() {
+    let app_data_dir = TempDir::new().unwrap();
+    let ws = make_repo_tempdir();
+    let runner = FakeGitRunner::new();
+    runner.set_repo_root(ws.path());
+
+    // Build an *unbound* AppContext (no workspace, no store) — mirrors the fresh-install boot path.
+    let workspace = Arc::new(RwLock::new(WorkspaceScope::unbound()));
+    let pool = Arc::new(PtyPool::new(Arc::new(PortablePtySpawner)));
+    let ctx = Arc::new(AppContext::with_workspace(
+        pool,
+        workspace,
+        null_sink(),
+        Arc::clone(&runner) as Arc<dyn GitRunner>,
+        Arc::new(|_| {}),
+        Arc::new(|_, _| {}),
+        Arc::new(|_, _| {}),
+    ));
+
+    let result = workspace_switch_impl_inner(&ctx, None, app_data_dir.path(), "main", ws.path())
+        .await
+        .expect("unbound-to-bound switch must succeed");
+
+    assert!(!result.no_op);
+    let canon = dunce::canonicalize(ws.path()).unwrap();
+    assert_eq!(result.workspace_root, canon);
+    assert_eq!(result.config.workspace_root, Some(canon.clone()));
+    // After the switch the context is bound.
+    let bound = ctx.workspace.read().unwrap().workspace_root.clone();
+    assert_eq!(bound, Some(canon));
+}
+
 /// Regression for the restore stale-worktree drop: if a parked session's worktree was deleted by some other means (e.g. `git worktree remove` while
 /// parked across a workspace switch), `restore_all_sessions` must drop the persisted record + trim the id from last_open_sessions / tab_order /
 /// active_session_id rather than leave a permanent ghost tab in error state.


### PR DESCRIPTION
## Problem

On first boot after a fresh install, selecting a valid workspace from the picker causes the button to switch to "Saving..." and hang indefinitely.

## Root Cause

\workspace_switch_impl_inner\ step 7 unconditionally calls \ctx.store().load_sessions()\ to enumerate sessions to park. On first boot the workspace is **unbound** (no \ConfigStore\ exists), so \ctx.store()\ panics. The panic kills the async task without sending a response back to the WebView, causing the frontend's \workspaceSwitch\ invoke to never resolve.

This was introduced in d744cd60 which added unbound boot mode but didn't update the workspace switch function to handle the unbound→bound transition.

## Fix

- Guard step 7 (park old sessions) with an \is_unbound()\ check — when transitioning from unbound boot there are no sessions to park
- Added doc comment on \workspace_switch_impl_inner\ documenting the unbound→bound invariant
- Added safety comment on step 3's no-op path explaining why it's safe during unbound boot

## Testing

- New regression test: \workspace_switch_from_unbound_boot_succeeds\
- All existing workspace_switch tests pass
- \cargo clippy\ and \cargo test\ clean