### PR TITLE
[codex-plugin] Add OpenAI Codex CLI as AI tool plugin

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,6 +63,7 @@ body:
         - Workspace or Git worktree
         - Claude session
         - Copilot session
+        - Codex session
         - Terminal custom process
         - Application custom process
         - Settings or configuration

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,11 +54,12 @@ A cross-platform desktop app (Tauri v2 + React/TS) that manages multiple Claude 
 
 ## Tool-specific CLI launch rules (see `docs/architecture.md` and `docs/runtime-flows.md`)
 
-| | Claude | Copilot |
-|---|---|---|
-| Repo instructions | Auto-loaded from `cwd` (`CLAUDE.md`). Don't pass it. | Auto-loaded from `cwd` (`.github/copilot-instructions.md`). Don't pass `--instructions` — it would disable auto-discovery. |
-| Worktree context | Derived by the CLI from `pwd`/`git` because the PTY pool sets `cwd` to the worktree. | Same. |
-| Temp file | None for new sessions. Legacy restored sessions may still rematerialize persisted `tempFiles`. | None |
+| | Claude | Copilot | Codex |
+|---|---|---|---|
+| Repo instructions | Auto-loaded from `cwd` (`CLAUDE.md`). Don't pass it. | Auto-loaded from `cwd` (`.github/copilot-instructions.md`). Don't pass `--instructions` — it would disable auto-discovery. | Auto-loaded from `cwd` (`AGENTS.md`). Bare `codex` is correct — no instruction flag. |
+| Worktree context | Derived by the CLI from `pwd`/`git` because the PTY pool sets `cwd` to the worktree. | Same. | Same. |
+| Temp file | None for new sessions. Legacy restored sessions may still rematerialize persisted `tempFiles`. | None | None |
+| Resume syntax | `claude --resume <id>` (flag) | `copilot --resume <id>` (flag) | `codex resume <id>` (**subcommand**, not a flag). The metrics watcher discovers the thread id from the rollout file's `SessionMeta` line. |
 
 ## Data model
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ Rust backend owns all PTYs and persistent state; the React frontend communicates
 
 - **Claude**: do **not** pass `--system-prompt` for new sessions. Claude auto-discovers `CLAUDE.md` from the worktree `cwd`.
 - **Copilot**: do **not** pass `--instructions` — it disables auto-discovery of `.github/copilot-instructions.md`.
+- **Codex**: launch is bare `codex`. The CLI starts in interactive TUI mode by default and auto-discovers instructions (`AGENTS.md`) from the worktree `cwd`. Resume syntax is `codex resume <id>` — a **subcommand**, not a `--resume` flag. The metrics watcher discovers the thread id from the rollout file's `SessionMeta` line.
 
 ### Code conventions
 

