### PR TITLE
[dependabot-audit] Add Dependabot and dependency audit automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,37 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    labels:
+      - github_actions
+      - dependencies
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+    groups:
+      npm-production:
+        dependency-type: production
+        patterns:
+          - '*'
+      npm-development:
+        dependency-type: development
+        patterns:
+          - '*'
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+    groups:
+      rust-workspace:
+        patterns:
+          - '*'

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,60 @@
+name: Dependency Audits
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '23 5 * * 1'
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      - 'deny.toml'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/dependabot.yml'
+      - '.github/workflows/dependency-audit.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      - 'deny.toml'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/dependabot.yml'
+      - '.github/workflows/dependency-audit.yml'
+
+concurrency:
+  group: dependency-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  rust-security:
+    name: Rust advisory/license audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+      - name: Install cargo-deny
+        run: cargo install --locked cargo-deny
+      - name: Run cargo-deny checks
+        run: cargo deny check advisories licenses
+
+  npm-production:
+    name: npm production audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
+      - run: corepack enable
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
+        with:
+          node-version: '22'
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm audit --prod --audit-level=moderate

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -35,6 +35,8 @@ jobs:
   rust-security:
     name: Rust advisory/license audit
     runs-on: ubuntu-latest
+    env:
+      CARGO_DENY_VERSION: '0.19.6'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       - name: Install Rust toolchain
@@ -42,7 +44,7 @@ jobs:
           rustup toolchain install stable --profile minimal
           rustup default stable
       - name: Install cargo-deny
-        run: cargo install --locked cargo-deny
+        run: cargo install --locked --version "$CARGO_DENY_VERSION" cargo-deny
       - name: Run cargo-deny checks
         run: cargo deny check advisories licenses
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,7 @@
 [graph]
 targets = [
   { triple = "x86_64-unknown-linux-gnu" },
+  { triple = "aarch64-apple-darwin" },
   { triple = "x86_64-apple-darwin" },
   { triple = "x86_64-pc-windows-msvc" },
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,44 @@
+[graph]
+targets = [
+  { triple = "x86_64-unknown-linux-gnu" },
+  { triple = "x86_64-apple-darwin" },
+  { triple = "x86_64-pc-windows-msvc" },
+]
+
+[advisories]
+yanked = "warn"
+ignore = [
+  { id = "RUSTSEC-2024-0411", reason = "Tauri/wry currently pull GTK3 bindings with no safe upgrade path." },
+  { id = "RUSTSEC-2024-0412", reason = "Tauri/wry currently pull GTK3 bindings with no safe upgrade path." },
+  { id = "RUSTSEC-2024-0413", reason = "Tauri/wry currently pull GTK3 bindings with no safe upgrade path." },
+  { id = "RUSTSEC-2024-0414", reason = "Tauri/wry currently pull GTK3 bindings with no safe upgrade path." },
+  { id = "RUSTSEC-2024-0415", reason = "Tauri/wry currently pull GTK3 bindings with no safe upgrade path." },
+  { id = "RUSTSEC-2024-0416", reason = "Tauri/wry currently pull GTK3 bindings with no safe upgrade path." },
+  { id = "RUSTSEC-2024-0417", reason = "Tauri/wry currently pull GTK3 bindings with no safe upgrade path." },
+  { id = "RUSTSEC-2024-0418", reason = "Tauri/wry currently pull GTK3 bindings with no safe upgrade path." },
+  { id = "RUSTSEC-2024-0419", reason = "Tauri/wry currently pull GTK3 bindings with no safe upgrade path." },
+  { id = "RUSTSEC-2024-0420", reason = "Tauri/wry currently pull GTK3 bindings with no safe upgrade path." },
+  { id = "RUSTSEC-2024-0370", reason = "Pulled transitively by gtk-rs macros in the current Tauri stack." },
+  { id = "RUSTSEC-2017-0008", reason = "Pulled transitively through linux-keyutils and not currently replaceable here." },
+  { id = "RUSTSEC-2025-0075", reason = "Pulled transitively by idna through crates without a patched release yet." },
+  { id = "RUSTSEC-2025-0080", reason = "Pulled transitively by idna through crates without a patched release yet." },
+  { id = "RUSTSEC-2025-0081", reason = "Pulled transitively by idna through crates without a patched release yet." },
+  { id = "RUSTSEC-2025-0098", reason = "Pulled transitively by idna through crates without a patched release yet." },
+  { id = "RUSTSEC-2025-0100", reason = "Pulled transitively by idna through crates without a patched release yet." },
+]
+
+[licenses]
+confidence-threshold = 0.8
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-3-Clause",
+  "Unicode-3.0",
+  "Zlib",
+  "MPL-2.0",
+  "CC0-1.0",
+]
+
+[licenses.private]
+ignore = true

--- a/docs/development.md
+++ b/docs/development.md
@@ -73,7 +73,7 @@ cargo test --workspace --features test-helpers <test-name-prefix>
 ```sh
 pnpm audit --prod --audit-level=moderate
 pnpm audit --audit-level=high
-cargo install --locked cargo-deny
+cargo install --locked --version 0.19.6 cargo-deny
 cargo deny check advisories licenses
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -72,7 +72,7 @@ cargo test --workspace --features test-helpers <test-name-prefix>
 
 ```sh
 pnpm audit --prod --audit-level=moderate
