### PR TITLE
[claude-codex-release-troubleshoot] Fix release CI failures across macOS/Linux/Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,9 +244,10 @@ jobs:
       - name: Clean stale bundle artifacts
         shell: bash
         run: |
+          shopt -s nullglob
           rm -rf target/release/bundle
           for d in target/*/release/bundle; do
-            [ -d "$d" ] && rm -rf "$d"
+            rm -rf "$d"
           done
 
       - name: Build Tauri app
@@ -258,13 +259,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          shopt -s nullglob
           # Account for --target placing bundles in target/<triple>/release/bundle/
           search_dirs=()
           if [ -d "target/release/bundle" ]; then
             search_dirs+=("target/release/bundle")
           fi
           for d in target/*/release/bundle; do
-            [ -d "$d" ] && search_dirs+=("$d")
+            search_dirs+=("$d")
           done
           if [ ${#search_dirs[@]} -eq 0 ]; then
             echo "::error::No bundle directories found under target/"

--- a/scripts/prepare-claude-hook-sidecar.mjs
+++ b/scripts/prepare-claude-hook-sidecar.mjs
@@ -84,10 +84,24 @@ function ensureDir(path) {
   if (!existsSync(path)) mkdirSync(path, { recursive: true });
 }
 
+function helperBuildEnv() {
+  const env = { ...process.env };
+  // Helper builds run inside Tauri's beforeBuildCommand. Strip Tauri_* vars so the
+  // helper's Cargo build doesn't read the release overlay config (externalBin) and
+  // fail before this script has staged the sidecar into src-tauri/binaries/.
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('TAURI_')) {
+      delete env[key];
+    }
+  }
+  return env;
+}
+
 function buildHelperForTarget(targetDir, targetTriple) {
   console.log(`[prepare-claude-hook-sidecar] building arborist-claude-hook (release, target=${targetTriple})…`);
   execFileSync(cargoBin('cargo'), ['build', '--release', '--bin', 'arborist-claude-hook', '--target', targetTriple], {
     cwd: tauriDir,
+    env: helperBuildEnv(),
     stdio: 'inherit',
   });
 


### PR DESCRIPTION
## Summary
- fix release workflow glob handling so cleanup/artifact discovery steps do not fail on empty matches under bash -e
- isolate helper sidecar cargo builds from inherited TAURI_* environment during beforeBuildCommand
- keep macOS universal release builds from failing externalBin validation before the helper is staged

## Validation
- pnpm run lint
- pnpm test --run
- pnpm run build
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --features test-helpers -- -D warnings
- cargo test --workspace --features test-helpers
- pnpm tauri build --config src-tauri/tauri.bundle.conf.json (Windows bundles)
- pnpm e2e:linux:build
- pnpm e2e:linux