### PR TITLE
Added arborist gitignore resulting from dogfooding

### DIFF
--- a/.arborist/.gitignore
+++ b/.arborist/.gitignore
@@ -1,0 +1,1 @@
+.worktrees/


### PR DESCRIPTION
This pull request makes a minor update to the `.gitignore` configuration by adding the `.worktrees/` directory to the ignore list, ensuring that worktree-related files are not tracked by git.