### PR TITLE
[claude-codex-release-troubleshoot] Fix release failures on macOS universal and Windows WiX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,9 +244,10 @@ jobs:
       - name: Clean stale bundle artifacts
         shell: bash
         run: |
+          shopt -s nullglob
           rm -rf target/release/bundle
           for d in target/*/release/bundle; do
-            [ -d "$d" ] && rm -rf "$d"
+            rm -rf "$d"
           done
 
       - name: Build Tauri app
@@ -258,13 +259,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          shopt -s nullglob
           # Account for --target placing bundles in target/<triple>/release/bundle/
           search_dirs=()
           if [ -d "target/release/bundle" ]; then
             search_dirs+=("target/release/bundle")
           fi
           for d in target/*/release/bundle; do
-            [ -d "$d" ] && search_dirs+=("$d")
+            search_dirs+=("$d")
           done
           if [ ${#search_dirs[@]} -eq 0 ]; then
             echo "::error::No bundle directories found under target/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,16 @@ jobs:
         if: runner.os == 'macOS'
         run: echo "RUSTFLAGS=" >> "$GITHUB_ENV"
 
+      # On windows-latest (currently windows-2025-vs2026), the auto-downloaded
+      # WiX binaries under %LOCALAPPDATA%\tauri can fail to execute. Install a
+      # known WiX toolset and point Tauri bundler at it explicitly.
+      - name: Install WiX toolset for bundling
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install wixtoolset --version=3.14.1 --no-progress -y
+          "WIX=C:\Program Files (x86)\WiX Toolset v3.14\bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - run: pnpm install --frozen-lockfile
 
       - name: Verify version matches tag

--- a/scripts/prepare-claude-hook-sidecar.mjs
+++ b/scripts/prepare-claude-hook-sidecar.mjs
@@ -84,10 +84,24 @@ function ensureDir(path) {
   if (!existsSync(path)) mkdirSync(path, { recursive: true });
 }
 
+function helperBuildEnv() {
+  const env = { ...process.env };
+  // Helper builds run inside Tauri's beforeBuildCommand. Strip Tauri_* vars so the
+  // helper's Cargo build doesn't read the release overlay config (externalBin) and
+  // fail before this script has staged the sidecar into src-tauri/binaries/.
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('TAURI_')) {
+      delete env[key];
+    }
+  }
+  return env;
+}
+
 function buildHelperForTarget(targetDir, targetTriple) {
   console.log(`[prepare-claude-hook-sidecar] building arborist-claude-hook (release, target=${targetTriple})…`);
   execFileSync(cargoBin('cargo'), ['build', '--release', '--bin', 'arborist-claude-hook', '--target', targetTriple], {
     cwd: tauriDir,
+    env: helperBuildEnv(),
     stdio: 'inherit',
   });
 

--- a/scripts/prepare-claude-hook-sidecar.mjs
+++ b/scripts/prepare-claude-hook-sidecar.mjs
@@ -125,9 +125,17 @@ if (triple === UNIVERSAL_MACOS_TARGET) {
   if (process.platform !== 'darwin') {
     throw new Error(`target ${UNIVERSAL_MACOS_TARGET} requires a darwin host for lipo`);
   }
-  const thinBinaries = MACOS_UNIVERSAL_TARGETS.map((target) => buildHelperForTarget(targetDir, target));
+  const thinBinaries = MACOS_UNIVERSAL_TARGETS.map((target) => ({
+    target,
+    src: buildHelperForTarget(targetDir, target),
+  }));
+  for (const { target, src } of thinBinaries) {
+    const thinDst = join(outDir, exe(`arborist-claude-hook-${target}`, target));
+    copyFileSync(src, thinDst);
+    console.log(`[prepare-claude-hook-sidecar] copied ${src} -> ${thinDst}`);
+  }
   console.log(`[prepare-claude-hook-sidecar] creating universal helper ${dst}`);
-  execFileSync('/usr/bin/lipo', ['-create', ...thinBinaries, '-output', dst], {
+  execFileSync('/usr/bin/lipo', ['-create', ...thinBinaries.map(({ src }) => src), '-output', dst], {
     cwd: tauriDir,
     stdio: 'inherit',
   });


### PR DESCRIPTION
## Summary
- stage per-architecture Claude hook sidecar binaries (arch64-apple-darwin and x86_64-apple-darwin) during universal macOS preparation so Tauri externalBin resolution succeeds during target-specific compile passes
- keep generating the universal helper binary via lipo for runtime compatibility
- install WiX 3.14.1 explicitly on Windows release jobs and set WIX to avoid failures launching the auto-downloaded light.exe from %LOCALAPPDATA%

## Validation
- pnpm run lint
- node scripts/prepare-claude-hook-sidecar.mjs
- pnpm tauri build --config src-tauri/tauri.bundle.conf.json