### PR TITLE
[release-cleanup] Clean stale bundle artifacts before release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,6 +237,18 @@ jobs:
           fi
           echo "Version check passed: all manifests at ${expected} match tag ${TAG}"
 
+      # Remove stale bundle artifacts that may have been restored from the
+      # Cargo cache. Without this, `find` in "Find release artifacts" can
+      # pick up installers from a previous release when Cargo.lock (and
+      # therefore the cache key) hasn't changed between versions.
+      - name: Clean stale bundle artifacts
+        shell: bash
+        run: |
+          rm -rf target/release/bundle
+          for d in target/*/release/bundle; do
+            [ -d "$d" ] && rm -rf "$d"
+          done
+
       - name: Build Tauri app
         shell: bash
         run: pnpm tauri build ${{ matrix.platform.args }}


### PR DESCRIPTION
## Problem

The release workflow caches \	arget/\ and restores it via prefix-match \estore-keys\. When \Cargo.lock\ hasn't changed between releases, bundle artifacts from the previous build (msi, dmg, deb, etc.) survive in the restored cache and get picked up by the 'Find release artifacts' step — causing old installers to be uploaded alongside the new ones.

## Fix

Add a step that removes \	arget/*/release/bundle/\ directories before running \	auri build\, so only freshly-built artifacts are found and uploaded.