-pnpm audit --audit-level=high
+pnpm audit --audit-level=high || true
 cargo install --locked --version 0.19.6 cargo-deny
 cargo deny check advisories licenses
 ```
@@ -81,6 +81,7 @@ Policy:
 
 - Production dependency vulnerabilities (`pnpm audit --prod`) at `moderate` or higher are blocking and should be fixed before merge/release.
 - Development dependency vulnerabilities (`pnpm audit`) are non-blocking unless they impact shipped artifacts; track remediation through follow-up issues.
+- `pnpm audit --audit-level=high` exits non-zero when findings exist. Use `|| true` when you want report-only output during routine checks.
 - Rust dependency advisories/licenses are enforced by `cargo deny check advisories licenses`.
 
 ### Acceptance gate

--- a/docs/development.md
+++ b/docs/development.md
@@ -68,6 +68,21 @@ cargo test --workspace --features test-helpers
 cargo test --workspace --features test-helpers <test-name-prefix>
 ```
 
+### Dependency audits
+
+```sh
+pnpm audit --prod --audit-level=moderate
+pnpm audit --audit-level=high
+cargo install --locked cargo-deny
+cargo deny check advisories licenses
+```
+
+Policy:
+
+- Production dependency vulnerabilities (`pnpm audit --prod`) at `moderate` or higher are blocking and should be fixed before merge/release.
+- Development dependency vulnerabilities (`pnpm audit`) are non-blocking unless they impact shipped artifacts; track remediation through follow-up issues.
+- Rust dependency advisories/licenses are enforced by `cargo deny check advisories licenses`.
+
 ### Acceptance gate
 
 Before a PR is ready for review, run the applicable local gate:
@@ -97,18 +112,19 @@ Do not bypass hooks on `main`. If you must use `--no-verify` on a personal WIP b
 
 ## CI
 
-| Workflow        | Trigger                              | Purpose                                                                           |
-| --------------- | ------------------------------------ | --------------------------------------------------------------------------------- |
-| `ci.yml`        | Pull requests and pushes to `main`   | Frontend install, lint, and Vitest run.                                           |
-| `rust-gate.yml` | PR review approval                   | Dispatches the Rust workflow against the PR head branch for same-repo PRs.        |
-| `rust.yml`      | Manual dispatch, or via rust gate    | Multi-platform Rust format, clippy, and tests after building the frontend bundle. |
-| `release.yml`   | Manual dispatch with an existing tag | Builds draft release artifacts and GitHub build attestations.                     |
+| Workflow               | Trigger                                                             | Purpose                                                                           |
+| ---------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `ci.yml`               | Pull requests and pushes to `main`                                  | Frontend install, lint, and Vitest run.                                           |
+| `dependency-audit.yml` | Weekly schedule, manual dispatch, and dependency-related pushes/PRs | Runs Rust advisory/license checks (`cargo deny`) and production npm audit.        |
+| `rust-gate.yml`        | PR review approval                                                  | Dispatches the Rust workflow against the PR head branch for same-repo PRs.        |
+| `rust.yml`             | Manual dispatch, or via rust gate                                   | Multi-platform Rust format, clippy, and tests after building the frontend bundle. |
+| `release.yml`          | Manual dispatch with an existing tag                                | Builds draft release artifacts and GitHub build attestations.                     |
 
 The Rust workflow is approval-gated because it is heavier and multi-platform. Reviewers should ensure it ran against the head SHA they approved.
 
 Workflow `uses:` dependencies are pinned to full commit SHAs. Each pin keeps an inline comment with the intended upstream action ref, and Dependabot is
-configured to open weekly `github-actions` update PRs. Review those PRs like code changes: confirm the new SHA belongs to the commented upstream ref,
-keep the comment accurate, and run the relevant workflow before merging.
+configured to open weekly update PRs for GitHub Actions, npm, and Cargo dependencies. Review those PRs like code changes: confirm each update is
+expected for the ecosystem/group, keep inline action-ref comments accurate, and run the relevant workflows before merging.
 
 ## Debugging
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -80,6 +80,16 @@ cargo test --workspace --features test-helpers <test-name-prefix>
 `cargo test --workspace --features test-helpers` builds the helper binaries and exposes paths such as
 `CARGO_BIN_EXE_arborist-test-child` to integration tests.
 
+## Dependency audit checks
+
+These checks are separate from unit/integration tests and target supply-chain risk:
+
+```sh
+pnpm audit --prod --audit-level=moderate
+pnpm audit --audit-level=high
+cargo deny check advisories licenses
+```
+
 ## Linux E2E harness
 
 The Dockerized Linux E2E harness lives under `dev/e2e/linux/`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -86,10 +86,12 @@ These checks are separate from unit/integration tests and target supply-chain ri
 
 ```sh
 pnpm audit --prod --audit-level=moderate
-pnpm audit --audit-level=high
+pnpm audit --audit-level=high || true
 cargo install --locked --version 0.19.6 cargo-deny
 cargo deny check advisories licenses
 ```
+
+`pnpm audit --audit-level=high` exits non-zero when findings are present; the `|| true` form keeps this check report-only in local test runs.
 
 ## Linux E2E harness
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -87,6 +87,7 @@ These checks are separate from unit/integration tests and target supply-chain ri
 ```sh
 pnpm audit --prod --audit-level=moderate
 pnpm audit --audit-level=high
+cargo install --locked --version 0.19.6 cargo-deny
 cargo deny check advisories licenses
 ```
 


### PR DESCRIPTION
## Summary
- expand Dependabot coverage to GitHub Actions, npm/pnpm, and Cargo with grouping + labels
- add a dependency audit workflow that runs cargo-deny (advisories/licenses) and production npm audit
- add deny.toml for cargo-deny policy/allowances and document local dependency audit policy/commands

Closes #131