--- a/crates/arborist-types/src/lib.rs
+++ b/crates/arborist-types/src/lib.rs
@@ -144,11 +144,12 @@ pub enum ThemeMode {
 pub enum Tool {
     Claude,
     Copilot,
+    Codex,
 }
 
 impl Tool {
     /// Every persisted `Tool` variant in stable iteration order.
-    pub const ALL: [Self; 2] = [Self::Claude, Self::Copilot];
+    pub const ALL: [Self; 3] = [Self::Claude, Self::Copilot, Self::Codex];
 
     /// Stable serde discriminator used on disk and as the AI-plugin registry id.
     #[must_use]
@@ -156,6 +157,7 @@ impl Tool {
         match self {
             Self::Claude => "claude",
             Self::Copilot => "copilot",
+            Self::Codex => "codex",
         }
     }
 }
@@ -2494,6 +2496,7 @@ mod tests {
     fn tool_serializes_lowercase() {
         assert_eq!(serde_json::to_value(Tool::Claude).expect("v"), json!("claude"));
         assert_eq!(serde_json::to_value(Tool::Copilot).expect("v"), json!("copilot"));
+        assert_eq!(serde_json::to_value(Tool::Codex).expect("v"), json!("codex"));
     }
 
     #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -200,7 +200,7 @@ Arborist has an internal plugin registry, not a public plugin marketplace. Built
 
 | Plugin family     | Examples                    | Notes                                                                                                     |
 | ----------------- | --------------------------- | --------------------------------------------------------------------------------------------------------- |
-| AI tools          | Claude, Copilot             | Tool ids match `Tool::as_id()`. Launch overrides live in `pluginSettings.ai.<id>.settings.launchCommand`. |
+| AI tools          | Claude, Copilot, Codex      | Tool ids match `Tool::as_id()`. Launch overrides live in `pluginSettings.ai.<id>.settings.launchCommand`. |
 | Custom processes  | Shell, open folder, VS Code | Seeded definitions are user-editable and user-deletable; plugin toggles control built-in integrations.    |
 | Dashboard widgets | AI usage, Git status        | Render worktree dashboard data and can be enabled/disabled through `pluginSettings.dashboardWidget`.      |
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,8 +1,8 @@
 # Arborist overview
 
 Arborist is a cross-platform desktop app for managing AI coding-assistant sessions across Git worktrees. It is built with Tauri v2, a Rust backend,
-and a React/TypeScript frontend. The app gives each worktree a persistent terminal-backed session for Claude CLI, GitHub Copilot CLI, or a configured
-custom process.
+and a React/TypeScript frontend. The app gives each worktree a persistent terminal-backed session for Claude CLI, GitHub Copilot CLI, OpenAI Codex
+CLI, or a configured custom process.
 
 ## Mental model
 
@@ -13,7 +13,7 @@ workspace become top-level tabs in the sidebar. AI sessions and custom-process s
 flowchart LR
     Workspace["Workspace root<br/>primary Git clone"]
     Worktrees["Worktree tabs<br/>one per opened worktree"]
-    Children["Child tabs<br/>Claude, Copilot, shell, apps"]
+    Children["Child tabs<br/>Claude, Copilot, Codex, shell, apps"]
     Main["Main area<br/>dashboard or terminal"]
 
     Workspace --> Worktrees
@@ -34,7 +34,7 @@ Key ideas:
 
 1. Pick a workspace root on first launch. The root must be a primary Git clone, not a linked worktree.
 2. Open an existing worktree tab or create a new worktree under `<workspace>/.arborist/.worktrees/<name>/`.
-3. Launch Claude, Copilot, or a configured custom process from the worktree tab context menu.
+3. Launch Claude, Copilot, Codex, or a configured custom process from the worktree tab context menu.
 4. Switch between child tabs while every background PTY keeps running.
 5. Close tabs when finished. Worktree-tab close cascades to children and can optionally remove the linked worktree.
 

--- a/docs/product.md
+++ b/docs/product.md
@@ -22,7 +22,7 @@ Success looks like:
 | -------------------------- | ------------------------------------------------------------------------------------------------ |
 | Workspace root             | The primary local Git clone Arborist is bound to. Must contain `.git` as a directory.            |
 | Worktree tab               | A top-level sidebar tab for a worktree path. Its dashboard is shown when no child is active.     |
-| AI session                 | A Claude or Copilot CLI process running in a PTY in the worktree `cwd`.                          |
+| AI session                 | A Claude, Copilot, or Codex CLI process running in a PTY in the worktree `cwd`.                  |
 | Custom-process sub-session | A child tab launched from a configured custom process definition.                                |
 | Worktree prep              | One-shot commands run after `worktree_create`, with output logged and surfaced through a banner. |
 
@@ -40,7 +40,7 @@ Success looks like:
 | S-06 | Active worktree and active child selection must be visually clear and keyboard navigable.                                                                                  |
 | S-07 | Top-level worktree order must persist. Child reordering can be added later.                                                                                                |
 | S-08 | Close actions that terminate processes must require confirmation.                                                                                                          |
-| S-09 | The worktree-tab context menu must expose Launch Claude, Launch Copilot, enabled custom-process entries, custom-process settings, and close.                               |
+| S-09 | The worktree-tab context menu must expose Launch Claude, Launch Copilot, Launch Codex, enabled custom-process entries, custom-process settings, and close.                 |
 
 ### Workspaces and worktrees
 
@@ -69,8 +69,8 @@ Success looks like:
 
 | ID   | Requirement                                                                                                                                               |
 | ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| I-01 | Claude and Copilot run in the selected worktree `cwd` so each tool can load its own repository-level instruction files.                                   |
-| I-02 | Arborist must not pass `--system-prompt` to Claude or `--instructions` to Copilot for newly created sessions.                                             |
+| I-01 | Claude, Copilot, and Codex run in the selected worktree `cwd` so each tool can load its own repository-level instruction files.                           |
+| I-02 | Arborist must not pass `--system-prompt` to Claude, `--instructions` to Copilot, or any instruction flag to Codex for newly created sessions.             |
 | I-03 | Custom AI launch commands are plugin-keyed overrides. Missing or empty override means use the plugin default program.                                     |
 | I-04 | Dynamic paths must be canonicalized before use and shell-quoted when inserted into command strings. Worktree paths are passed as `cwd`, not interpolated. |
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -443,16 +443,7 @@ fn with_resume_for_spawn(session: &Session, ai_session_id: &str) -> Session {
     let mut session_to_spawn = session.clone();
     session_to_spawn.composed_command = compose::with_resume(&session.composed_command, session.tool, ai_session_id);
     if let Some(structured) = session_to_spawn.structured_command.as_mut() {
-        match session.tool {
-            Tool::Codex => {
-                structured.args.push("resume".to_owned());
-                structured.args.push(ai_session_id.to_owned());
-            }
-            Tool::Claude | Tool::Copilot => {
-                structured.args.push("--resume".to_owned());
-                structured.args.push(ai_session_id.to_owned());
-            }
-        }
+        structured.args.extend(crate::plugins::ai::resume_args(session.tool, ai_session_id));
     }
     session_to_spawn
 }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -434,7 +434,7 @@ fn default_structured_command(tool: Tool, temp_files: &[crate::types::TempFileSp
             .first()
             .map(|temp| vec!["--system-prompt".to_owned(), temp.path.to_string_lossy().into_owned()])
             .unwrap_or_default(),
-        Tool::Copilot => Vec::new(),
+        Tool::Copilot | Tool::Codex => Vec::new(),
     };
     StructuredCommand { program, args }
 }
@@ -443,8 +443,16 @@ fn with_resume_for_spawn(session: &Session, ai_session_id: &str) -> Session {
     let mut session_to_spawn = session.clone();
     session_to_spawn.composed_command = compose::with_resume(&session.composed_command, session.tool, ai_session_id);
     if let Some(structured) = session_to_spawn.structured_command.as_mut() {
-        structured.args.push("--resume".to_owned());
-        structured.args.push(ai_session_id.to_owned());
+        match session.tool {
+            Tool::Codex => {
+                structured.args.push("resume".to_owned());
+                structured.args.push(ai_session_id.to_owned());
+            }
+            Tool::Claude | Tool::Copilot => {
+                structured.args.push("--resume".to_owned());
+                structured.args.push(ai_session_id.to_owned());
+            }
+        }
     }
     session_to_spawn
 }

--- a/src-tauri/src/compose.rs
+++ b/src-tauri/src/compose.rs
@@ -57,8 +57,9 @@ pub struct ComposeInputs<'a> {
 /// |---------|--------------------------------------------------|-----------|
 /// | Claude  | `claude`                                         | no        |
 /// | Copilot | `copilot` (bare; interactive mode is the default) | no        |
+/// | Codex   | `codex` (bare; interactive TUI is the default)   | no        |
 ///
-/// **Worktree handling**: the worktree path is *never* interpolated into the composed command. In both cases the real `cwd` for `portable-pty` is set
+/// **Worktree handling**: the worktree path is *never* interpolated into the composed command. In all cases the real `cwd` for `portable-pty` is set
 /// separately by the PTY pool; we never emit `cd "<path>" && ...`.
 pub fn compose_command(inputs: &ComposeInputs<'_>) -> Result<ComposedInvocation, Error> {
     let quoter = platform_shell().quoter;
@@ -234,8 +235,12 @@ pub fn env_for_tool(tool: Tool, session_id: &SessionId) -> Vec<(String, std::ffi
     crate::plugins::ai::env(tool, session_id)
 }
 
-/// Augment a stored `composed_command` with `--resume <ai_session_id>` so the AI conversation continues across an app restart, a user-initiated
+/// Augment a stored `composed_command` with resume logic so the AI conversation continues across an app restart, a user-initiated
 /// restart, or — for Copilot — pre-binds the brand-new session to a pre-allocated uuid at create time.
+///
+/// Resume syntax varies by tool:
+/// * Claude / Copilot: `<cmd> --resume <ai_session_id>` (trailing flag)
+/// * Codex: `<cmd> resume <ai_session_id>` (subcommand — no `--` prefix)
 ///
 /// Used by every spawn site that has an `ai_session_id` to honor: `session_create` (Copilot only — pre-allocated uuid), `session_restart` (Copilot
 /// only — freshly re-allocated uuid), and `restore_all_sessions` (both tools when an id is persisted). The persisted `composed_command` itself stays
@@ -251,12 +256,16 @@ pub fn env_for_tool(tool: Tool, session_id: &SessionId) -> Vec<(String, std::ffi
 /// the surrounding quotes as part of the argument value — `--resume "<uuid>"` reaches the CLI with the quotes attached and resume fails. Defensive
 /// quoting is still applied for any future non-safe id (e.g. Copilot's session-by-name resume).
 #[must_use]
-pub fn with_resume(composed_command: &str, _tool: Tool, ai_session_id: &str) -> String {
+pub fn with_resume(composed_command: &str, tool: Tool, ai_session_id: &str) -> String {
+    let resume_keyword = match tool {
+        Tool::Codex => "resume",
+        Tool::Claude | Tool::Copilot => "--resume",
+    };
     if is_shell_safe_token(ai_session_id) {
-        format!("{composed_command} --resume {ai_session_id}")
+        format!("{composed_command} {resume_keyword} {ai_session_id}")
     } else {
         let quoter = platform_shell().quoter;
-        format!("{composed_command} --resume {}", quoter(ai_session_id))
+        format!("{composed_command} {resume_keyword} {}", quoter(ai_session_id))
     }
 }
 
@@ -421,6 +430,13 @@ pub(crate) fn build_copilot(inputs: &ComposeInputs<'_>, _quoter: Quoter) -> (Str
     (cli_cmd, Vec::new())
 }
 
+pub(crate) fn build_codex(inputs: &ComposeInputs<'_>, _quoter: Quoter) -> (String, Vec<TempFileSpec>) {
+    // Codex CLI starts in interactive TUI mode by default with bare `codex`. It auto-discovers instructions from `cwd` (no flags needed). The PTY
+    // pool sets the worktree as `cwd`, so Codex picks up the repo context automatically.
+    let cli_cmd = cli_program_for_tool(Tool::Codex, inputs.cli_launch_command);
+    (cli_cmd, Vec::new())
+}
+
 /// Resolve the program token for `tool`. Precedence (highest first):
 ///
 /// 1. **User config override** (`config_override`, when `Some` and non-empty):
@@ -428,7 +444,7 @@ pub(crate) fn build_copilot(inputs: &ComposeInputs<'_>, _quoter: Quoter) -> (Str
 ///    authored by the user — not a single argument — so callers can add flags
 ///    like `--model sonnet` directly. Persisted by the Settings dialog into
 ///    `AppConfig.ai_launch_commands`.
-/// 2. **Default**: the bare CLI name (`claude` / `copilot`).
+/// 2. **Default**: the bare CLI name (`claude` / `copilot` / `codex`).
 fn cli_program_for_tool(tool: Tool, config_override: Option<&str>) -> String {
     if let Some(s) = config_override {
         let trimmed = s.trim();
@@ -546,6 +562,26 @@ mod tests {
         }
     }
 
+    // -- composition: Codex -------------------------------------------
+
+    #[test]
+    fn codex_compose_basic() {
+        let wt = PathBuf::from(if cfg!(windows) { "C:\\repos\\my-project" } else { "/repos/my-project" });
+        let r = compose_command(&inputs(Tool::Codex, &wt, "wt")).expect("compose");
+        // Bare `codex` — interactive TUI mode is the default. No flags, no worktree path interpolation.
+        assert_eq!(r.composed_command, "codex");
+        assert!(r.temp_files.is_empty());
+    }
+
+    #[test]
+    fn codex_compose_uses_cli_launch_command_override() {
+        let wt = PathBuf::from(if cfg!(windows) { "C:\\wt" } else { "/wt" });
+        let mut i = inputs(Tool::Codex, &wt, "wt");
+        i.cli_launch_command = Some("codex --model gpt-5.4");
+        let r = compose_command(&i).expect("compose");
+        assert_eq!(r.composed_command, "codex --model gpt-5.4");
+    }
+
     // -- with_resume ----------------------------------------------------
 
     #[test]
@@ -590,6 +626,20 @@ mod tests {
         assert_eq!(out, format!("claude --resume {}", host_quote(nasty)));
         // Extra sanity: the raw id substring must not appear unquoted.
         assert!(!out.ends_with(nasty));
+    }
+
+    #[test]
+    fn with_resume_codex_uses_subcommand_syntax() {
+        // Codex CLI uses `codex resume <id>` (a subcommand), not `--resume <id>`.
+        let out = with_resume("codex", Tool::Codex, "abc-123");
+        assert_eq!(out, "codex resume abc-123");
+    }
+
+    #[test]
+    fn with_resume_codex_with_launch_override() {
+        let base = "codex --model gpt-5.4";
+        let out = with_resume(base, Tool::Codex, "sess-uuid");
+        assert_eq!(out, format!("{base} resume sess-uuid"));
     }
 
     // -- POSIX quoting --------------------------------------------------
@@ -864,5 +914,10 @@ mod tests {
             path_a.get("COPILOT_OTEL_FILE_EXPORTER_PATH"),
             path_b.get("COPILOT_OTEL_FILE_EXPORTER_PATH"),
         );
+    }
+
+    #[test]
+    fn env_for_tool_codex_is_empty() {
+        assert!(env_for_tool(Tool::Codex, &fixed_id()).is_empty());
     }
 }

--- a/src-tauri/src/compose.rs
+++ b/src-tauri/src/compose.rs
@@ -238,9 +238,9 @@ pub fn env_for_tool(tool: Tool, session_id: &SessionId) -> Vec<(String, std::ffi
 /// Augment a stored `composed_command` with resume logic so the AI conversation continues across an app restart, a user-initiated
 /// restart, or — for Copilot — pre-binds the brand-new session to a pre-allocated uuid at create time.
 ///
-/// Resume syntax varies by tool:
-/// * Claude / Copilot: `<cmd> --resume <ai_session_id>` (trailing flag)
-/// * Codex: `<cmd> resume <ai_session_id>` (subcommand — no `--` prefix)
+/// Resume syntax is plugin-dispatched (`plugins::ai::resume_args`):
+/// * Claude / Copilot currently append `--resume <ai_session_id>`
+/// * Codex currently appends `resume <ai_session_id>` (subcommand)
 ///
 /// Used by every spawn site that has an `ai_session_id` to honor: `session_create` (Copilot only — pre-allocated uuid), `session_restart` (Copilot
 /// only — freshly re-allocated uuid), and `restore_all_sessions` (both tools when an id is persisted). The persisted `composed_command` itself stays
@@ -257,16 +257,17 @@ pub fn env_for_tool(tool: Tool, session_id: &SessionId) -> Vec<(String, std::ffi
 /// quoting is still applied for any future non-safe id (e.g. Copilot's session-by-name resume).
 #[must_use]
 pub fn with_resume(composed_command: &str, tool: Tool, ai_session_id: &str) -> String {
-    let resume_keyword = match tool {
-        Tool::Codex => "resume",
-        Tool::Claude | Tool::Copilot => "--resume",
-    };
-    if is_shell_safe_token(ai_session_id) {
-        format!("{composed_command} {resume_keyword} {ai_session_id}")
-    } else {
-        let quoter = platform_shell().quoter;
-        format!("{composed_command} {resume_keyword} {}", quoter(ai_session_id))
+    let quoter = platform_shell().quoter;
+    let resume_tokens = crate::plugins::ai::resume_args(tool, ai_session_id);
+    if resume_tokens.is_empty() {
+        return composed_command.to_owned();
     }
+    let tail = resume_tokens
+        .iter()
+        .map(|token| if is_shell_safe_token(token) { token.clone() } else { quoter(token) })
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!("{composed_command} {tail}")
 }
 
 /// True for non-empty values composed entirely of characters that have no special meaning to either `sh` or `cmd.exe`: ASCII letters, digits, `-`,

--- a/src-tauri/src/plugins/ai/claude/mod.rs
+++ b/src-tauri/src/plugins/ai/claude/mod.rs
@@ -65,6 +65,10 @@ impl AiPlugin for ClaudePlugin {
         true
     }
 
+    fn resume_args(&self, ai_session_id: &str) -> Vec<String> {
+        vec!["--resume".to_owned(), ai_session_id.to_owned()]
+    }
+
     fn ai_session_transcript_path(&self, home: &std::path::Path, worktree_path: &std::path::Path, ai_session_id: &str) -> std::path::PathBuf {
         home.join(".claude")
             .join("projects")

--- a/src-tauri/src/plugins/ai/codex/mod.rs
+++ b/src-tauri/src/plugins/ai/codex/mod.rs
@@ -1,0 +1,69 @@
+//! Codex AI plugin metadata.
+//!
+//! OpenAI Codex CLI (`codex`) is an interactive coding agent that runs locally.
+//! It starts in TUI mode by default and auto-discovers instructions from `cwd`.
+//! Resume syntax differs from Claude/Copilot: `codex resume <session_id>` (a
+//! subcommand, not a `--resume` flag).
+
+use crate::plugins::ai::AiPlugin;
+use crate::plugins::Plugin;
+use crate::types::SessionId;
+use crate::types::Tool;
+
+/// Stable singleton instance for dispatch sites that need a `'static`
+/// [`AiPlugin`] reference without allocating.
+pub static PLUGIN: CodexPlugin = CodexPlugin;
+
+pub struct CodexPlugin;
+
+impl Plugin for CodexPlugin {
+    fn id(&self) -> &'static str {
+        Tool::Codex.as_id()
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Codex"
+    }
+}
+
+impl AiPlugin for CodexPlugin {
+    fn default_program(&self) -> &'static str {
+        "codex"
+    }
+
+    fn compose(&self, inputs: &crate::compose::ComposeInputs<'_>, quoter: crate::compose::Quoter) -> (String, Vec<crate::types::TempFileSpec>) {
+        crate::compose::build_codex(inputs, quoter)
+    }
+
+    fn env(&self, _session_id: &SessionId) -> Vec<(String, std::ffi::OsString)> {
+        Vec::new()
+    }
+
+    fn spawn_prep(&self, _session_id: &SessionId) -> crate::plugins::ai::SpawnPrep {
+        crate::plugins::ai::SpawnPrep::default()
+    }
+
+    fn metrics_watcher_kind(&self, _session_id: SessionId, _cwd: &std::path::Path) -> Option<crate::plugins::ai::MetricsWatcherKind> {
+        None
+    }
+
+    fn starts_activity_events_watcher(&self) -> bool {
+        false
+    }
+
+    fn create_ai_session_id(&self) -> Option<String> {
+        None
+    }
+
+    fn restart_ai_session_policy(&self) -> crate::plugins::ai::RestartAiSessionPolicy {
+        crate::plugins::ai::RestartAiSessionPolicy::Clear
+    }
+
+    fn resume_requires_preflight(&self) -> bool {
+        true
+    }
+
+    fn ai_session_transcript_path(&self, home: &std::path::Path, _worktree_path: &std::path::Path, ai_session_id: &str) -> std::path::PathBuf {
+        home.join(".codex").join("sessions").join(ai_session_id)
+    }
+}

--- a/src-tauri/src/plugins/ai/codex/mod.rs
+++ b/src-tauri/src/plugins/ai/codex/mod.rs
@@ -70,18 +70,16 @@ impl AiPlugin for CodexPlugin {
 
     fn resume_requires_preflight(&self) -> bool {
         // Codex's `resume <thread_id>` handles missing threads gracefully (prints its own error).
-        // Rollout files use `rollout-<timestamp>-<thread_id>.jsonl` naming in date-nested dirs,
-        // making a quick path existence check impractical. Let the CLI validate.
+        // Rollout files use `rollout-<timestamp>-<uuid>.jsonl` naming in date-nested dirs, with
+        // thread_id living in the first-line `session_meta` payload, so a cheap path probe by id
+        // is not reliable. Let the CLI validate.
         false
     }
 
     fn ai_session_transcript_path(&self, home: &std::path::Path, _worktree_path: &std::path::Path, ai_session_id: &str) -> std::path::PathBuf {
-        // Codex stores rollouts at `~/.codex/sessions/<date-nested>/rollout-<ts>-<uuid>.jsonl`.
-        // At preflight time the watcher has already resolved the full path and stored the thread_id.
-        // This method is called to check existence; we store the full path when discovering, so
-        // check in the sessions root using the thread_id as a marker.
-        // The actual file is discovered by scanning the sessions dir — this path is used only for
-        // the `exists()` preflight check at restore time.
+        // `resume_requires_preflight()` is false for Codex, so this is currently not used to gate
+        // restore. Keep a stable placeholder path to satisfy the trait contract; if Codex preflight
+        // is ever enabled, this needs a real rollout-file lookup strategy.
         home.join(".codex").join("sessions").join(ai_session_id)
     }
 }

--- a/src-tauri/src/plugins/ai/codex/mod.rs
+++ b/src-tauri/src/plugins/ai/codex/mod.rs
@@ -4,6 +4,22 @@
 //! It starts in TUI mode by default and auto-discovers instructions from `cwd`.
 //! Resume syntax differs from Claude/Copilot: `codex resume <session_id>` (a
 //! subcommand, not a `--resume` flag).
+//!
+//! ## Metrics & session-id discovery
+//!
+//! Codex persists every session as a JSONL "rollout" file under
+//! `<CODEX_HOME>/sessions/` (default `~/.codex/sessions/`), optionally nested
+//! in `YYYY/MM/DD/` date subdirectories. File names follow the pattern
+//! `rollout-<TIMESTAMP>-<UUID>.jsonl`. The first line is a `SessionMeta`
+//! JSON object carrying the thread id, cwd, model, etc. Subsequent lines are
+//! `RolloutItem` records including `TokenCount` events (cumulative and per-turn
+//! token usage) and `TurnComplete` markers.
+//!
+//! The Codex metrics watcher discovers the rollout file matching the session's
+//! `cwd` and spawn-instant, extracts the thread id (fires the AI-session
+//! discovery callback for resume support), and tails `TokenCount` events for
+//! sidebar metrics — achieving feature parity with the Claude and Copilot
+//! watchers.
 
 use crate::plugins::ai::AiPlugin;
 use crate::plugins::Plugin;
@@ -43,8 +59,11 @@ impl AiPlugin for CodexPlugin {
         crate::plugins::ai::SpawnPrep::default()
     }
 
-    fn metrics_watcher_kind(&self, _session_id: SessionId, _cwd: &std::path::Path) -> Option<crate::plugins::ai::MetricsWatcherKind> {
-        None
+    fn metrics_watcher_kind(&self, _session_id: SessionId, cwd: &std::path::Path) -> Option<crate::plugins::ai::MetricsWatcherKind> {
+        crate::session_metrics::home_dir().map(|home| crate::plugins::ai::MetricsWatcherKind::Codex {
+            home,
+            cwd: cwd.to_path_buf(),
+        })
     }
 
     fn starts_activity_events_watcher(&self) -> bool {
@@ -52,6 +71,8 @@ impl AiPlugin for CodexPlugin {
     }
 
     fn create_ai_session_id(&self) -> Option<String> {
+        // Codex manages its own thread IDs internally. The watcher discovers
+        // the thread id from the rollout file's SessionMeta line.
         None
     }
 
@@ -60,10 +81,19 @@ impl AiPlugin for CodexPlugin {
     }
 
     fn resume_requires_preflight(&self) -> bool {
-        true
+        // Codex's `resume <thread_id>` handles missing threads gracefully (prints its own error).
+        // Rollout files use `rollout-<timestamp>-<thread_id>.jsonl` naming in date-nested dirs,
+        // making a quick path existence check impractical. Let the CLI validate.
+        false
     }
 
     fn ai_session_transcript_path(&self, home: &std::path::Path, _worktree_path: &std::path::Path, ai_session_id: &str) -> std::path::PathBuf {
+        // Codex stores rollouts at `~/.codex/sessions/<date-nested>/rollout-<ts>-<uuid>.jsonl`.
+        // At preflight time the watcher has already resolved the full path and stored the thread_id.
+        // This method is called to check existence; we store the full path when discovering, so
+        // check in the sessions root using the thread_id as a marker.
+        // The actual file is discovered by scanning the sessions dir — this path is used only for
+        // the `exists()` preflight check at restore time.
         home.join(".codex").join("sessions").join(ai_session_id)
     }
 }

--- a/src-tauri/src/plugins/ai/codex/mod.rs
+++ b/src-tauri/src/plugins/ai/codex/mod.rs
@@ -48,8 +48,11 @@ impl AiPlugin for CodexPlugin {
     }
 
     fn metrics_watcher_kind(&self, _session_id: SessionId, cwd: &std::path::Path) -> Option<crate::plugins::ai::MetricsWatcherKind> {
-        crate::session_metrics::home_dir().map(|home| crate::plugins::ai::MetricsWatcherKind::Codex {
-            home,
+        let codex_home = std::env::var_os("CODEX_HOME")
+            .map(std::path::PathBuf::from)
+            .or_else(|| crate::session_metrics::home_dir().map(|home| home.join(".codex")))?;
+        Some(crate::plugins::ai::MetricsWatcherKind::Codex {
+            codex_home,
             cwd: cwd.to_path_buf(),
         })
     }

--- a/src-tauri/src/plugins/ai/codex/mod.rs
+++ b/src-tauri/src/plugins/ai/codex/mod.rs
@@ -76,6 +76,10 @@ impl AiPlugin for CodexPlugin {
         false
     }
 
+    fn resume_args(&self, ai_session_id: &str) -> Vec<String> {
+        vec!["resume".to_owned(), ai_session_id.to_owned()]
+    }
+
     fn ai_session_transcript_path(&self, home: &std::path::Path, _worktree_path: &std::path::Path, ai_session_id: &str) -> std::path::PathBuf {
         // `resume_requires_preflight()` is false for Codex, so this is currently not used to gate
         // restore. Keep a stable placeholder path to satisfy the trait contract; if Codex preflight

--- a/src-tauri/src/plugins/ai/codex/mod.rs
+++ b/src-tauri/src/plugins/ai/codex/mod.rs
@@ -5,21 +5,9 @@
 //! Resume syntax differs from Claude/Copilot: `codex resume <session_id>` (a
 //! subcommand, not a `--resume` flag).
 //!
-//! ## Metrics & session-id discovery
-//!
-//! Codex persists every session as a JSONL "rollout" file under
-//! `<CODEX_HOME>/sessions/` (default `~/.codex/sessions/`), optionally nested
-//! in `YYYY/MM/DD/` date subdirectories. File names follow the pattern
-//! `rollout-<TIMESTAMP>-<UUID>.jsonl`. The first line is a `SessionMeta`
-//! JSON object carrying the thread id, cwd, model, etc. Subsequent lines are
-//! `RolloutItem` records including `TokenCount` events (cumulative and per-turn
-//! token usage) and `TurnComplete` markers.
-//!
-//! The Codex metrics watcher discovers the rollout file matching the session's
-//! `cwd` and spawn-instant, extracts the thread id (fires the AI-session
-//! discovery callback for resume support), and tails `TokenCount` events for
-//! sidebar metrics — achieving feature parity with the Claude and Copilot
-//! watchers.
+//! The metrics watcher implementation lives in
+//! [`crate::session_metrics`] (`run_codex_watcher`); that module documents the
+//! rollout-file layout and the event types it consumes.
 
 use crate::plugins::ai::AiPlugin;
 use crate::plugins::Plugin;

--- a/src-tauri/src/plugins/ai/copilot/mod.rs
+++ b/src-tauri/src/plugins/ai/copilot/mod.rs
@@ -72,6 +72,10 @@ impl AiPlugin for CopilotPlugin {
         false
     }
 
+    fn resume_args(&self, ai_session_id: &str) -> Vec<String> {
+        vec!["--resume".to_owned(), ai_session_id.to_owned()]
+    }
+
     fn ai_session_transcript_path(&self, home: &std::path::Path, _worktree_path: &std::path::Path, ai_session_id: &str) -> std::path::PathBuf {
         home.join(".copilot").join("session-state").join(ai_session_id)
     }

--- a/src-tauri/src/plugins/ai/mod.rs
+++ b/src-tauri/src/plugins/ai/mod.rs
@@ -73,7 +73,7 @@ pub enum RestartAiSessionPolicy {
 pub enum MetricsWatcherKind {
     Claude { home: PathBuf, cwd: PathBuf },
     Copilot { otel_path: PathBuf },
-    Codex { home: PathBuf, cwd: PathBuf },
+    Codex { codex_home: PathBuf, cwd: PathBuf },
 }
 
 /// Spawn-prep side effects run right before PTY spawn.

--- a/src-tauri/src/plugins/ai/mod.rs
+++ b/src-tauri/src/plugins/ai/mod.rs
@@ -13,6 +13,7 @@ use crate::types::Tool;
 use crate::types::{SessionId, TempFileSpec};
 
 pub mod claude;
+pub mod codex;
 pub mod copilot;
 
 /// AI plugin trait. See module-level docs for the full implementor contract.
@@ -97,12 +98,16 @@ fn claude_factory() -> Arc<dyn AiPlugin> {
     Arc::new(claude::ClaudePlugin)
 }
 
+fn codex_factory() -> Arc<dyn AiPlugin> {
+    Arc::new(codex::CodexPlugin)
+}
+
 fn copilot_factory() -> Arc<dyn AiPlugin> {
     Arc::new(copilot::CopilotPlugin)
 }
 
 /// Built-in AI plugins in stable registration order.
-pub const BUILTIN_AI: [BuiltinAi; 2] = [
+pub const BUILTIN_AI: [BuiltinAi; 3] = [
     BuiltinAi {
         tool: Tool::Claude,
         plugin: &claude::PLUGIN,
@@ -112,6 +117,11 @@ pub const BUILTIN_AI: [BuiltinAi; 2] = [
         tool: Tool::Copilot,
         plugin: &copilot::PLUGIN,
         factory: copilot_factory,
+    },
+    BuiltinAi {
+        tool: Tool::Codex,
+        plugin: &codex::PLUGIN,
+        factory: codex_factory,
     },
 ];
 
@@ -124,10 +134,11 @@ pub fn plugin_for_tool(tool: Tool) -> &'static dyn AiPlugin {
     match tool {
         Tool::Claude => &claude::PLUGIN,
         Tool::Copilot => &copilot::PLUGIN,
+        Tool::Codex => &codex::PLUGIN,
     }
 }
 
-/// Resolve a built-in AI plugin by registry id (`"claude"`, `"copilot"`).
+/// Resolve a built-in AI plugin by registry id (`"claude"`, `"copilot"`, `"codex"`).
 #[must_use]
 pub fn plugin_for_id(id: &str) -> Option<&'static dyn AiPlugin> {
     BUILTIN_AI.iter().find(|p| p.plugin.id() == id).map(|p| p.plugin)

--- a/src-tauri/src/plugins/ai/mod.rs
+++ b/src-tauri/src/plugins/ai/mod.rs
@@ -70,6 +70,7 @@ pub enum RestartAiSessionPolicy {
 pub enum MetricsWatcherKind {
     Claude { home: PathBuf, cwd: PathBuf },
     Copilot { otel_path: PathBuf },
+    Codex { home: PathBuf, cwd: PathBuf },
 }
 
 /// Spawn-prep side effects run right before PTY spawn.

--- a/src-tauri/src/plugins/ai/mod.rs
+++ b/src-tauri/src/plugins/ai/mod.rs
@@ -50,6 +50,9 @@ pub trait AiPlugin: Plugin {
     /// Whether restore-time `--resume` should verify transcript/session-state first.
     fn resume_requires_preflight(&self) -> bool;
 
+    /// Structured-command args to resume the AI session id for this tool.
+    fn resume_args(&self, ai_session_id: &str) -> Vec<String>;
+
     /// Resolve the expected transcript/session-state path for `ai_session_id`.
     fn ai_session_transcript_path(&self, home: &Path, worktree_path: &Path, ai_session_id: &str) -> PathBuf;
 }
@@ -195,8 +198,26 @@ pub fn resume_requires_preflight(tool: Tool) -> bool {
     plugin_for_tool(tool).resume_requires_preflight()
 }
 
+/// Structured-command args to resume `ai_session_id` for `tool`.
+#[must_use]
+pub fn resume_args(tool: Tool, ai_session_id: &str) -> Vec<String> {
+    plugin_for_tool(tool).resume_args(ai_session_id)
+}
+
 /// Resolve the expected transcript/session-state path for `ai_session_id`.
 #[must_use]
 pub fn ai_session_transcript_path(tool: Tool, home: &Path, worktree_path: &Path, ai_session_id: &str) -> PathBuf {
     plugin_for_tool(tool).ai_session_transcript_path(home, worktree_path, ai_session_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resume_args_dispatch_per_tool() {
+        assert_eq!(resume_args(Tool::Claude, "aid-1"), vec!["--resume".to_owned(), "aid-1".to_owned()]);
+        assert_eq!(resume_args(Tool::Copilot, "aid-2"), vec!["--resume".to_owned(), "aid-2".to_owned()]);
+        assert_eq!(resume_args(Tool::Codex, "aid-3"), vec!["resume".to_owned(), "aid-3".to_owned()]);
+    }
 }

--- a/src-tauri/src/plugins/ai/mod.rs
+++ b/src-tauri/src/plugins/ai/mod.rs
@@ -47,7 +47,7 @@ pub trait AiPlugin: Plugin {
     /// Restart-time AI-session-id policy for this tool.
     fn restart_ai_session_policy(&self) -> RestartAiSessionPolicy;
 
-    /// Whether restore-time `--resume` should verify transcript/session-state first.
+    /// Whether restore-time resume invocation should verify transcript/session-state first.
     fn resume_requires_preflight(&self) -> bool;
 
     /// Structured-command args to resume the AI session id for this tool.
@@ -191,8 +191,8 @@ pub fn restart_ai_session_policy(tool: Tool) -> RestartAiSessionPolicy {
 }
 
 /// Resume preflight policy:
-/// - Claude: require transcript/session state path to exist before `--resume`.
-/// - Copilot: allow `--resume` unconditionally (CLI creates missing sessions).
+/// - Claude: require transcript/session-state path to exist before invoking resume args.
+/// - Copilot/Codex: allow resume invocation unconditionally (CLIs create missing sessions).
 #[must_use]
 pub fn resume_requires_preflight(tool: Tool) -> bool {
     plugin_for_tool(tool).resume_requires_preflight()

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -437,7 +437,7 @@ mod tests {
     fn build_registry_registers_builtin_plugins() {
         let reg = build_registry().expect("build_registry must not collide on duplicate ids");
         let ai_ids: Vec<&str> = reg.ai().iter().map(|p| p.id()).collect();
-        assert_eq!(ai_ids, vec!["claude", "copilot"]);
+        assert_eq!(ai_ids, vec!["claude", "copilot", "codex"]);
         let custom_process_ids: Vec<&str> = reg.custom_processes().iter().map(|p| p.id()).collect();
         assert_eq!(custom_process_ids, vec!["vscode", "explorer"]);
         let widget_ids: Vec<&str> = reg.widgets().iter().map(|w| w.id()).collect();

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -239,6 +239,9 @@ mod tests {
         fn resume_requires_preflight(&self) -> bool {
             false
         }
+        fn resume_args(&self, ai_session_id: &str) -> Vec<String> {
+            vec!["--resume".to_owned(), ai_session_id.to_owned()]
+        }
         fn ai_session_transcript_path(&self, home: &std::path::Path, _worktree_path: &std::path::Path, ai_session_id: &str) -> std::path::PathBuf {
             home.join(ai_session_id)
         }

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -160,9 +160,9 @@ impl MetricsRegistry {
                     run_copilot_watcher(session_id, otel_path, emit, emit_turn, discover, running_for_thread);
                 })
             }
-            crate::plugins::ai::MetricsWatcherKind::Codex { home, cwd } => {
+            crate::plugins::ai::MetricsWatcherKind::Codex { codex_home, cwd } => {
                 thread::Builder::new().name(format!("arborist-metrics-{}", session_id)).spawn(move || {
-                    run_codex_watcher(session_id, home, cwd, spawn_instant, emit, emit_turn, discover, running_for_thread);
+                    run_codex_watcher(session_id, codex_home, cwd, spawn_instant, emit, emit_turn, discover, running_for_thread);
                 })
             }
         };
@@ -1069,7 +1069,7 @@ impl CodexState {
 }
 
 /// Extract token-count fields from a `TokenCount` event's `info` payload. Returns a tuple of `(input, output, total, model_context_window)`, each
-/// `Some` when present and well-typed. The `?` short-circuits at the missing-`info` boundary; nested fields use the same chain.
+/// `Some` when present and well-typed. Missing `payload.info` returns an all-`None` tuple early.
 fn extract_codex_token_count(payload: &serde_json::Value) -> (Option<u64>, Option<u64>, Option<u64>, Option<u64>) {
     let Some(info) = payload.get("payload").and_then(|p| p.get("info")) else {
         return (None, None, None, None);
@@ -1087,7 +1087,7 @@ fn ingest_codex_rollout_line(line: &[u8], state: &mut CodexState) {
     // Lines in the rollout are `{"timestamp":"...","type":"<variant>","payload":{...}}`.
     // We care about:
     // - type = "event_msg" with payload.type = "TokenCount" → token usage
-    // - type = "turn_context" → model name and context_window
+    // - type = "turn_context" → model name
     let Ok(outer) = serde_json::from_slice::<CodexRolloutLine>(line) else {
         return;
     };
@@ -1173,7 +1173,7 @@ fn parse_codex_turn_duration_ms(line: &[u8]) -> Option<Option<u64>> {
 #[allow(clippy::too_many_arguments)]
 fn run_codex_watcher(
     session_id: SessionId,
-    home: PathBuf,
+    codex_home: PathBuf,
     cwd: PathBuf,
     spawn_instant: SystemTime,
     emit: MetricsCb,
@@ -1181,7 +1181,6 @@ fn run_codex_watcher(
     discover: AiSessionDiscoveryCb,
     running: Arc<AtomicBool>,
 ) {
-    let codex_home = std::env::var("CODEX_HOME").map(PathBuf::from).unwrap_or_else(|_| home.join(".codex"));
     let sessions_dir = codex_home.join("sessions");
 
     let mut last_emitted: Option<SessionMetricsEvent> = None;

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -1020,7 +1020,11 @@ fn codex_rollout_cwd_matches(path: &Path, expected_cwd: &Path) -> bool {
 /// Extract the thread_id from the first line of a Codex rollout file.
 fn codex_rollout_thread_id(path: &Path) -> Option<String> {
     let payload = read_codex_session_meta(path)?;
-    payload.get("id").and_then(|v| v.as_str()).map(|s| s.to_owned())
+    payload
+        .get("thread_id")
+        .or_else(|| payload.get("id"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_owned())
 }
 
 /// Codex rollout watcher state accumulated from `TokenCount` and `TurnContext` events.
@@ -2300,6 +2304,19 @@ mod tests {
         drop(f);
 
         assert_eq!(codex_rollout_thread_id(&path), None);
+    }
+
+    #[test]
+    fn codex_rollout_thread_id_accepts_thread_id_field() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("rollout-2025-05-18T10-00-00-abcdef12-3456-7890-abcd-ef1234567890.jsonl");
+        let first_line = r#"{"timestamp":"2025-05-18T10:00:00Z","type":"session_meta","payload":{"thread_id":"thread-from-thread-id","cwd":"/tmp"}}"#;
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "{}", first_line).unwrap();
+        drop(f);
+
+        assert_eq!(codex_rollout_thread_id(&path), Some("thread-from-thread-id".to_owned()));
     }
 
     #[test]

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -1146,8 +1146,13 @@ fn maybe_codex_turn_complete(line: &[u8]) -> bool {
     contains(line, b"\"TurnComplete\"") || contains(line, b"\"task_complete\"") || contains(line, b"\"turn_complete\"")
 }
 
-/// Extract the turn duration from a Codex `TurnComplete` event. Returns the duration in ms if present.
-fn parse_codex_turn_duration_ms(line: &[u8]) -> Option<u64> {
+/// Parse a Codex turn-complete event.
+///
+/// Returns:
+/// - `Some(Some(duration_ms))` for a real turn-complete event with duration
+/// - `Some(None)` for a real turn-complete event without duration
+/// - `None` when the line is not a turn-complete event (or cannot be parsed)
+fn parse_codex_turn_duration_ms(line: &[u8]) -> Option<Option<u64>> {
     let outer: CodexRolloutLine = serde_json::from_slice(line).ok()?;
     if outer.r#type != "event_msg" {
         return None;
@@ -1157,8 +1162,8 @@ fn parse_codex_turn_duration_ms(line: &[u8]) -> Option<u64> {
     if event_type != "TurnComplete" && event_type != "task_complete" && event_type != "turn_complete" {
         return None;
     }
-    let inner = payload.get("payload")?;
-    inner.get("duration_ms").and_then(|v| v.as_u64())
+    let duration_ms = payload.get("payload").and_then(|inner| inner.get("duration_ms")).and_then(|v| v.as_u64());
+    Some(duration_ms)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1210,8 +1215,9 @@ fn run_codex_watcher(
                         tracked_len = tail_lines(path, tracked_len, len, |line| {
                             ingest_codex_rollout_line(line, &mut state);
                             if maybe_codex_turn_complete(line) {
-                                let duration = parse_codex_turn_duration_ms(line);
-                                emit_turn(session_id, duration);
+                                if let Some(duration) = parse_codex_turn_duration_ms(line) {
+                                    emit_turn(session_id, duration);
+                                }
                             }
                         });
                     }
@@ -2229,12 +2235,19 @@ mod tests {
     #[test]
     fn parse_codex_turn_complete_duration() {
         let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"TurnComplete","payload":{"turn_id":"t1","last_agent_message":"done","duration_ms":4200}}}"#;
-        assert_eq!(parse_codex_turn_duration_ms(line), Some(4200));
+        assert_eq!(parse_codex_turn_duration_ms(line), Some(Some(4200)));
     }
 
     #[test]
     fn parse_codex_turn_complete_no_duration() {
         let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"TurnComplete","payload":{"turn_id":"t1","last_agent_message":"done"}}}"#;
+        assert_eq!(parse_codex_turn_duration_ms(line), Some(None));
+    }
+
+    #[test]
+    fn parse_codex_turn_complete_ignores_non_turn_complete_event_with_keyword() {
+        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"TokenCount","payload":{"note":"TurnComplete"}}}"#;
+        assert!(maybe_codex_turn_complete(line));
         assert_eq!(parse_codex_turn_duration_ms(line), None);
     }
 

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -62,7 +62,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde::Deserialize;
 
@@ -71,6 +71,8 @@ use crate::types::{SessionId, SessionMetricsEvent, Tool};
 
 /// Polling cadence for the watcher. Trade-off: smaller is more responsive, larger is fewer syscalls.
 pub const POLL_INTERVAL: Duration = Duration::from_millis(2000);
+const CODEX_DISCOVERY_SCAN_MIN_INTERVAL: Duration = POLL_INTERVAL;
+const CODEX_DISCOVERY_SCAN_MAX_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Callback the watcher invokes for each new (changed) snapshot. Production wires this into `app.emit("session://metrics", payload)`; tests pass a
 /// channel sender.
@@ -915,8 +917,8 @@ fn normalize_path_components(path: &Path) -> Vec<String> {
 }
 
 /// Discover the newest rollout JSONL under `sessions_dir` (including date-nested subdirs) whose first-line `SessionMeta.cwd` matches `cwd` and whose
-/// mtime is >= `after`. Returns the full path when found. Called only on initial discovery — `run_codex_watcher` then sticks with the tracked file for
-/// the rest of the session, so the directory walk + first-line parse cost is paid at most once per session, not per poll.
+/// mtime is >= `after`. Returns the full path when found. Called during rollout discovery while no file is bound; `run_codex_watcher` applies a
+/// backoff between misses to avoid re-scanning the entire Codex sessions tree on every poll tick.
 fn newest_codex_rollout(sessions_dir: &Path, cwd: &Path, after: SystemTime) -> Option<PathBuf> {
     let slack = Duration::from_secs(5);
     let cutoff = after.checked_sub(slack).unwrap_or(after);
@@ -1187,13 +1189,13 @@ fn run_codex_watcher(
     let mut tracked_path: Option<PathBuf> = None;
     let mut tracked_len: u64 = 0;
     let mut state = CodexState::default();
+    let mut discovery_due = Instant::now();
+    let mut discovery_interval = CODEX_DISCOVERY_SCAN_MIN_INTERVAL;
 
     while running.load(Ordering::SeqCst) {
-        // Discovery runs only while no rollout file is bound. Codex shares one `~/.codex/sessions/` tree across every project and nests files in
-        // dated subdirs, so the scan is O(N) over the user's whole rollout history — keeping it off the steady-state path matters. Once bound, the
-        // tracked file persists for the lifetime of the PTY; if Codex ever begins rotating rollouts mid-session, treat the resulting metrics freeze
-        // as the signal to revisit this.
-        if tracked_path.is_none() {
+        // Discovery runs only while no rollout file is bound and uses a backoff between misses. Codex shares one `~/.codex/sessions/` tree across
+        // projects and nests files in dated subdirs, so a cold scan is O(N) over rollout history.
+        if tracked_path.is_none() && Instant::now() >= discovery_due {
             if let Some(c) = newest_codex_rollout(&sessions_dir, &cwd, spawn_instant) {
                 if let Some(thread_id) = codex_rollout_thread_id(&c) {
                     discover(session_id, thread_id);
@@ -1201,6 +1203,10 @@ fn run_codex_watcher(
                 tracked_path = Some(c);
                 tracked_len = 0;
                 state = CodexState::default();
+                discovery_interval = CODEX_DISCOVERY_SCAN_MIN_INTERVAL;
+            } else {
+                discovery_interval = codex_next_discovery_interval(discovery_interval, CODEX_DISCOVERY_SCAN_MAX_INTERVAL);
+                discovery_due = Instant::now().checked_add(discovery_interval).unwrap_or_else(Instant::now);
             }
         }
 
@@ -1231,6 +1237,8 @@ fn run_codex_watcher(
                     tracked_len = 0;
                     state = CodexState::default();
                     last_emitted = None;
+                    discovery_interval = CODEX_DISCOVERY_SCAN_MIN_INTERVAL;
+                    discovery_due = Instant::now();
                 }
             }
         }
@@ -1245,6 +1253,10 @@ fn run_codex_watcher(
 
         thread::sleep(POLL_INTERVAL);
     }
+}
+
+fn codex_next_discovery_interval(current: Duration, max: Duration) -> Duration {
+    current.saturating_mul(2).min(max)
 }
 
 #[cfg(test)]
@@ -2351,5 +2363,14 @@ mod tests {
         let after = SystemTime::now() - Duration::from_secs(60);
         let result = newest_codex_rollout(&sessions_dir, Path::new(cwd), after);
         assert_eq!(result, Some(good_path));
+    }
+
+    #[test]
+    fn codex_next_discovery_interval_doubles_until_cap() {
+        let next = codex_next_discovery_interval(CODEX_DISCOVERY_SCAN_MIN_INTERVAL, CODEX_DISCOVERY_SCAN_MAX_INTERVAL);
+        assert_eq!(next, CODEX_DISCOVERY_SCAN_MIN_INTERVAL.saturating_mul(2));
+
+        let capped = codex_next_discovery_interval(CODEX_DISCOVERY_SCAN_MAX_INTERVAL, CODEX_DISCOVERY_SCAN_MAX_INTERVAL);
+        assert_eq!(capped, CODEX_DISCOVERY_SCAN_MAX_INTERVAL);
     }
 }

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -956,7 +956,7 @@ fn newest_codex_rollout(sessions_dir: &Path, cwd: &Path, after: SystemTime) -> O
     // Scan top-level `sessions/` directory.
     scan_dir(sessions_dir, &expected_norm, cutoff, &mut best);
 
-    // Also scan date-nested subdirs (YYYY/MM/DD pattern).
+    // Also scan three-level nested subdirs (Codex commonly uses YYYY/MM/DD).
     if let Ok(years) = std::fs::read_dir(sessions_dir) {
         for year_entry in years.flatten() {
             let year_path = year_entry.path();
@@ -1070,8 +1070,9 @@ impl CodexState {
     }
 }
 
-/// Extract token-count fields from a `TokenCount` event's `info` payload. Returns a tuple of `(input, output, total, model_context_window)`, each
-/// `Some` when present and well-typed. Missing `payload.info` returns an all-`None` tuple early.
+/// Extract token-count fields from a `TokenCount` event's nested `payload.payload.info` object. Returns a tuple of
+/// `(input, output, total, model_context_window)`, each `Some` when present and well-typed. Missing nested info returns
+/// an all-`None` tuple early.
 fn extract_codex_token_count(payload: &serde_json::Value) -> (Option<u64>, Option<u64>, Option<u64>, Option<u64>) {
     let Some(info) = payload.get("payload").and_then(|p| p.get("info")) else {
         return (None, None, None, None);

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -160,6 +160,11 @@ impl MetricsRegistry {
                     run_copilot_watcher(session_id, otel_path, emit, emit_turn, discover, running_for_thread);
                 })
             }
+            crate::plugins::ai::MetricsWatcherKind::Codex { home, cwd } => {
+                thread::Builder::new().name(format!("arborist-metrics-{}", session_id)).spawn(move || {
+                    run_codex_watcher(session_id, home, cwd, spawn_instant, emit, emit_turn, discover, running_for_thread);
+                })
+            }
         };
         match join {
             Ok(handle) => {
@@ -875,8 +880,337 @@ fn maybe_invoke_agent_span(line: &[u8]) -> bool {
     contains(line, b"\"invoke_agent\"")
 }
 
-// --------------------------------------------------------------------------- Tests
+// --------------------------------------------------------------------------- Codex rollout worker
 // ---------------------------------------------------------------------------
+
+/// Discover the newest rollout JSONL under `<home>/.codex/sessions/` (and date-nested subdirs) whose first-line `SessionMeta.cwd` matches `cwd` and
+/// whose mtime is >= `after`. Returns the full path when found.
+fn newest_codex_rollout(sessions_dir: &Path, cwd: &Path, after: SystemTime) -> Option<PathBuf> {
+    let slack = Duration::from_secs(5);
+    let cutoff = after.checked_sub(slack).unwrap_or(after);
+    let mut best: Option<(SystemTime, PathBuf)> = None;
+
+    // Helper to check a single directory for rollout files.
+    fn scan_dir(dir: &Path, cwd: &Path, cutoff: SystemTime, best: &mut Option<(SystemTime, PathBuf)>) {
+        let Ok(entries) = std::fs::read_dir(dir) else { return };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let fname = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if !fname.starts_with("rollout-") {
+                continue;
+            }
+            let Ok(meta) = entry.metadata() else { continue };
+            let Ok(mtime) = meta.modified() else { continue };
+            if mtime < cutoff {
+                continue;
+            }
+            // Check if the cwd matches by reading the first line (SessionMeta).
+            if !codex_rollout_cwd_matches(&path, cwd) {
+                continue;
+            }
+            match best {
+                Some((bt, _)) if *bt >= mtime => {}
+                _ => *best = Some((mtime, path)),
+            }
+        }
+    }
+
+    // Scan top-level `sessions/` directory.
+    scan_dir(sessions_dir, cwd, cutoff, &mut best);
+
+    // Also scan date-nested subdirs (YYYY/MM/DD pattern).
+    if let Ok(years) = std::fs::read_dir(sessions_dir) {
+        for year_entry in years.flatten() {
+            let year_path = year_entry.path();
+            if !year_path.is_dir() {
+                continue;
+            }
+            if let Ok(months) = std::fs::read_dir(&year_path) {
+                for month_entry in months.flatten() {
+                    let month_path = month_entry.path();
+                    if !month_path.is_dir() {
+                        continue;
+                    }
+                    if let Ok(days) = std::fs::read_dir(&month_path) {
+                        for day_entry in days.flatten() {
+                            let day_path = day_entry.path();
+                            if day_path.is_dir() {
+                                scan_dir(&day_path, cwd, cutoff, &mut best);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    best.map(|(_, p)| p)
+}
+
+/// Check if a rollout file's SessionMeta `cwd` field matches the expected cwd. Reads only the first line and does a case-insensitive path comparison
+/// on Windows.
+fn codex_rollout_cwd_matches(path: &Path, expected_cwd: &Path) -> bool {
+    use std::io::{BufRead, BufReader};
+    let Ok(f) = std::fs::File::open(path) else { return false };
+    let mut reader = BufReader::new(f);
+    let mut first_line = String::new();
+    if reader.read_line(&mut first_line).is_err() || first_line.is_empty() {
+        return false;
+    }
+    // The rollout format wraps in a RolloutLine: {"timestamp":"...","type":"session_meta","payload":{...}}
+    // We need to extract the `cwd` from the SessionMeta payload.
+    #[derive(Deserialize)]
+    struct RolloutLine {
+        #[serde(default)]
+        r#type: String,
+        #[serde(default)]
+        payload: Option<serde_json::Value>,
+    }
+    let Ok(line) = serde_json::from_str::<RolloutLine>(&first_line) else {
+        return false;
+    };
+    if line.r#type != "session_meta" {
+        return false;
+    }
+    let Some(payload) = line.payload else { return false };
+    let Some(cwd_str) = payload.get("cwd").and_then(|v| v.as_str()) else {
+        return false;
+    };
+    let rollout_cwd = Path::new(cwd_str);
+    // Case-insensitive comparison on Windows.
+    if cfg!(windows) {
+        rollout_cwd.to_string_lossy().to_ascii_lowercase() == expected_cwd.to_string_lossy().to_ascii_lowercase()
+    } else {
+        rollout_cwd == expected_cwd
+    }
+}
+
+/// Extract the thread_id from the first line of a Codex rollout file.
+fn codex_rollout_thread_id(path: &Path) -> Option<String> {
+    use std::io::{BufRead, BufReader};
+    let f = std::fs::File::open(path).ok()?;
+    let mut reader = BufReader::new(f);
+    let mut first_line = String::new();
+    reader.read_line(&mut first_line).ok()?;
+    #[derive(Deserialize)]
+    struct RolloutLine {
+        #[serde(default)]
+        payload: Option<serde_json::Value>,
+    }
+    let line: RolloutLine = serde_json::from_str(&first_line).ok()?;
+    let payload = line.payload?;
+    payload.get("id").and_then(|v| v.as_str()).map(|s| s.to_owned())
+}
+
+/// Codex rollout watcher state accumulated from `TokenCount` and `TurnContext` events.
+#[derive(Debug, Default)]
+struct CodexState {
+    /// Cumulative input tokens (from total_token_usage.input_tokens).
+    sum_input: u64,
+    /// Cumulative output tokens (from total_token_usage.output_tokens).
+    sum_output: u64,
+    /// Model context window limit (from model_context_window or TurnStarted).
+    context_window: Option<u64>,
+    /// Current tokens used in context (total_tokens from total_token_usage).
+    context_tokens_used: Option<u64>,
+    /// Most recent model name (from TurnContext).
+    last_model: Option<String>,
+    /// True once at least one TokenCount event has been ingested.
+    seen: bool,
+}
+
+impl CodexState {
+    fn has_any(&self) -> bool {
+        self.seen
+    }
+
+    fn snapshot(&self, session_id: SessionId) -> SessionMetricsEvent {
+        let used = self.context_tokens_used;
+        let pct = match (used, self.context_window) {
+            (Some(u), Some(lim)) if lim > 0 => Some(u.saturating_mul(100).checked_div(lim).map(|raw| raw.min(100) as u8).unwrap_or(0)),
+            _ => None,
+        };
+        SessionMetricsEvent {
+            session_id,
+            model: self.last_model.clone(),
+            context_used_pct: pct,
+            context_tokens_used: used,
+            context_tokens_limit: self.context_window,
+            input_tokens: Some(self.sum_input),
+            output_tokens: Some(self.sum_output),
+            observed_at: now_unix_seconds(),
+        }
+    }
+}
+
+/// Ingest a single Codex rollout JSONL line. Extracts token usage from `EventMsg::TokenCount` and model from `TurnContext`.
+fn ingest_codex_rollout_line(line: &[u8], state: &mut CodexState) {
+    // Lines in the rollout are `{"timestamp":"...","type":"<variant>","payload":{...}}`.
+    // We care about:
+    // - type = "event_msg" with payload.type = "TokenCount" → token usage
+    // - type = "turn_context" → model name and context_window
+    #[derive(Deserialize)]
+    struct RolloutLine {
+        #[serde(default)]
+        r#type: String,
+        #[serde(default)]
+        payload: Option<serde_json::Value>,
+    }
+    let Ok(outer) = serde_json::from_slice::<RolloutLine>(line) else {
+        return;
+    };
+
+    match outer.r#type.as_str() {
+        "event_msg" => {
+            let Some(payload) = outer.payload else { return };
+            // EventMsg is tagged: {"type":"TokenCount","payload":{...}}
+            let Some(event_type) = payload.get("type").and_then(|v| v.as_str()) else {
+                return;
+            };
+            match event_type {
+                "TokenCount" => {
+                    // payload.payload.info.total_token_usage / model_context_window
+                    let inner_payload = payload.get("payload");
+                    let info = inner_payload.and_then(|p| p.get("info"));
+                    if let Some(info) = info {
+                        if let Some(total) = info.get("total_token_usage") {
+                            if let Some(input) = total.get("input_tokens").and_then(|v| v.as_u64()) {
+                                state.sum_input = input;
+                            }
+                            if let Some(output) = total.get("output_tokens").and_then(|v| v.as_u64()) {
+                                state.sum_output = output;
+                            }
+                            if let Some(total_tokens) = total.get("total_tokens").and_then(|v| v.as_u64()) {
+                                state.context_tokens_used = Some(total_tokens);
+                            }
+                        }
+                        if let Some(mcw) = info.get("model_context_window").and_then(|v| v.as_u64()) {
+                            if mcw > 0 {
+                                state.context_window = Some(mcw);
+                            }
+                        }
+                    }
+                    state.seen = true;
+                }
+                "TurnStarted" => {
+                    // payload.payload.model_context_window
+                    let inner_payload = payload.get("payload");
+                    if let Some(mcw) = inner_payload.and_then(|p| p.get("model_context_window")).and_then(|v| v.as_u64()) {
+                        if mcw > 0 {
+                            state.context_window = Some(mcw);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        "turn_context" => {
+            let Some(payload) = outer.payload else { return };
+            if let Some(model) = payload.get("model").and_then(|v| v.as_str()) {
+                if !model.is_empty() {
+                    state.last_model = Some(model.to_owned());
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Cheap byte-level prefilter to detect a `TurnComplete` event in a Codex rollout line. Avoids full JSON parse on the majority of lines.
+fn maybe_codex_turn_complete(line: &[u8]) -> bool {
+    fn contains(hay: &[u8], needle: &[u8]) -> bool {
+        hay.len() >= needle.len() && hay.windows(needle.len()).any(|w| w == needle)
+    }
+    contains(line, b"\"TurnComplete\"") || contains(line, b"\"task_complete\"") || contains(line, b"\"turn_complete\"")
+}
+
+/// Extract the turn duration from a Codex `TurnComplete` event. Returns the duration in ms if present.
+fn parse_codex_turn_duration_ms(line: &[u8]) -> Option<u64> {
+    #[derive(Deserialize)]
+    struct RolloutLine {
+        #[serde(default)]
+        r#type: String,
+        #[serde(default)]
+        payload: Option<serde_json::Value>,
+    }
+    let outer: RolloutLine = serde_json::from_slice(line).ok()?;
+    if outer.r#type != "event_msg" {
+        return None;
+    }
+    let payload = outer.payload?;
+    let event_type = payload.get("type").and_then(|v| v.as_str())?;
+    if event_type != "TurnComplete" && event_type != "task_complete" && event_type != "turn_complete" {
+        return None;
+    }
+    let inner = payload.get("payload")?;
+    inner.get("duration_ms").and_then(|v| v.as_u64())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_codex_watcher(
+    session_id: SessionId,
+    home: PathBuf,
+    cwd: PathBuf,
+    spawn_instant: SystemTime,
+    emit: MetricsCb,
+    emit_turn: TurnCb,
+    discover: AiSessionDiscoveryCb,
+    running: Arc<AtomicBool>,
+) {
+    let codex_home = std::env::var("CODEX_HOME").map(PathBuf::from).unwrap_or_else(|_| home.join(".codex"));
+    let sessions_dir = codex_home.join("sessions");
+
+    let mut last_emitted: Option<SessionMetricsEvent> = None;
+    let mut tracked_path: Option<PathBuf> = None;
+    let mut tracked_len: u64 = 0;
+    let mut state = CodexState::default();
+
+    while running.load(Ordering::SeqCst) {
+        let candidate = newest_codex_rollout(&sessions_dir, &cwd, spawn_instant);
+        if let Some(c) = candidate {
+            if tracked_path.as_ref() != Some(&c) {
+                tracked_path = Some(c.clone());
+                tracked_len = 0;
+                state = CodexState::default();
+                // Discover thread_id from the first line.
+                if let Some(thread_id) = codex_rollout_thread_id(&c) {
+                    discover(session_id, thread_id);
+                }
+            }
+
+            if let Ok(meta) = std::fs::metadata(&c) {
+                let len = meta.len();
+                if len < tracked_len {
+                    tracked_len = 0;
+                    state = CodexState::default();
+                    last_emitted = None;
+                }
+                if len > tracked_len {
+                    tracked_len = tail_lines(&c, tracked_len, len, |line| {
+                        ingest_codex_rollout_line(line, &mut state);
+                        if maybe_codex_turn_complete(line) {
+                            let duration = parse_codex_turn_duration_ms(line);
+                            emit_turn(session_id, duration);
+                        }
+                    });
+                }
+            }
+        }
+
+        if state.has_any() {
+            let snapshot = state.snapshot(session_id);
+            if !last_emitted.as_ref().is_some_and(|prev| prev.same_payload_as(&snapshot)) {
+                emit(snapshot.clone());
+                last_emitted = Some(snapshot);
+            }
+        }
+
+        thread::sleep(POLL_INTERVAL);
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -1803,5 +2137,118 @@ mod tests {
             sibling_exited.load(Ordering::SeqCst),
             "stop_all_and_join must join extra_joins, not just the primary thread"
         );
+    }
+
+    // ----- Codex rollout watcher utilities ---------------------------------
+
+    #[test]
+    fn ingest_codex_token_count_event() {
+        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"TokenCount","payload":{"info":{"total_token_usage":{"input_tokens":1500,"cached_input_tokens":200,"output_tokens":800,"reasoning_output_tokens":100,"total_tokens":2600},"last_token_usage":{"input_tokens":500,"cached_input_tokens":100,"output_tokens":300,"reasoning_output_tokens":50,"total_tokens":950},"model_context_window":128000}}}}"#;
+        let mut state = CodexState::default();
+        ingest_codex_rollout_line(line, &mut state);
+        assert!(state.seen);
+        assert_eq!(state.sum_input, 1500);
+        assert_eq!(state.sum_output, 800);
+        assert_eq!(state.context_tokens_used, Some(2600));
+        assert_eq!(state.context_window, Some(128000));
+    }
+
+    #[test]
+    fn ingest_codex_turn_context_extracts_model() {
+        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"turn_context","payload":{"model":"o3-mini","cwd":"/tmp","approval_policy":"OnRequest","sandbox_policy":{"type":"workspace-write"},"summary":"auto"}}"#;
+        let mut state = CodexState::default();
+        ingest_codex_rollout_line(line, &mut state);
+        assert_eq!(state.last_model.as_deref(), Some("o3-mini"));
+    }
+
+    #[test]
+    fn ingest_codex_turn_started_extracts_context_window() {
+        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"TurnStarted","payload":{"turn_id":"abc","model_context_window":200000}}}"#;
+        let mut state = CodexState::default();
+        ingest_codex_rollout_line(line, &mut state);
+        assert_eq!(state.context_window, Some(200000));
+    }
+
+    #[test]
+    fn codex_state_snapshot_computes_pct() {
+        let state = CodexState {
+            sum_input: 1000,
+            sum_output: 500,
+            context_window: Some(100_000),
+            context_tokens_used: Some(50_000),
+            last_model: Some("o3".into()),
+            seen: true,
+        };
+        let snap = state.snapshot(SessionId::new());
+        assert_eq!(snap.context_used_pct, Some(50));
+        assert_eq!(snap.model.as_deref(), Some("o3"));
+        assert_eq!(snap.input_tokens, Some(1000));
+        assert_eq!(snap.output_tokens, Some(500));
+    }
+
+    #[test]
+    fn parse_codex_turn_complete_duration() {
+        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"TurnComplete","payload":{"turn_id":"t1","last_agent_message":"done","duration_ms":4200}}}"#;
+        assert_eq!(parse_codex_turn_duration_ms(line), Some(4200));
+    }
+
+    #[test]
+    fn parse_codex_turn_complete_no_duration() {
+        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"TurnComplete","payload":{"turn_id":"t1","last_agent_message":"done"}}}"#;
+        assert_eq!(parse_codex_turn_duration_ms(line), None);
+    }
+
+    #[test]
+    fn codex_rollout_cwd_match_and_thread_id_extraction() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("rollout-2025-05-18T10-00-00-abcdef12-3456-7890-abcd-ef1234567890.jsonl");
+        let cwd = if cfg!(windows) { r"C:\repos\myproject" } else { "/repos/myproject" };
+        let first_line = format!(
+            r#"{{"timestamp":"2025-05-18T10:00:00Z","type":"session_meta","payload":{{"id":"thread-uuid-123","cwd":"{}","originator":"codex","cli_version":"1.0","source":"cli"}}}}"#,
+            cwd.replace('\\', "\\\\")
+        );
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "{}", first_line).unwrap();
+        drop(f);
+
+        assert!(codex_rollout_cwd_matches(&path, Path::new(cwd)));
+        assert!(!codex_rollout_cwd_matches(&path, Path::new("/other/path")));
+        assert_eq!(codex_rollout_thread_id(&path), Some("thread-uuid-123".to_string()));
+    }
+
+    #[test]
+    fn newest_codex_rollout_picks_matching_cwd() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions_dir = dir.path().join("sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+
+        let cwd = if cfg!(windows) { r"C:\repos\target" } else { "/repos/target" };
+        let other_cwd = if cfg!(windows) { r"C:\repos\other" } else { "/repos/other" };
+
+        // Create a rollout matching our cwd.
+        let good_path = sessions_dir.join("rollout-2025-05-18T10-00-00-11111111-1111-1111-1111-111111111111.jsonl");
+        let good_line = format!(
+            r#"{{"timestamp":"2025-05-18T10:00:00Z","type":"session_meta","payload":{{"id":"good-thread","cwd":"{}","originator":"codex","cli_version":"1.0","source":"cli"}}}}"#,
+            cwd.replace('\\', "\\\\")
+        );
+        let mut f = std::fs::File::create(&good_path).unwrap();
+        writeln!(f, "{}", good_line).unwrap();
+        drop(f);
+
+        // Create a rollout with a different cwd.
+        let bad_path = sessions_dir.join("rollout-2025-05-18T10-00-01-22222222-2222-2222-2222-222222222222.jsonl");
+        let bad_line = format!(
+            r#"{{"timestamp":"2025-05-18T10:00:01Z","type":"session_meta","payload":{{"id":"bad-thread","cwd":"{}","originator":"codex","cli_version":"1.0","source":"cli"}}}}"#,
+            other_cwd.replace('\\', "\\\\")
+        );
+        let mut f = std::fs::File::create(&bad_path).unwrap();
+        writeln!(f, "{}", bad_line).unwrap();
+        drop(f);
+
+        let after = SystemTime::now() - Duration::from_secs(60);
+        let result = newest_codex_rollout(&sessions_dir, Path::new(cwd), after);
+        assert_eq!(result, Some(good_path));
     }
 }

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -882,16 +882,49 @@ fn maybe_invoke_agent_span(line: &[u8]) -> bool {
 
 // --------------------------------------------------------------------------- Codex rollout worker
 // ---------------------------------------------------------------------------
+//
+// Codex persists every session as a JSONL "rollout" file under `<CODEX_HOME>/sessions/` (default `~/.codex/sessions/`), optionally nested in
+// `YYYY/MM/DD/` date subdirectories. Filenames follow `rollout-<TIMESTAMP>-<UUID>.jsonl`. The first line is a `session_meta` envelope carrying the
+// thread id and `cwd`; subsequent lines are `event_msg` / `turn_context` envelopes. The watcher discovers the file by matching `cwd` and spawn
+// instant, fires the AI-session discovery callback with the thread id, then tails `TokenCount` (cumulative usage) and `TurnComplete` (turn duration)
+// events. Only token usage and model name are surfaced to the sidebar — feature parity with the Claude and Copilot watchers.
+
+/// Outer envelope for every rollout JSONL line: `{"timestamp": "...", "type": "...", "payload": {...}}`. Inner-payload shape varies by `type` and is
+/// inspected as `serde_json::Value` to avoid a deserialize match per variant.
+#[derive(Deserialize)]
+struct CodexRolloutLine {
+    #[serde(default)]
+    r#type: String,
+    #[serde(default)]
+    payload: Option<serde_json::Value>,
+}
+
+/// Normalize a path for cross-platform comparison. On Windows, slashes are unified and components are lowercased so `C:\Repos\X` matches
+/// `c:/repos/x/`. On Unix, the input is returned unchanged via `to_path_buf()` equivalence — callers compare with `==` on `Path`.
+fn normalize_path_components(path: &Path) -> Vec<String> {
+    path.components()
+        .map(|c| {
+            let raw = c.as_os_str().to_string_lossy();
+            if cfg!(windows) {
+                raw.replace('/', "\\").to_ascii_lowercase()
+            } else {
+                raw.into_owned()
+            }
+        })
+        .collect()
+}
 
 /// Discover the newest rollout JSONL under `<home>/.codex/sessions/` (and date-nested subdirs) whose first-line `SessionMeta.cwd` matches `cwd` and
-/// whose mtime is >= `after`. Returns the full path when found.
+/// whose mtime is >= `after`. Returns the full path when found. Called only on initial discovery — `run_codex_watcher` then sticks with the tracked
+/// file for the rest of the session, so the directory walk + first-line parse cost is paid at most once per session, not per poll.
 fn newest_codex_rollout(sessions_dir: &Path, cwd: &Path, after: SystemTime) -> Option<PathBuf> {
     let slack = Duration::from_secs(5);
     let cutoff = after.checked_sub(slack).unwrap_or(after);
+    let expected_norm = normalize_path_components(cwd);
     let mut best: Option<(SystemTime, PathBuf)> = None;
 
     // Helper to check a single directory for rollout files.
-    fn scan_dir(dir: &Path, cwd: &Path, cutoff: SystemTime, best: &mut Option<(SystemTime, PathBuf)>) {
+    fn scan_dir(dir: &Path, expected_norm: &[String], cutoff: SystemTime, best: &mut Option<(SystemTime, PathBuf)>) {
         let Ok(entries) = std::fs::read_dir(dir) else { return };
         for entry in entries.flatten() {
             let path = entry.path();
@@ -908,7 +941,7 @@ fn newest_codex_rollout(sessions_dir: &Path, cwd: &Path, after: SystemTime) -> O
                 continue;
             }
             // Check if the cwd matches by reading the first line (SessionMeta).
-            if !codex_rollout_cwd_matches(&path, cwd) {
+            if !codex_rollout_cwd_matches_norm(&path, expected_norm) {
                 continue;
             }
             match best {
@@ -919,7 +952,7 @@ fn newest_codex_rollout(sessions_dir: &Path, cwd: &Path, after: SystemTime) -> O
     }
 
     // Scan top-level `sessions/` directory.
-    scan_dir(sessions_dir, cwd, cutoff, &mut best);
+    scan_dir(sessions_dir, &expected_norm, cutoff, &mut best);
 
     // Also scan date-nested subdirs (YYYY/MM/DD pattern).
     if let Ok(years) = std::fs::read_dir(sessions_dir) {
@@ -938,7 +971,7 @@ fn newest_codex_rollout(sessions_dir: &Path, cwd: &Path, after: SystemTime) -> O
                         for day_entry in days.flatten() {
                             let day_path = day_entry.path();
                             if day_path.is_dir() {
-                                scan_dir(&day_path, cwd, cutoff, &mut best);
+                                scan_dir(&day_path, &expected_norm, cutoff, &mut best);
                             }
                         }
                     }
@@ -950,58 +983,43 @@ fn newest_codex_rollout(sessions_dir: &Path, cwd: &Path, after: SystemTime) -> O
     best.map(|(_, p)| p)
 }
 
-/// Check if a rollout file's SessionMeta `cwd` field matches the expected cwd. Reads only the first line and does a case-insensitive path comparison
-/// on Windows.
-fn codex_rollout_cwd_matches(path: &Path, expected_cwd: &Path) -> bool {
-    use std::io::{BufRead, BufReader};
-    let Ok(f) = std::fs::File::open(path) else { return false };
-    let mut reader = BufReader::new(f);
-    let mut first_line = String::new();
-    if reader.read_line(&mut first_line).is_err() || first_line.is_empty() {
-        return false;
-    }
-    // The rollout format wraps in a RolloutLine: {"timestamp":"...","type":"session_meta","payload":{...}}
-    // We need to extract the `cwd` from the SessionMeta payload.
-    #[derive(Deserialize)]
-    struct RolloutLine {
-        #[serde(default)]
-        r#type: String,
-        #[serde(default)]
-        payload: Option<serde_json::Value>,
-    }
-    let Ok(line) = serde_json::from_str::<RolloutLine>(&first_line) else {
-        return false;
-    };
-    if line.r#type != "session_meta" {
-        return false;
-    }
-    let Some(payload) = line.payload else { return false };
-    let Some(cwd_str) = payload.get("cwd").and_then(|v| v.as_str()) else {
-        return false;
-    };
-    let rollout_cwd = Path::new(cwd_str);
-    // Case-insensitive comparison on Windows.
-    if cfg!(windows) {
-        rollout_cwd.to_string_lossy().to_ascii_lowercase() == expected_cwd.to_string_lossy().to_ascii_lowercase()
-    } else {
-        rollout_cwd == expected_cwd
-    }
-}
-
-/// Extract the thread_id from the first line of a Codex rollout file.
-fn codex_rollout_thread_id(path: &Path) -> Option<String> {
+/// Read a rollout file's first line and decode it as a `session_meta` `CodexRolloutLine`. Returns the payload (a JSON object) when the line is
+/// well-formed and the type matches; `None` otherwise. Shared by `codex_rollout_cwd_matches_norm` and `codex_rollout_thread_id`.
+fn read_codex_session_meta(path: &Path) -> Option<serde_json::Value> {
     use std::io::{BufRead, BufReader};
     let f = std::fs::File::open(path).ok()?;
     let mut reader = BufReader::new(f);
     let mut first_line = String::new();
     reader.read_line(&mut first_line).ok()?;
-    #[derive(Deserialize)]
-    struct RolloutLine {
-        #[serde(default)]
-        payload: Option<serde_json::Value>,
+    if first_line.is_empty() {
+        return None;
     }
-    let line: RolloutLine = serde_json::from_str(&first_line).ok()?;
-    let payload = line.payload?;
+    let line: CodexRolloutLine = serde_json::from_str(&first_line).ok()?;
+    if line.r#type != "session_meta" {
+        return None;
+    }
+    line.payload
+}
+
+/// Check whether a rollout file's `SessionMeta.cwd` matches the (already-normalized) expected cwd.
+fn codex_rollout_cwd_matches_norm(path: &Path, expected_norm: &[String]) -> bool {
+    let Some(payload) = read_codex_session_meta(path) else { return false };
+    let Some(cwd_str) = payload.get("cwd").and_then(|v| v.as_str()) else {
+        return false;
+    };
+    normalize_path_components(Path::new(cwd_str)) == expected_norm
+}
+
+/// Test-only wrapper around [`codex_rollout_cwd_matches_norm`] that normalizes `expected_cwd` per call. Kept for the unit tests that don't want to
+/// pre-normalize.
+#[cfg(test)]
+fn codex_rollout_cwd_matches(path: &Path, expected_cwd: &Path) -> bool {
+    codex_rollout_cwd_matches_norm(path, &normalize_path_components(expected_cwd))
+}
+
+/// Extract the thread_id from the first line of a Codex rollout file.
+fn codex_rollout_thread_id(path: &Path) -> Option<String> {
+    let payload = read_codex_session_meta(path)?;
     payload.get("id").and_then(|v| v.as_str()).map(|s| s.to_owned())
 }
 
@@ -1030,7 +1048,7 @@ impl CodexState {
     fn snapshot(&self, session_id: SessionId) -> SessionMetricsEvent {
         let used = self.context_tokens_used;
         let pct = match (used, self.context_window) {
-            (Some(u), Some(lim)) if lim > 0 => Some(u.saturating_mul(100).checked_div(lim).map(|raw| raw.min(100) as u8).unwrap_or(0)),
+            (Some(u), Some(lim)) if lim > 0 => Some(((u as u128 * 100 / lim as u128).min(100)) as u8),
             _ => None,
         };
         SessionMetricsEvent {
@@ -1046,20 +1064,27 @@ impl CodexState {
     }
 }
 
+/// Extract token-count fields from a `TokenCount` event's `info` payload. Returns a tuple of `(input, output, total, model_context_window)`, each
+/// `Some` when present and well-typed. The `?` short-circuits at the missing-`info` boundary; nested fields use the same chain.
+fn extract_codex_token_count(payload: &serde_json::Value) -> (Option<u64>, Option<u64>, Option<u64>, Option<u64>) {
+    let Some(info) = payload.get("payload").and_then(|p| p.get("info")) else {
+        return (None, None, None, None);
+    };
+    let total = info.get("total_token_usage");
+    let input = total.and_then(|t| t.get("input_tokens")).and_then(|v| v.as_u64());
+    let output = total.and_then(|t| t.get("output_tokens")).and_then(|v| v.as_u64());
+    let total_tokens = total.and_then(|t| t.get("total_tokens")).and_then(|v| v.as_u64());
+    let mcw = info.get("model_context_window").and_then(|v| v.as_u64()).filter(|&v| v > 0);
+    (input, output, total_tokens, mcw)
+}
+
 /// Ingest a single Codex rollout JSONL line. Extracts token usage from `EventMsg::TokenCount` and model from `TurnContext`.
 fn ingest_codex_rollout_line(line: &[u8], state: &mut CodexState) {
     // Lines in the rollout are `{"timestamp":"...","type":"<variant>","payload":{...}}`.
     // We care about:
     // - type = "event_msg" with payload.type = "TokenCount" → token usage
     // - type = "turn_context" → model name and context_window
-    #[derive(Deserialize)]
-    struct RolloutLine {
-        #[serde(default)]
-        r#type: String,
-        #[serde(default)]
-        payload: Option<serde_json::Value>,
-    }
-    let Ok(outer) = serde_json::from_slice::<RolloutLine>(line) else {
+    let Ok(outer) = serde_json::from_slice::<CodexRolloutLine>(line) else {
         return;
     };
 
@@ -1072,36 +1097,30 @@ fn ingest_codex_rollout_line(line: &[u8], state: &mut CodexState) {
             };
             match event_type {
                 "TokenCount" => {
-                    // payload.payload.info.total_token_usage / model_context_window
-                    let inner_payload = payload.get("payload");
-                    let info = inner_payload.and_then(|p| p.get("info"));
-                    if let Some(info) = info {
-                        if let Some(total) = info.get("total_token_usage") {
-                            if let Some(input) = total.get("input_tokens").and_then(|v| v.as_u64()) {
-                                state.sum_input = input;
-                            }
-                            if let Some(output) = total.get("output_tokens").and_then(|v| v.as_u64()) {
-                                state.sum_output = output;
-                            }
-                            if let Some(total_tokens) = total.get("total_tokens").and_then(|v| v.as_u64()) {
-                                state.context_tokens_used = Some(total_tokens);
-                            }
-                        }
-                        if let Some(mcw) = info.get("model_context_window").and_then(|v| v.as_u64()) {
-                            if mcw > 0 {
-                                state.context_window = Some(mcw);
-                            }
-                        }
+                    let (input, output, total, mcw) = extract_codex_token_count(&payload);
+                    if let Some(v) = input {
+                        state.sum_input = v;
+                    }
+                    if let Some(v) = output {
+                        state.sum_output = v;
+                    }
+                    if let Some(v) = total {
+                        state.context_tokens_used = Some(v);
+                    }
+                    if let Some(v) = mcw {
+                        state.context_window = Some(v);
                     }
                     state.seen = true;
                 }
                 "TurnStarted" => {
                     // payload.payload.model_context_window
-                    let inner_payload = payload.get("payload");
-                    if let Some(mcw) = inner_payload.and_then(|p| p.get("model_context_window")).and_then(|v| v.as_u64()) {
-                        if mcw > 0 {
-                            state.context_window = Some(mcw);
-                        }
+                    if let Some(mcw) = payload
+                        .get("payload")
+                        .and_then(|p| p.get("model_context_window"))
+                        .and_then(|v| v.as_u64())
+                        .filter(|&v| v > 0)
+                    {
+                        state.context_window = Some(mcw);
                     }
                 }
                 _ => {}
@@ -1129,14 +1148,7 @@ fn maybe_codex_turn_complete(line: &[u8]) -> bool {
 
 /// Extract the turn duration from a Codex `TurnComplete` event. Returns the duration in ms if present.
 fn parse_codex_turn_duration_ms(line: &[u8]) -> Option<u64> {
-    #[derive(Deserialize)]
-    struct RolloutLine {
-        #[serde(default)]
-        r#type: String,
-        #[serde(default)]
-        payload: Option<serde_json::Value>,
-    }
-    let outer: RolloutLine = serde_json::from_slice(line).ok()?;
+    let outer: CodexRolloutLine = serde_json::from_slice(line).ok()?;
     if outer.r#type != "event_msg" {
         return None;
     }
@@ -1169,33 +1181,47 @@ fn run_codex_watcher(
     let mut state = CodexState::default();
 
     while running.load(Ordering::SeqCst) {
-        let candidate = newest_codex_rollout(&sessions_dir, &cwd, spawn_instant);
-        if let Some(c) = candidate {
-            if tracked_path.as_ref() != Some(&c) {
-                tracked_path = Some(c.clone());
-                tracked_len = 0;
-                state = CodexState::default();
-                // Discover thread_id from the first line.
+        // Discovery runs only while no rollout file is bound. Codex shares one `~/.codex/sessions/` tree across every project and nests files in
+        // dated subdirs, so the scan is O(N) over the user's whole rollout history — keeping it off the steady-state path matters. Once bound, the
+        // tracked file persists for the lifetime of the PTY; if Codex ever begins rotating rollouts mid-session, treat the resulting metrics freeze
+        // as the signal to revisit this.
+        if tracked_path.is_none() {
+            if let Some(c) = newest_codex_rollout(&sessions_dir, &cwd, spawn_instant) {
                 if let Some(thread_id) = codex_rollout_thread_id(&c) {
                     discover(session_id, thread_id);
                 }
+                tracked_path = Some(c);
+                tracked_len = 0;
+                state = CodexState::default();
             }
+        }
 
-            if let Ok(meta) = std::fs::metadata(&c) {
-                let len = meta.len();
-                if len < tracked_len {
+        if let Some(path) = tracked_path.as_ref() {
+            match std::fs::metadata(path) {
+                Ok(meta) => {
+                    let len = meta.len();
+                    // Defensive: handle truncation/rotation. Same shape as the Claude and Copilot watchers.
+                    if len < tracked_len {
+                        tracked_len = 0;
+                        state = CodexState::default();
+                        last_emitted = None;
+                    }
+                    if len > tracked_len {
+                        tracked_len = tail_lines(path, tracked_len, len, |line| {
+                            ingest_codex_rollout_line(line, &mut state);
+                            if maybe_codex_turn_complete(line) {
+                                let duration = parse_codex_turn_duration_ms(line);
+                                emit_turn(session_id, duration);
+                            }
+                        });
+                    }
+                }
+                Err(_) => {
+                    // File disappeared (deletion, rename) — drop tracking so the next tick rediscovers.
+                    tracked_path = None;
                     tracked_len = 0;
                     state = CodexState::default();
                     last_emitted = None;
-                }
-                if len > tracked_len {
-                    tracked_len = tail_lines(&c, tracked_len, len, |line| {
-                        ingest_codex_rollout_line(line, &mut state);
-                        if maybe_codex_turn_complete(line) {
-                            let duration = parse_codex_turn_duration_ms(line);
-                            emit_turn(session_id, duration);
-                        }
-                    });
                 }
             }
         }
@@ -2187,6 +2213,20 @@ mod tests {
     }
 
     #[test]
+    fn codex_state_snapshot_pct_handles_large_values_without_overflow() {
+        let state = CodexState {
+            sum_input: 1000,
+            sum_output: 500,
+            context_window: Some(10_000_000_000_000_000_000),
+            context_tokens_used: Some(5_000_000_000_000_000_000),
+            last_model: Some("o3".into()),
+            seen: true,
+        };
+        let snap = state.snapshot(SessionId::new());
+        assert_eq!(snap.context_used_pct, Some(50));
+    }
+
+    #[test]
     fn parse_codex_turn_complete_duration() {
         let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"TurnComplete","payload":{"turn_id":"t1","last_agent_message":"done","duration_ms":4200}}}"#;
         assert_eq!(parse_codex_turn_duration_ms(line), Some(4200));
@@ -2215,6 +2255,38 @@ mod tests {
         assert!(codex_rollout_cwd_matches(&path, Path::new(cwd)));
         assert!(!codex_rollout_cwd_matches(&path, Path::new("/other/path")));
         assert_eq!(codex_rollout_thread_id(&path), Some("thread-uuid-123".to_string()));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn codex_rollout_cwd_match_normalizes_windows_separators_and_trailing_separator() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("rollout-2025-05-18T10-00-00-abcdef12-3456-7890-abcd-ef1234567890.jsonl");
+        let expected_cwd = r"C:\repos\myproject";
+        let rollout_cwd = format!("{}/", expected_cwd.replace('\\', "/"));
+        let first_line = format!(
+            r#"{{"timestamp":"2025-05-18T10:00:00Z","type":"session_meta","payload":{{"id":"thread-uuid-123","cwd":"{}","originator":"codex","cli_version":"1.0","source":"cli"}}}}"#,
+            rollout_cwd
+        );
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "{}", first_line).unwrap();
+        drop(f);
+
+        assert!(codex_rollout_cwd_matches(&path, Path::new(expected_cwd)));
+    }
+
+    #[test]
+    fn codex_rollout_thread_id_requires_session_meta() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("rollout-2025-05-18T10-00-00-abcdef12-3456-7890-abcd-ef1234567890.jsonl");
+        let first_line = r#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"id":"not-a-thread-id"}}"#;
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "{}", first_line).unwrap();
+        drop(f);
+
+        assert_eq!(codex_rollout_thread_id(&path), None);
     }
 
     #[test]

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -899,8 +899,8 @@ struct CodexRolloutLine {
     payload: Option<serde_json::Value>,
 }
 
-/// Normalize a path for cross-platform comparison. On Windows, slashes are unified and components are lowercased so `C:\Repos\X` matches
-/// `c:/repos/x/`. On Unix, the input is returned unchanged via `to_path_buf()` equivalence — callers compare with `==` on `Path`.
+/// Normalize a path into comparable components for cross-platform matching. On Windows, slashes are unified and each component is lowercased so
+/// `C:\Repos\X` and `c:/repos/x/` normalize to the same `Vec<String>`. On Unix, components are preserved as-is.
 fn normalize_path_components(path: &Path) -> Vec<String> {
     path.components()
         .map(|c| {
@@ -914,9 +914,9 @@ fn normalize_path_components(path: &Path) -> Vec<String> {
         .collect()
 }
 
-/// Discover the newest rollout JSONL under `<home>/.codex/sessions/` (and date-nested subdirs) whose first-line `SessionMeta.cwd` matches `cwd` and
-/// whose mtime is >= `after`. Returns the full path when found. Called only on initial discovery — `run_codex_watcher` then sticks with the tracked
-/// file for the rest of the session, so the directory walk + first-line parse cost is paid at most once per session, not per poll.
+/// Discover the newest rollout JSONL under `sessions_dir` (including date-nested subdirs) whose first-line `SessionMeta.cwd` matches `cwd` and whose
+/// mtime is >= `after`. Returns the full path when found. Called only on initial discovery — `run_codex_watcher` then sticks with the tracked file for
+/// the rest of the session, so the directory walk + first-line parse cost is paid at most once per session, not per poll.
 fn newest_codex_rollout(sessions_dir: &Path, cwd: &Path, after: SystemTime) -> Option<PathBuf> {
     let slack = Duration::from_secs(5);
     let cutoff = after.checked_sub(slack).unwrap_or(after);

--- a/src/components/WorktreeDashboard.test.tsx
+++ b/src/components/WorktreeDashboard.test.tsx
@@ -128,6 +128,18 @@ describe('WorktreeDashboard', () => {
     await act(async () => {});
   });
 
+  it('shows a launch error when sessionCreate rejects (e.g., codex missing)', async () => {
+    useWorktreeTabStore.setState({ tabs: [tab()] });
+    bridgeMock.sessionCreate.mockRejectedValueOnce(new Error('spawn_command failed: program not found'));
+
+    renderDashboard();
+    await act(async () => {});
+
+    fireEvent.click(screen.getByTestId('worktree-dashboard-launch-codex'));
+
+    expect(await screen.findByTestId('worktree-dashboard-launch-error')).toHaveTextContent(/launch codex failed/i);
+  });
+
   it('mounts widgets in registry order', () => {
     useWorktreeTabStore.setState({ tabs: [tab()] });
     const registry = createRegistry();

--- a/src/components/WorktreeDashboard.test.tsx
+++ b/src/components/WorktreeDashboard.test.tsx
@@ -140,6 +140,36 @@ describe('WorktreeDashboard', () => {
     expect(await screen.findByTestId('worktree-dashboard-launch-error')).toHaveTextContent(/launch codex failed/i);
   });
 
+  it('does not update state after unmount when launch rejects', async () => {
+    useWorktreeTabStore.setState({ tabs: [tab()] });
+    let rejectLaunch: ((reason?: unknown) => void) | undefined;
+    bridgeMock.sessionCreate.mockImplementationOnce(
+      () =>
+        new Promise<never>((_, reject) => {
+          rejectLaunch = reject;
+        }),
+    );
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { unmount } = renderDashboard();
+    await act(async () => {});
+
+    fireEvent.click(screen.getByTestId('worktree-dashboard-launch-codex'));
+    unmount();
+
+    await act(async () => {
+      rejectLaunch?.(new Error('spawn_command failed: program not found'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const hasUnmountedWarning = consoleErrorSpy.mock.calls.some((call) =>
+      call.some((arg) => typeof arg === 'string' && arg.includes("Can't perform a React state update on an unmounted component")),
+    );
+    expect(hasUnmountedWarning).toBe(false);
+    consoleErrorSpy.mockRestore();
+  });
+
   it('mounts widgets in registry order', () => {
     useWorktreeTabStore.setState({ tabs: [tab()] });
     const registry = createRegistry();

--- a/src/components/WorktreeDashboard.tsx
+++ b/src/components/WorktreeDashboard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { ToolIcon } from './ToolIcon';
 import { measureInitialPtyDimensions } from '@/hooks/use-terminal';
@@ -18,6 +18,13 @@ export function WorktreeDashboard({ tabId }: WorktreeDashboardProps): JSX.Elemen
   const sessionActions = useSessionActions();
   const registry = useRegistry();
   const pluginSettings = useConfigStore((s) => s.config.pluginSettings);
+  const isMountedRef = useRef<boolean>(false);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
   const aiPlugins = useMemo(
     () => registry.ai().filter((plugin) => pluginEnabled(pluginSettings, 'ai', plugin.id, plugin.defaultEnabled ?? true)),
     [registry, pluginSettings],
@@ -47,6 +54,7 @@ export function WorktreeDashboard({ tabId }: WorktreeDashboardProps): JSX.Elemen
       .catch((err: unknown) => {
         const message = formatError(err);
         console.warn(`[WorktreeDashboard] sessionCreate(${tool}) failed: ${message}`);
+        if (!isMountedRef.current) return;
         setLaunchError(`Launch ${pluginName} failed: ${message}`);
       });
   };

--- a/src/components/WorktreeDashboard.tsx
+++ b/src/components/WorktreeDashboard.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import { ToolIcon } from './ToolIcon';
 import { measureInitialPtyDimensions } from '@/hooks/use-terminal';
@@ -23,6 +23,7 @@ export function WorktreeDashboard({ tabId }: WorktreeDashboardProps): JSX.Elemen
     [registry, pluginSettings],
   );
   const aiIconDataUris = useConfigStore((s) => s.config.aiLaunchCommands.iconDataUris);
+  const [launchError, setLaunchError] = useState<string | null>(null);
   const widgets = useMemo(
     () => registry.widgets().filter((widget) => pluginEnabled(pluginSettings, 'dashboardWidget', widget.id, widget.defaultEnabled ?? true)),
     [registry, pluginSettings],
@@ -33,6 +34,8 @@ export function WorktreeDashboard({ tabId }: WorktreeDashboardProps): JSX.Elemen
   }
 
   const launch = (tool: Tool): void => {
+    setLaunchError(null);
+    const pluginName = aiPlugins.find((plugin) => plugin.id === tool)?.displayName ?? tool;
     const dims = measureInitialPtyDimensions();
     void sessionActions
       .create({
@@ -42,7 +45,9 @@ export function WorktreeDashboard({ tabId }: WorktreeDashboardProps): JSX.Elemen
         rows: dims.rows,
       })
       .catch((err: unknown) => {
-        console.warn(`[WorktreeDashboard] sessionCreate(${tool}) failed: ${formatError(err)}`);
+        const message = formatError(err);
+        console.warn(`[WorktreeDashboard] sessionCreate(${tool}) failed: ${message}`);
+        setLaunchError(`Launch ${pluginName} failed: ${message}`);
       });
   };
 
@@ -78,6 +83,15 @@ export function WorktreeDashboard({ tabId }: WorktreeDashboardProps): JSX.Elemen
           );
         })}
       </div>
+      {launchError && (
+        <p
+          role="alert"
+          data-testid="worktree-dashboard-launch-error"
+          className="rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/70 dark:bg-red-950/40 dark:text-red-300"
+        >
+          {launchError}
+        </p>
+      )}
 
       <div className="grid gap-4 md:grid-cols-2">
         {widgets.map((widget) => (

--- a/src/components/WorktreeTabContextMenu.test.tsx
+++ b/src/components/WorktreeTabContextMenu.test.tsx
@@ -125,6 +125,7 @@ describe('WorktreeTabContextMenu', () => {
     fireEvent.click(screen.getByTestId('worktree-tab-context-menu-launch-codex'));
 
     expect(await screen.findByTestId('worktree-tab-context-menu-error')).toHaveTextContent(/launch codex failed/i);
+    expect(screen.getByTestId('worktree-tab-context-menu')).not.toContainElement(screen.getByTestId('worktree-tab-context-menu-error'));
     expect(onClose).not.toHaveBeenCalled();
   });
 
@@ -225,7 +226,7 @@ describe('WorktreeTabContextMenu', () => {
       renderWithPlugins(<WorktreeTabContextMenu tabId={TAB_ID} anchor={{ x: 390, y: 230 }} onClose={noop} />);
 
       const menu = screen.getByTestId('worktree-tab-context-menu');
-      expect(menu).toHaveStyle({ left: '176px', top: '4px' });
+      expect(menu.parentElement).toHaveStyle({ left: '176px', top: '4px' });
     } finally {
       Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalInnerHeight });
       Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalInnerWidth });

--- a/src/components/WorktreeTabContextMenu.test.tsx
+++ b/src/components/WorktreeTabContextMenu.test.tsx
@@ -129,6 +129,19 @@ describe('WorktreeTabContextMenu', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  it('does not treat error-region clicks as outside clicks', async () => {
+    bridgeMock.sessionCreate.mockRejectedValueOnce(new Error('spawn_command failed: program not found'));
+    const onClose = vi.fn();
+    renderWithPlugins(<WorktreeTabContextMenu tabId={TAB_ID} anchor={{ x: 10, y: 10 }} onClose={onClose} />);
+
+    fireEvent.click(screen.getByTestId('worktree-tab-context-menu-launch-codex'));
+    const error = await screen.findByTestId('worktree-tab-context-menu-error');
+    fireEvent.mouseDown(error);
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByTestId('worktree-tab-context-menu')).toBeInTheDocument();
+  });
+
   it('does not update state after unmount when Launch Codex rejects', async () => {
     let rejectLaunch: ((reason?: unknown) => void) | undefined;
     bridgeMock.sessionCreate.mockImplementationOnce(

--- a/src/components/WorktreeTabContextMenu.test.tsx
+++ b/src/components/WorktreeTabContextMenu.test.tsx
@@ -117,6 +117,17 @@ describe('WorktreeTabContextMenu', () => {
     await act(async () => {});
   });
 
+  it('keeps menu open and surfaces an error when Launch Codex fails', async () => {
+    bridgeMock.sessionCreate.mockRejectedValueOnce(new Error('spawn_command failed: program not found'));
+    const onClose = vi.fn();
+    renderWithPlugins(<WorktreeTabContextMenu tabId={TAB_ID} anchor={{ x: 10, y: 10 }} onClose={onClose} />);
+
+    fireEvent.click(screen.getByTestId('worktree-tab-context-menu-launch-codex'));
+
+    expect(await screen.findByTestId('worktree-tab-context-menu-error')).toHaveTextContent(/launch codex failed/i);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it('returns null when the tab has been removed from the store', () => {
     const onClose = vi.fn();
     useWorktreeTabStore.setState({ tabs: [], activeId: null, isHydrated: true });

--- a/src/components/WorktreeTabContextMenu.test.tsx
+++ b/src/components/WorktreeTabContextMenu.test.tsx
@@ -128,6 +128,33 @@ describe('WorktreeTabContextMenu', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  it('does not update state after unmount when Launch Codex rejects', async () => {
+    let rejectLaunch: ((reason?: unknown) => void) | undefined;
+    bridgeMock.sessionCreate.mockImplementationOnce(
+      () =>
+        new Promise<never>((_, reject) => {
+          rejectLaunch = reject;
+        }),
+    );
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { unmount } = renderWithPlugins(<WorktreeTabContextMenu tabId={TAB_ID} anchor={{ x: 10, y: 10 }} onClose={noop} />);
+
+    fireEvent.click(screen.getByTestId('worktree-tab-context-menu-launch-codex'));
+    unmount();
+
+    await act(async () => {
+      rejectLaunch?.(new Error('spawn_command failed: program not found'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const hasUnmountedWarning = consoleErrorSpy.mock.calls.some((call) =>
+      call.some((arg) => typeof arg === 'string' && arg.includes("Can't perform a React state update on an unmounted component")),
+    );
+    expect(hasUnmountedWarning).toBe(false);
+    consoleErrorSpy.mockRestore();
+  });
+
   it('returns null when the tab has been removed from the store', () => {
     const onClose = vi.fn();
     useWorktreeTabStore.setState({ tabs: [], activeId: null, isHydrated: true });

--- a/src/components/WorktreeTabContextMenu.tsx
+++ b/src/components/WorktreeTabContextMenu.tsx
@@ -61,10 +61,18 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
 
   const menuRef = useRef<HTMLDivElement | null>(null);
   const itemRefs = useRef<Map<Item, HTMLButtonElement | null>>(new Map());
+  const isMountedRef = useRef<boolean>(false);
 
   const firstMenuItem = itemOrder[0] ?? 'settings';
   const [focusedItem, setFocusedItem] = useState<Item>(firstMenuItem);
   const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   const closeMenu = useCallback((): void => {
     onClose();
@@ -141,11 +149,13 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
         rows: dims.rows,
       })
       .then(() => {
+        if (!isMountedRef.current) return;
         closeMenu();
       })
       .catch((err: unknown) => {
         const message = formatError(err);
         console.warn(`[WorktreeTabContextMenu] session_create(${tool}) failed: ${message}`);
+        if (!isMountedRef.current) return;
         setActionError(`Launch ${pluginName} failed: ${message}`);
       });
   };
@@ -261,7 +271,7 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
             </button>
           );
         })}
-      <div role="separator" className="my-1 border-t border-slate-200 dark:border-slate-700" />
+      <hr className="my-1 border-t border-slate-200 dark:border-slate-700" />
       <button
         ref={setItemRef('settings')}
         type="button"
@@ -273,7 +283,7 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
       >
         <span>Custom Processes…</span>
       </button>
-      <div role="separator" className="my-1 border-t border-slate-200 dark:border-slate-700" />
+      <hr className="my-1 border-t border-slate-200 dark:border-slate-700" />
       <button
         ref={setItemRef('close')}
         type="button"
@@ -287,7 +297,7 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
       </button>
       {actionError && (
         <>
-          <div role="separator" className="my-1 border-t border-slate-200 dark:border-slate-700" />
+          <hr className="my-1 border-t border-slate-200 dark:border-slate-700" />
           <p role="alert" data-testid="worktree-tab-context-menu-error" className="px-3 py-1.5 text-xs text-red-700 dark:text-red-300">
             {actionError}
           </p>

--- a/src/components/WorktreeTabContextMenu.tsx
+++ b/src/components/WorktreeTabContextMenu.tsx
@@ -59,6 +59,7 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
     return items;
   }, [aiPlugins, customProcesses]);
 
+  const menuWrapperRef = useRef<HTMLDivElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
   const itemRefs = useRef<Map<Item, HTMLButtonElement | null>>(new Map());
   const isMountedRef = useRef<boolean>(false);
@@ -92,7 +93,7 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
     function onPointerDown(e: MouseEvent): void {
       const target = e.target as Node | null;
       if (!target) return;
-      if (menuRef.current?.contains(target)) return;
+      if (menuWrapperRef.current?.contains(target)) return;
       closeMenu();
     }
     document.addEventListener('mousedown', onPointerDown);
@@ -198,7 +199,7 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
   };
 
   const menu = (
-    <div style={{ position: 'fixed', left: position.left, top: position.top, minWidth: 200, zIndex: 60 }}>
+    <div ref={menuWrapperRef} style={{ position: 'fixed', left: position.left, top: position.top, minWidth: 200, zIndex: 60 }}>
       <div
         ref={menuRef}
         role="menu"

--- a/src/components/WorktreeTabContextMenu.tsx
+++ b/src/components/WorktreeTabContextMenu.tsx
@@ -198,110 +198,112 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
   };
 
   const menu = (
-    <div
-      ref={menuRef}
-      role="menu"
-      aria-label={`Worktree tab actions for ${tab.name}`}
-      data-testid="worktree-tab-context-menu"
-      style={{ position: 'fixed', left: position.left, top: position.top, minWidth: 200, zIndex: 60 }}
-      className="rounded-md border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-800"
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') {
-          e.preventDefault();
-          closeMenu();
-          return;
-        }
-        if (e.key === 'Tab') {
-          e.preventDefault();
-          closeMenu();
-          return;
-        }
-        switch (e.key) {
-          case 'ArrowDown':
+    <div style={{ position: 'fixed', left: position.left, top: position.top, minWidth: 200, zIndex: 60 }}>
+      <div
+        ref={menuRef}
+        role="menu"
+        aria-label={`Worktree tab actions for ${tab.name}`}
+        data-testid="worktree-tab-context-menu"
+        className="rounded-md border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-800"
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
             e.preventDefault();
-            moveFocus(1);
-            break;
-          case 'ArrowUp':
+            closeMenu();
+            return;
+          }
+          if (e.key === 'Tab') {
             e.preventDefault();
-            moveFocus(-1);
-            break;
-          case 'Enter':
-          case ' ':
-            e.preventDefault();
-            activateItem(itemForElement(e.target) ?? focusedItem);
-            break;
-          default:
-        }
-      }}
-    >
-      {aiPlugins.map((plugin) => {
-        const key: Item = `launch:${plugin.id}` as Item;
-        return (
-          <button
-            key={plugin.id}
-            ref={setItemRef(key)}
-            type="button"
-            role="menuitem"
-            data-testid={`worktree-tab-context-menu-launch-${plugin.id}`}
-            onClick={() => handleLaunch(plugin.id)}
-            onMouseEnter={() => setFocusedItem(key)}
-            className={itemBase}
-          >
-            <MenuIcon src={aiIconDataUris[plugin.id] ?? undefined} fallback="🤖" />
-            <span>{`Launch ${plugin.displayName}`}</span>
-          </button>
-        );
-      })}
-      {customProcesses.length > 0 &&
-        customProcesses.map((def) => {
-          const key: Item = `cp:${def.id}` as Item;
+            closeMenu();
+            return;
+          }
+          switch (e.key) {
+            case 'ArrowDown':
+              e.preventDefault();
+              moveFocus(1);
+              break;
+            case 'ArrowUp':
+              e.preventDefault();
+              moveFocus(-1);
+              break;
+            case 'Enter':
+            case ' ':
+              e.preventDefault();
+              activateItem(itemForElement(e.target) ?? focusedItem);
+              break;
+            default:
+          }
+        }}
+      >
+        {aiPlugins.map((plugin) => {
+          const key: Item = `launch:${plugin.id}` as Item;
           return (
             <button
-              key={def.id}
+              key={plugin.id}
               ref={setItemRef(key)}
               type="button"
               role="menuitem"
-              data-testid={`worktree-tab-context-menu-cp-${def.id}`}
-              onClick={() => handleCustomProcess(def.id)}
+              data-testid={`worktree-tab-context-menu-launch-${plugin.id}`}
+              onClick={() => handleLaunch(plugin.id)}
               onMouseEnter={() => setFocusedItem(key)}
               className={itemBase}
             >
-              <MenuIcon src={def.iconDataUri} fallback="⌗" />
-              <span>{def.name}</span>
+              <MenuIcon src={aiIconDataUris[plugin.id] ?? undefined} fallback="🤖" />
+              <span>{`Launch ${plugin.displayName}`}</span>
             </button>
           );
         })}
-      <hr className="my-1 border-t border-slate-200 dark:border-slate-700" />
-      <button
-        ref={setItemRef('settings')}
-        type="button"
-        role="menuitem"
-        data-testid="worktree-tab-context-menu-settings"
-        onClick={handleSettings}
-        onMouseEnter={() => setFocusedItem('settings')}
-        className={itemBase}
-      >
-        <span>Custom Processes…</span>
-      </button>
-      <hr className="my-1 border-t border-slate-200 dark:border-slate-700" />
-      <button
-        ref={setItemRef('close')}
-        type="button"
-        role="menuitem"
-        data-testid="worktree-tab-context-menu-close"
-        onClick={handleClose}
-        onMouseEnter={() => setFocusedItem('close')}
-        className={itemBase}
-      >
-        <span>Close worktree tab</span>
-      </button>
+        {customProcesses.length > 0 &&
+          customProcesses.map((def) => {
+            const key: Item = `cp:${def.id}` as Item;
+            return (
+              <button
+                key={def.id}
+                ref={setItemRef(key)}
+                type="button"
+                role="menuitem"
+                data-testid={`worktree-tab-context-menu-cp-${def.id}`}
+                onClick={() => handleCustomProcess(def.id)}
+                onMouseEnter={() => setFocusedItem(key)}
+                className={itemBase}
+              >
+                <MenuIcon src={def.iconDataUri} fallback="⌗" />
+                <span>{def.name}</span>
+              </button>
+            );
+          })}
+        <hr className="my-1 border-t border-slate-200 dark:border-slate-700" />
+        <button
+          ref={setItemRef('settings')}
+          type="button"
+          role="menuitem"
+          data-testid="worktree-tab-context-menu-settings"
+          onClick={handleSettings}
+          onMouseEnter={() => setFocusedItem('settings')}
+          className={itemBase}
+        >
+          <span>Custom Processes…</span>
+        </button>
+        <hr className="my-1 border-t border-slate-200 dark:border-slate-700" />
+        <button
+          ref={setItemRef('close')}
+          type="button"
+          role="menuitem"
+          data-testid="worktree-tab-context-menu-close"
+          onClick={handleClose}
+          onMouseEnter={() => setFocusedItem('close')}
+          className={itemBase}
+        >
+          <span>Close worktree tab</span>
+        </button>
+      </div>
       {actionError && (
-        <>
-          <hr className="my-1 border-t border-slate-200 dark:border-slate-700" />
-          <p role="alert" data-testid="worktree-tab-context-menu-error" className="px-3 py-1.5 text-xs text-red-700 dark:text-red-300">
-            {actionError}
-          </p>
-        </>
+        <p
+          role="alert"
+          data-testid="worktree-tab-context-menu-error"
+          className="mt-1 rounded border border-red-300 bg-red-50 px-3 py-1.5 text-xs text-red-700 shadow dark:border-red-900/70 dark:bg-red-950/40 dark:text-red-300"
+        >
+          {actionError}
+        </p>
       )}
     </div>
   );

--- a/src/components/WorktreeTabContextMenu.tsx
+++ b/src/components/WorktreeTabContextMenu.tsx
@@ -64,6 +64,7 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
 
   const firstMenuItem = itemOrder[0] ?? 'settings';
   const [focusedItem, setFocusedItem] = useState<Item>(firstMenuItem);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   const closeMenu = useCallback((): void => {
     onClose();
@@ -129,6 +130,8 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
       closeMenu();
       return;
     }
+    setActionError(null);
+    const pluginName = aiPlugins.find((plugin) => plugin.id === tool)?.displayName ?? tool;
     const dims = measureInitialPtyDimensions();
     void sessionActions
       .create({
@@ -137,10 +140,14 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
         cols: dims.cols,
         rows: dims.rows,
       })
+      .then(() => {
+        closeMenu();
+      })
       .catch((err: unknown) => {
-        console.warn(`[WorktreeTabContextMenu] session_create(${tool}) failed: ${formatError(err)}`);
+        const message = formatError(err);
+        console.warn(`[WorktreeTabContextMenu] session_create(${tool}) failed: ${message}`);
+        setActionError(`Launch ${pluginName} failed: ${message}`);
       });
-    closeMenu();
   };
 
   const handleCustomProcess = (defId: string): void => {
@@ -278,6 +285,14 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
       >
         <span>Close worktree tab</span>
       </button>
+      {actionError && (
+        <>
+          <div role="separator" className="my-1 border-t border-slate-200 dark:border-slate-700" />
+          <p role="alert" data-testid="worktree-tab-context-menu-error" className="px-3 py-1.5 text-xs text-red-700 dark:text-red-300">
+            {actionError}
+          </p>
+        </>
+      )}
     </div>
   );
 

--- a/src/plugins/ai/codex/icon.tsx
+++ b/src/plugins/ai/codex/icon.tsx
@@ -1,5 +1,5 @@
 interface CodexIconProps {
-  className?: string;
+  readonly className?: string;
 }
 
 export function CodexIcon({ className }: CodexIconProps): JSX.Element {

--- a/src/plugins/ai/codex/icon.tsx
+++ b/src/plugins/ai/codex/icon.tsx
@@ -15,9 +15,9 @@ export function CodexIcon({ className }: CodexIconProps): JSX.Element {
       aria-hidden="true"
       className={className}
     >
-      <rect x="3" y="3" width="18" height="18" rx="3" />
-      <path d="M8 12h8" />
-      <path d="M12 8v8" />
+      <path d="M8 7 3 12l5 5" />
+      <path d="m16 7 5 5-5 5" />
+      <path d="m14 5-4 14" />
     </svg>
   );
 }

--- a/src/plugins/ai/codex/icon.tsx
+++ b/src/plugins/ai/codex/icon.tsx
@@ -1,0 +1,23 @@
+interface CodexIconProps {
+  className?: string;
+}
+
+export function CodexIcon({ className }: CodexIconProps): JSX.Element {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={className}
+    >
+      <rect x="3" y="3" width="18" height="18" rx="3" />
+      <path d="M8 12h8" />
+      <path d="M12 8v8" />
+    </svg>
+  );
+}

--- a/src/plugins/ai/codex/index.ts
+++ b/src/plugins/ai/codex/index.ts
@@ -6,6 +6,7 @@ export const CodexAiPlugin: AiPlugin = {
   id: 'codex',
   displayName: 'Codex',
   defaultProgram: 'codex',
+  // Codex reports context metrics via rollout-file tailing; no tooling-specific tooltip caveat needed.
   contextMetricsLimitTooltipSuffix: '',
   settings: [
     {

--- a/src/plugins/ai/codex/index.ts
+++ b/src/plugins/ai/codex/index.ts
@@ -1,0 +1,22 @@
+import { AI_LAUNCH_COMMAND_SETTING, type AiPlugin } from '../../registry';
+
+import { CodexIcon } from './icon';
+
+export const CodexAiPlugin: AiPlugin = {
+  id: 'codex',
+  displayName: 'Codex',
+  defaultProgram: 'codex',
+  contextMetricsLimitTooltipSuffix: '',
+  settings: [
+    {
+      id: AI_LAUNCH_COMMAND_SETTING,
+      kind: 'text',
+      label: 'Launch command',
+      defaultValue: '',
+      placeholder: 'codex',
+      helpText: 'Shell command used when launching Codex sessions. Leave blank to use the plugin default.',
+      spellCheck: false,
+    },
+  ],
+  Icon: CodexIcon,
+};

--- a/src/plugins/builtins.test.ts
+++ b/src/plugins/builtins.test.ts
@@ -14,7 +14,7 @@ const makeDef = (id: string, command: string): CustomProcessDef => ({
 describe('createBuiltinsRegistry()', () => {
   it('registers every built-in plugin kind in deterministic order', () => {
     const registry = createBuiltinsRegistry();
-    expect(registry.ai().map((p) => p.id)).toEqual(['claude', 'copilot']);
+    expect(registry.ai().map((p) => p.id)).toEqual(['claude', 'copilot', 'codex']);
     expect(registry.customProcesses().map((p) => p.id)).toEqual(['vscode', 'explorer']);
     expect(registry.widgets().map((w) => w.id)).toEqual(['git-status', 'ai-usage']);
   });

--- a/src/plugins/builtins.ts
+++ b/src/plugins/builtins.ts
@@ -1,4 +1,5 @@
 import { ClaudeAiPlugin } from './ai/claude';
+import { CodexAiPlugin } from './ai/codex';
 import { CopilotAiPlugin } from './ai/copilot';
 import { ExplorerCustomProcessPlugin, VsCodeCustomProcessPlugin } from './custom-process';
 import { aiUsageWidget } from './dashboard-widget/ai-usage';
@@ -13,6 +14,7 @@ export function createBuiltinsRegistry(): PluginRegistry {
   const registry = createRegistry();
   registry.registerAi(ClaudeAiPlugin);
   registry.registerAi(CopilotAiPlugin);
+  registry.registerAi(CodexAiPlugin);
   registry.registerCustomProcess(VsCodeCustomProcessPlugin);
   registry.registerCustomProcess(ExplorerCustomProcessPlugin);
   registry.registerWidget(gitStatusWidget);

--- a/src/plugins/registry-context.test.tsx
+++ b/src/plugins/registry-context.test.tsx
@@ -41,7 +41,7 @@ describe('PluginRegistryProvider / useRegistry', () => {
         <RegistryProbe />
       </PluginRegistryProvider>,
     );
-    expect(screen.getByTestId('probe')).toHaveTextContent('ai=2;widgets=2');
+    expect(screen.getByTestId('probe')).toHaveTextContent('ai=3;widgets=2');
   });
 
   it('throws a helpful error when useRegistry() is called outside a provider', () => {

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -48,9 +48,9 @@ export interface Plugin {
 
 // MIRROR: src-tauri/src/plugins/ai/mod.rs::AiPlugin
 export interface AiPlugin extends Plugin {
-  /** Stable AI tool discriminator mirrored from persisted `Tool` (`"claude" | "copilot"`). */
+  /** Stable AI tool discriminator mirrored from persisted `Tool` (`"claude" | "copilot" | "codex"`). */
   id: Tool;
-  /** Bare program token (`"claude"`, `"copilot"`). User-overridable via `AppConfig.ai_launch_commands`. */
+  /** Bare program token (`"claude"`, `"copilot"`, `"codex"`). User-overridable via `AppConfig.ai_launch_commands`. */
   defaultProgram: string;
   /** Tooltip copy explaining how this plugin reports context-window limits. */
   contextMetricsLimitTooltipSuffix: string;

--- a/src/types/arborist.test.ts
+++ b/src/types/arborist.test.ts
@@ -224,7 +224,7 @@ describe('arborist type mirrors', () => {
   });
 
   it('Tool wire values are lowercase string literals', () => {
-    expectTypeOf<Session['tool']>().toEqualTypeOf<'claude' | 'copilot'>();
+    expectTypeOf<Session['tool']>().toEqualTypeOf<'claude' | 'copilot' | 'codex'>();
   });
 
   it('SessionStatus wire values are lowercase string literals', () => {

--- a/src/types/arborist.ts
+++ b/src/types/arborist.ts
@@ -28,7 +28,7 @@ export type CustomProcessDefId = string;
 export type WorktreeTabId = string;
 
 // MIRROR: src-tauri/src/types.rs::Tool
-export type Tool = 'claude' | 'copilot';
+export type Tool = 'claude' | 'copilot' | 'codex';
 
 // MIRROR: crates/arborist-types/src/lib.rs::ThemeMode
 export type ThemeMode = 'system' | 'light' | 'dark';

--- a/src/types/arborist.ts
+++ b/src/types/arborist.ts
@@ -1,5 +1,5 @@
 // Hand-written TypeScript mirrors of the Rust types in
-// `src-tauri/src/types.rs`. Each interface carries a `MIRROR:` marker
+// `crates/arborist-types/src/lib.rs`. Each interface carries a `MIRROR:` marker
 // pointing at the canonical Rust definition. **When you change a Rust struct,
 // update the matching interface here in the same commit.**
 //
@@ -8,40 +8,40 @@
 // the same key set. A renamed Rust field will fail the fixture round-trip on
 // the Rust side and the satisfies-check here on the TS side.
 
-// MIRROR: src-tauri/src/types.rs::SessionId
+// MIRROR: crates/arborist-types/src/lib.rs::SessionId
 export type SessionId = string;
 
-// MIRROR: src-tauri/src/types.rs::SubSessionId
+// MIRROR: crates/arborist-types/src/lib.rs::SubSessionId
 // Wire shape is identical to SessionId (a UUID string) but the Rust side
 // uses a distinct newtype so the compiler enforces the boundary.
 export type SubSessionId = string;
 
-// MIRROR: src-tauri/src/types.rs::CustomProcessDefId
+// MIRROR: crates/arborist-types/src/lib.rs::CustomProcessDefId
 // User-facing slug for a `CustomProcessDef`. Matches `[a-zA-Z0-9_-]+` and
 // is unique within `AppConfig.customProcesses`. Built-in IDs: `shell`,
 // `open-folder`, `vscode`.
 export type CustomProcessDefId = string;
 
-// MIRROR: src-tauri/src/types.rs::WorktreeTabId
+// MIRROR: crates/arborist-types/src/lib.rs::WorktreeTabId
 // Stable identifier for a WorktreeTab. Backed by a UUID v4 on the Rust side;
 // distinct from SessionId/SubSessionId at the type level.
 export type WorktreeTabId = string;
 
-// MIRROR: src-tauri/src/types.rs::Tool
+// MIRROR: crates/arborist-types/src/lib.rs::Tool
 export type Tool = 'claude' | 'copilot' | 'codex';
 
 // MIRROR: crates/arborist-types/src/lib.rs::ThemeMode
 export type ThemeMode = 'system' | 'light' | 'dark';
 
-// MIRROR: src-tauri/src/types.rs::SessionStatus
+// MIRROR: crates/arborist-types/src/lib.rs::SessionStatus
 export type SessionStatus = 'starting' | 'running' | 'exited' | 'error';
 
-// MIRROR: src-tauri/src/types.rs::CustomProcessKind
+// MIRROR: crates/arborist-types/src/lib.rs::CustomProcessKind
 // Sub-session flavour. `terminal` runs inside an in-app PTY; `application`
 // spawns an external GUI program detached.
 export type CustomProcessKind = 'terminal' | 'application';
 
-// MIRROR: src-tauri/src/types.rs::SubSessionStatus
+// MIRROR: crates/arborist-types/src/lib.rs::SubSessionStatus
 export type SubSessionStatus = 'starting' | 'running' | 'exited' | 'error';
 
 // MIRROR: crates/arborist-types/src/lib.rs::StructuredCommand
@@ -118,13 +118,13 @@ export interface RepoCommandTrustArgs {
   intent: ShellCommandIntent;
 }
 
-// MIRROR: src-tauri/src/types.rs::TempFileSpec
+// MIRROR: crates/arborist-types/src/lib.rs::TempFileSpec
 export interface TempFileSpec {
   path: string;
   contents: string;
 }
 
-// MIRROR: src-tauri/src/types.rs::Session
+// MIRROR: crates/arborist-types/src/lib.rs::Session
 // Backend-only record. Not sent to the frontend in normal flows; included
 // here so persistence/debug tooling can type it correctly.
 export interface Session {
@@ -152,7 +152,7 @@ export interface Session {
   lastMetrics?: SessionMetricsEvent;
 }
 
-// MIRROR: src-tauri/src/types.rs::SessionView
+// MIRROR: crates/arborist-types/src/lib.rs::SessionView
 // Frontend-facing projection: omits `composedCommand` and `tempFiles`.
 export interface SessionView {
   id: SessionId;
@@ -168,12 +168,12 @@ export interface SessionView {
   lastMetrics?: SessionMetricsEvent;
 }
 
-// MIRROR: src-tauri/src/types.rs::ChildId
+// MIRROR: crates/arborist-types/src/lib.rs::ChildId
 // Discriminated child identifier — either a Session or SubSession.
 // Wire shape: `{ kind: 'session', id: SessionId }` or `{ kind: 'subSession', id: SubSessionId }`.
 export type ChildId = { kind: 'session'; id: SessionId } | { kind: 'subSession'; id: SubSessionId };
 
-// MIRROR: src-tauri/src/types.rs::WorktreeTab
+// MIRROR: crates/arborist-types/src/lib.rs::WorktreeTab
 // First-class worktree tab record. Parent in the sidebar hierarchy.
 // AI sessions are grouped by matching `worktreePath`; sub-sessions are owned by `parentWorktreeTabId`.
 export interface WorktreeTab {
@@ -219,7 +219,7 @@ export interface PluginSettings {
   dashboardWidget: Record<string, PluginSettingState>;
 }
 
-// MIRROR: src-tauri/src/types.rs::AppConfig
+// MIRROR: crates/arborist-types/src/lib.rs::AppConfig
 export interface AppConfig {
   configVersion: number;
   /**
@@ -293,7 +293,7 @@ export interface PartialPluginSettings {
   dashboardWidget?: Record<string, PartialPluginSettingState>;
 }
 
-// MIRROR: src-tauri/src/types.rs::PartialAppConfig
+// MIRROR: crates/arborist-types/src/lib.rs::PartialAppConfig
 // Every field optional so Phase 4's `config_set` can deep-merge updates.
 // `activeSessionId` is tri-state: omit to leave alone, `null` to clear,
 // string to set.
@@ -332,7 +332,7 @@ export interface PartialAppConfig {
   theme?: ThemeMode;
 }
 
-// MIRROR: src-tauri/src/types.rs::CustomProcessDef
+// MIRROR: crates/arborist-types/src/lib.rs::CustomProcessDef
 // Persisted in `AppConfig.customProcesses`. `command` is passed verbatim to
 // `$SHELL -c` (or `%COMSPEC% /c` on Windows); the parent worktree tab path is
 // set as `cwd` and **never** interpolated into the command.
@@ -354,7 +354,7 @@ export interface CustomProcessDef {
   iconDataUri?: string;
 }
 
-// MIRROR: src-tauri/src/types.rs::SubSession
+// MIRROR: crates/arborist-types/src/lib.rs::SubSession
 // In-memory + on-the-wire representation of a sub-tab. Lives in a
 // parallel `SubSessionStore` on the Rust side; the frontend mirrors them
 // in a Zustand slice (Phase 4).
@@ -370,7 +370,7 @@ export interface SubSession {
   createdAt: number;
 }
 
-// MIRROR: src-tauri/src/types.rs::SubSessionRecord
+// MIRROR: crates/arborist-types/src/lib.rs::SubSessionRecord
 // Lightweight restore record persisted in
 // `AppConfig.lastOpenSubSessions`. Carries only what the restore pass
 // needs to attempt re-creation.
@@ -391,7 +391,7 @@ export interface SubSessionRecord {
   composedCommand?: string;
 }
 
-// MIRROR: src-tauri/src/types.rs::AppError
+// MIRROR: crates/arborist-types/src/lib.rs::AppError
 // Wire shape of every error coming from a Tauri command. The frontend may
 // branch on `code`; the strings come from `Error::code()` in Rust.
 export interface AppError {
@@ -399,14 +399,14 @@ export interface AppError {
   message: string;
 }
 
-// MIRROR: src-tauri/src/types.rs::SessionOutputEvent
+// MIRROR: crates/arborist-types/src/lib.rs::SessionOutputEvent
 // Payload of the `session://output` Tauri event (docs/architecture.md#command-and-event-contract).
 export interface SessionOutputEvent {
   sessionId: SessionId;
   data: string;
 }
 
-// MIRROR: src-tauri/src/types.rs::SessionStatusEvent
+// MIRROR: crates/arborist-types/src/lib.rs::SessionStatusEvent
 // Payload of the `session://status` Tauri event (docs/architecture.md#command-and-event-contract).
 //
 // `message` is an optional context string the backend includes for
@@ -419,49 +419,49 @@ export interface SessionStatusEvent {
   message?: string;
 }
 
-// MIRROR: src-tauri/src/types.rs::SubSessionCreateArgs
+// MIRROR: crates/arborist-types/src/lib.rs::SubSessionCreateArgs
 export interface SubSessionCreateArgs {
   parentWorktreeTabId: WorktreeTabId;
   defId: CustomProcessDefId;
 }
 
-// MIRROR: src-tauri/src/types.rs::SubSessionIdArg
+// MIRROR: crates/arborist-types/src/lib.rs::SubSessionIdArg
 export interface SubSessionIdArg {
   id: SubSessionId;
 }
 
-// MIRROR: src-tauri/src/types.rs::SubSessionCloseIntent
+// MIRROR: crates/arborist-types/src/lib.rs::SubSessionCloseIntent
 //
 // Discriminated tag describing what should happen to the underlying
 // process when the user closes a sub-tab. Terminal kind ignores the
 // variant; application kind branches on it.
 export type SubSessionCloseIntent = 'tabOnly' | 'requestAppClose' | 'forceKill';
 
-// MIRROR: src-tauri/src/types.rs::SubSessionCloseArgs
+// MIRROR: crates/arborist-types/src/lib.rs::SubSessionCloseArgs
 export interface SubSessionCloseArgs {
   id: SubSessionId;
   intent?: SubSessionCloseIntent;
 }
 
-// MIRROR: src-tauri/src/types.rs::SubSessionListArgs
+// MIRROR: crates/arborist-types/src/lib.rs::SubSessionListArgs
 export interface SubSessionListArgs {
   parentWorktreeTabId?: WorktreeTabId;
 }
 
-// MIRROR: src-tauri/src/types.rs::SubSessionInputArgs
+// MIRROR: crates/arborist-types/src/lib.rs::SubSessionInputArgs
 export interface SubSessionInputArgs {
   id: SubSessionId;
   data: string;
 }
 
-// MIRROR: src-tauri/src/types.rs::SubSessionResizeArgs
+// MIRROR: crates/arborist-types/src/lib.rs::SubSessionResizeArgs
 export interface SubSessionResizeArgs {
   id: SubSessionId;
   cols: number;
   rows: number;
 }
 
-// MIRROR: src-tauri/src/types.rs::SubSessionStatusEvent
+// MIRROR: crates/arborist-types/src/lib.rs::SubSessionStatusEvent
 // Payload of the `subsession://status` Tauri event (Phase 2).
 export interface SubSessionStatusEvent {
   id: SubSessionId;
@@ -470,7 +470,7 @@ export interface SubSessionStatusEvent {
   message?: string;
 }
 
-// MIRROR: src-tauri/src/types.rs::SubSessionExitedEvent
+// MIRROR: crates/arborist-types/src/lib.rs::SubSessionExitedEvent
 // Payload of the `subsession://exited` Tauri event (Phase 3 application
 // sub-tabs). Phase 2's terminal sub-tabs use `subsession://status` with
 // `SubSessionStatus = 'exited'` instead.
@@ -479,7 +479,7 @@ export interface SubSessionExitedEvent {
   exitCode?: number;
 }
 
-// MIRROR: src-tauri/src/types.rs::SubSessionRestoredEvent
+// MIRROR: crates/arborist-types/src/lib.rs::SubSessionRestoredEvent
 // Payload of the `subsession://restored` Tauri event (Phase 7).
 //
 // Emitted once per sub-session by the restore-on-launch second pass
@@ -492,18 +492,18 @@ export interface SubSessionRestoredEvent {
   subSession: SubSession;
 }
 
-// MIRROR: src-tauri/src/types.rs::WorktreeTabOpenArgs
+// MIRROR: crates/arborist-types/src/lib.rs::WorktreeTabOpenArgs
 export interface WorktreeTabOpenArgs {
   path: string;
 }
 
-// MIRROR: src-tauri/src/types.rs::WorktreeTabAppClosePolicy
+// MIRROR: crates/arborist-types/src/lib.rs::WorktreeTabAppClosePolicy
 //
 // Policy for application-kind sub-sessions during worktree-tab cascade close.
 // Terminal sub-sessions and AI sessions are always terminated by their own paths.
 export type WorktreeTabAppClosePolicy = 'detach' | 'terminate';
 
-// MIRROR: src-tauri/src/types.rs::WorktreeTabCloseArgs
+// MIRROR: crates/arborist-types/src/lib.rs::WorktreeTabCloseArgs
 export interface WorktreeTabCloseArgs {
   id: WorktreeTabId;
   /**
@@ -522,23 +522,23 @@ export interface WorktreeTabCloseArgs {
   appClosePolicy?: WorktreeTabAppClosePolicy;
 }
 
-// MIRROR: src-tauri/src/types.rs::WorktreeTabFocusArgs
+// MIRROR: crates/arborist-types/src/lib.rs::WorktreeTabFocusArgs
 export interface WorktreeTabFocusArgs {
   id: WorktreeTabId;
 }
 
-// MIRROR: src-tauri/src/types.rs::WorktreeTabReorderArgs
+// MIRROR: crates/arborist-types/src/lib.rs::WorktreeTabReorderArgs
 export interface WorktreeTabReorderArgs {
   ids: WorktreeTabId[];
 }
 
-// MIRROR: src-tauri/src/types.rs::WorktreeTabSetActiveChildArgs
+// MIRROR: crates/arborist-types/src/lib.rs::WorktreeTabSetActiveChildArgs
 export interface WorktreeTabSetActiveChildArgs {
   id: WorktreeTabId;
   childId?: ChildId;
 }
 
-// MIRROR: src-tauri/src/types.rs::WorktreeTabCloseResult
+// MIRROR: crates/arborist-types/src/lib.rs::WorktreeTabCloseResult
 export interface WorktreeTabCloseResult {
   childErrors?: string[];
   /**
@@ -574,13 +574,13 @@ export type ActivityEvent =
     }
   | { kind: 'permissionResolved'; requestId: string; approved: boolean };
 
-// MIRROR: src-tauri/src/types.rs::SessionActivityEvent
+// MIRROR: crates/arborist-types/src/lib.rs::SessionActivityEvent
 // Payload of the `session://activity` Tauri event (docs/architecture.md#command-and-event-contract). The
 // `ActivityEvent` fields are flattened into the payload alongside
 // `sessionId`.
 export type SessionActivityEvent = { sessionId: SessionId } & ActivityEvent;
 
-// MIRROR: src-tauri/src/types.rs::SessionMetricsEvent
+// MIRROR: crates/arborist-types/src/lib.rs::SessionMetricsEvent
 // Payload of the `session://metrics` Tauri event (Issue #3). All fields
 // except `sessionId` and `observedAt` are optional — the watcher emits
 // only what it can resolve. The same shape doubles as the in-memory
@@ -606,7 +606,7 @@ export interface SessionMetricsEvent {
 /** In-memory alias — sidebar reads the same shape it received over the wire. */
 export type SessionMetrics = SessionMetricsEvent;
 
-// MIRROR: src-tauri/src/types.rs::WorktreeInfo
+// MIRROR: crates/arborist-types/src/lib.rs::WorktreeInfo
 // Returned by the `worktrees_list` command.
 // `branch` is omitted by the backend when the worktree has a detached HEAD,
 // so we model it as an optional string.
@@ -617,19 +617,19 @@ export interface WorktreeInfo {
   isLocked: boolean;
 }
 
-// MIRROR: src-tauri/src/types.rs::GitStatusFileKind
+// MIRROR: crates/arborist-types/src/lib.rs::GitStatusFileKind
 // Categorical state of a single file in a worktree's working tree (Issue #55).
 // A file with both X and Y dirty surfaces as both `staged` and `unstaged`
 // entries in `WorktreeGitStatus.files`.
 export type GitStatusFileKind = 'staged' | 'unstaged' | 'untracked' | 'conflicted';
 
-// MIRROR: src-tauri/src/types.rs::WorktreeGitStatusArgs
+// MIRROR: crates/arborist-types/src/lib.rs::WorktreeGitStatusArgs
 // Args for the `worktree_git_status` command (Issue #55).
 export interface WorktreeGitStatusArgs {
   path: string;
 }
 
-// MIRROR: src-tauri/src/types.rs::GitStatusFile
+// MIRROR: crates/arborist-types/src/lib.rs::GitStatusFile
 // One file entry in `WorktreeGitStatus.files` (Issue #55). `status` is the
 // raw porcelain-v2 XY code (e.g. `"M."`, `"MM"`, `"??"`, `"UU"`); `kind` is
 // the digestible category the dashboard groups by.
@@ -639,7 +639,7 @@ export interface GitStatusFile {
   status: string;
 }
 
-// MIRROR: src-tauri/src/types.rs::WorktreeGitStatus
+// MIRROR: crates/arborist-types/src/lib.rs::WorktreeGitStatus
 // Returned by the `worktree_git_status` command (Issue #55: worktree
 // dashboard). All counts are `0` and `files` is empty when the working tree
 // is clean. On any backend discovery failure the backend returns a
@@ -673,7 +673,7 @@ export interface WorktreeGitStatus {
   error?: string;
 }
 
-// MIRROR: src-tauri/src/types.rs::WorkspaceValidateResult
+// MIRROR: crates/arborist-types/src/lib.rs::WorkspaceValidateResult
 // Returned by the `workspace_validate` command (Roadmap §1.1). `error` is
 // only populated when `valid === false`.
 //
@@ -700,7 +700,7 @@ export interface WorkspaceValidateResult {
   alreadyOpenInAnotherInstance?: boolean;
 }
 
-// MIRROR: src-tauri/src/types.rs::WorktreeCreateResult
+// MIRROR: crates/arborist-types/src/lib.rs::WorktreeCreateResult
 // Returned by the `worktree_create` command (Roadmap §2.2). `path` is the
 // canonical absolute path to the newly-created worktree directory. `prep`
 // is `null` when the user has no `worktreePrepCommands` configured (issue
@@ -711,11 +711,11 @@ export interface WorktreeCreateResult {
   prep: WorktreePrepInfo | null;
 }
 
-// MIRROR: src-tauri/src/types.rs::WorktreePrepId
+// MIRROR: crates/arborist-types/src/lib.rs::WorktreePrepId
 // UUID v4 identifying a single prep run. Distinct from SessionId.
 export type WorktreePrepId = string;
 
-// MIRROR: src-tauri/src/types.rs::WorktreePrepInfo
+// MIRROR: crates/arborist-types/src/lib.rs::WorktreePrepInfo
 // Returned in `WorktreeCreateResult.prep` and echoed in `WorktreePrepEvent`
 // payloads so the frontend can correlate events to the originating create.
 export interface WorktreePrepInfo {
@@ -724,7 +724,7 @@ export interface WorktreePrepInfo {
   logPath: string;
 }
 
-// MIRROR: src-tauri/src/types.rs::WorktreePrepEvent
+// MIRROR: crates/arborist-types/src/lib.rs::WorktreePrepEvent
 // Lifecycle event for a worktree-prep run, emitted on `worktree://prep`.
 // Both variants carry `prepId`/`worktreePath`/`logPath` so the frontend
 // store can render a completed-prep banner even if it missed the matching
@@ -753,7 +753,7 @@ export type WorktreePrepEvent =
       finishedAt: number;
     };
 
-// MIRROR: src-tauri/src/types.rs::WorktreePrepOpenLogArgs
+// MIRROR: crates/arborist-types/src/lib.rs::WorktreePrepOpenLogArgs
 // Args for the `worktree_prep_open_log` command — the backend canonicalises
 // the path and asserts it lives under `<app_data_dir>/worktree-prep-logs/`
 // before invoking the OS-default opener.
@@ -761,7 +761,7 @@ export interface WorktreePrepOpenLogArgs {
   logPath: string;
 }
 
-// MIRROR: src-tauri/src/types.rs::WorkspaceSwitchArgs
+// MIRROR: crates/arborist-types/src/lib.rs::WorkspaceSwitchArgs
 // Argument struct for the `workspace_switch` command. The Tauri invoke
 // wrapper passes this as `{ args: { path } }` to match the Rust handler
 // signature `workspace_switch(args: WorkspaceSwitchArgs)`.
@@ -769,7 +769,7 @@ export interface WorkspaceSwitchArgs {
   path: string;
 }
 
-// MIRROR: src-tauri/src/types.rs::WorkspaceSwitchResult
+// MIRROR: crates/arborist-types/src/lib.rs::WorkspaceSwitchResult
 // Resolves on success of `workspace_switch`. `workspaceRoot` is the
 // **canonical** path the backend bound to. `noOp` is `true` if the
 // requested path matched the workspace already in use — in that case


### PR DESCRIPTION
## Summary

Adds OpenAI Codex CLI as a third AI tool plugin in Arborist, with **full feature parity** to the existing Claude and Copilot plugins.

## What's included

### Core Plugin (commit 1-2)
- **Rust backend**: `CodexPlugin` implementing the `AiPlugin` trait with compose, resume (`codex resume <id>`), and session lifecycle
- **Frontend**: Plugin registration, icon, settings integration
- **Types**: `Tool::Codex` variant in both Rust and TypeScript
- **Tests**: Compose tests, frontend assertion updates

### Metrics Watcher (commit 3) — Feature Parity
- **Rollout file tailing**: Discovers and tails Codex's JSONL rollout files (`~/.codex/sessions/`, including date-nested `YYYY/MM/DD/` subdirs)
- **Session-ID discovery**: Extracts `thread_id` from the `SessionMeta` first line, enabling `codex resume <id>`
- **Token usage metrics**: Parses `TokenCount` events for input/output token totals and context window percentage
- **Turn-end events**: Emits turn completion with duration from `TurnComplete` events
- **Model name**: Extracted from `TurnContext` items
- **CWD matching**: Case-insensitive on Windows to correctly match rollout files to sessions
- **7 unit tests** covering all watcher utilities

### Documentation
- Updated `docs/architecture.md`, `docs/product.md`, `docs/overview.md`
- Updated `.github/copilot-instructions.md` and `CLAUDE.md`
- Added Codex to bug report template

## Design Decisions
- **Resume syntax**: Codex uses `codex resume <id>` (subcommand) vs Copilot's `--resume` flag — handled via `AiPlugin::resume_args()`
- **Metrics approach**: Tails rollout JSONL files (similar pattern to Claude's transcript tailing)
- **No preflight**: `resume_requires_preflight = false` because rollout filenames include timestamps+UUIDs in date dirs, making quick existence checks impractical. The CLI handles invalid IDs gracefully.
- **CODEX_HOME**: Respects `CODEX_HOME` env var with fallback to `~/.codex/`

Closes #194