### PR TITLE
[lsp] Configure LSP for Claude Code and Copilot CLI in-repo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "enabledPlugins": {
+    "typescript-lsp@claude-plugins-official": true,
+    "rust-analyzer-lsp@claude-plugins-official": true
+  }
+}

--- a/.github/lsp.json
+++ b/.github/lsp.json
@@ -9,7 +9,9 @@
         ".js": "javascript",
         ".jsx": "javascriptreact",
         ".mjs": "javascript",
-        ".cjs": "javascript"
+        ".cjs": "javascript",
+        ".mts": "typescript",
+        ".cts": "typescript"
       }
     },
     "rust-analyzer": {


### PR DESCRIPTION
## Summary
- Enable `typescript-lsp` and `rust-analyzer-lsp` from the official `claude-plugins-official` marketplace via `.claude/settings.json` at project scope, so Claude Code activates LSP for any collaborator that trusts the folder.
- Extend `.github/lsp.json` to include `.mts` / `.cts` in the typescript-language-server entry (matches GitHub's documented schema example).

## Test plan
- [ ] Run `claude` in a fresh clone, accept the project-scope plugin install prompts, then `/reload-plugins` and confirm `typescript-lsp` and `rust-analyzer-lsp` load without errors in `/plugin` Errors tab.
- [ ] In Claude Code, edit a `.ts` and `.rs` file and confirm diagnostics surface inline.
- [ ] Run `copilot` in the repo, `/lsp reload`, then `/lsp test typescript-language-server` and `/lsp test rust-analyzer` — both should succeed.
- [ ] Verify the binaries `typescript-language-server` and `rust-analyzer` are documented as runtime prerequisites (or installed locally before testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)