### PR TITLE
[claude-codex-release-troubleshoot-wix] Stabilize Windows release build and add manual release verifier

### DIFF
--- a/.github/workflows/release-verify-builds.yml
+++ b/.github/workflows/release-verify-builds.yml
@@ -19,6 +19,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # We pass `--target` explicitly on every platform so the sidecar
+        # build (scripts/prepare-claude-hook-sidecar.mjs, which always uses
+        # `--target <triple>`) and the main Tauri build share the same
+        # `target/<triple>/` directory. Without this, the helper's artifacts
+        # land in `target/<triple>/release/` while Tauri's main build (no
+        # `--target`) writes to `target/release/`, forcing Cargo to recompile
+        # `arborist` and `arborist-types` from scratch a second time.
         platform:
           - name: macos-universal
             os: macos-latest
@@ -26,16 +33,16 @@ jobs:
             args: '--target universal-apple-darwin'
           - name: linux-x86_64
             os: ubuntu-22.04
-            rust-targets: ''
-            args: ''
+            rust-targets: 'x86_64-unknown-linux-gnu'
+            args: '--target x86_64-unknown-linux-gnu'
           - name: windows-x86_64
             # windows-latest currently points at a transitional image
             # (windows-2025-vs2026) where WiX v3 light.exe fails at bundle
             # time. Pin to the last known-good image until the image/tooling
             # regression is resolved upstream.
             os: windows-2025
-            rust-targets: ''
-            args: ''
+            rust-targets: 'x86_64-pc-windows-msvc'
+            args: '--target x86_64-pc-windows-msvc'
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
@@ -146,7 +153,37 @@ jobs:
 
       - name: Build Tauri app
         shell: bash
-        run: pnpm tauri build --config src-tauri/tauri.bundle.conf.json ${{ matrix.platform.args }}
+        # `--verbose` makes the bundler propagate WiX `light.exe` / `candle.exe`
+        # stderr (e.g. ICE0204 / LGHT errors) to the workflow log. Without it,
+        # MSI bundling failures surface only as the opaque
+        # `failed to run … light.exe` line and the actual error is lost.
+        run: pnpm tauri build --verbose --config src-tauri/tauri.bundle.conf.json ${{ matrix.platform.args }}
+
+      # Surface what actually landed under target/ before the verification
+      # step so failures are easier to diagnose without re-running the build.
+      - name: List built bundle artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          dirs=()
+          if [ -d "target/release/bundle" ]; then
+            dirs+=("target/release/bundle")
+          fi
+          for d in target/*/release/bundle; do
+            dirs+=("$d")
+          done
+          if [ ${#dirs[@]} -eq 0 ]; then
+            echo "(no bundle directories found under target/)"
+            exit 0
+          fi
+          for d in "${dirs[@]}"; do
+            echo "::group::${d}"
+            # `-printf` is GNU-find only; use the default output (path per line)
+            # so this step also works on the macOS runner (BSD find).
+            find "$d" -maxdepth 3 -mindepth 1 | sort
+            echo "::endgroup::"
+          done
 
       - name: Verify platform installers were produced
         shell: bash
@@ -176,8 +213,12 @@ jobs:
               has_match "*.exe" || { echo "::error::Expected an NSIS .exe artifact"; exit 1; }
               ;;
             macos-universal)
+              # Tauri only emits `.app.tar.gz` when the updater is configured
+              # (requires signing keys). Without it the macOS bundle output is
+              # the .app directory + the .dmg. v0.1.6 — the last fully
+              # successful release — shipped only the .dmg, so that's the
+              # required artifact here.
               has_match "*.dmg" || { echo "::error::Expected a macOS .dmg artifact"; exit 1; }
-              has_match "*.app.tar.gz" || { echo "::error::Expected a macOS app archive (.app.tar.gz)"; exit 1; }
               ;;
             linux-x86_64)
               has_match "*.deb" || { echo "::error::Expected a Linux .deb artifact"; exit 1; }

--- a/.github/workflows/release-verify-builds.yml
+++ b/.github/workflows/release-verify-builds.yml
@@ -1,0 +1,189 @@
+name: Release Verify Builds
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: release-verify-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build (${{ matrix.platform.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: macos-universal
+            os: macos-latest
+            rust-targets: 'aarch64-apple-darwin,x86_64-apple-darwin'
+            args: '--target universal-apple-darwin'
+          - name: linux-x86_64
+            os: ubuntu-22.04
+            rust-targets: ''
+            args: ''
+          - name: windows-x86_64
+            # windows-latest currently points at a transitional image
+            # (windows-2025-vs2026) where WiX v3 light.exe fails at bundle
+            # time. Pin to the last known-good image until the image/tooling
+            # regression is resolved upstream.
+            os: windows-2025
+            rust-targets: ''
+            args: ''
+    runs-on: ${{ matrix.platform.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
+      - run: corepack enable
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
+        with:
+          node-version: '22'
+          cache: pnpm
+
+      - name: Install Rust toolchain
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Add Rust targets
+        if: matrix.platform.rust-targets != ''
+        shell: bash
+        run: |
+          for target in $(echo "${{ matrix.platform.rust-targets }}" | tr ',' ' '); do
+            rustup target add "$target"
+          done
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # actions/cache@v4.2.3
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-release-verify-${{ matrix.platform.name }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-release-verify-${{ matrix.platform.name }}-cargo-
+
+      # Tauri's Linux build needs system libraries (must match ci.yml). `lld`
+      # + `clang` are required by the workspace `.cargo/config.toml` for the
+      # faster linker.
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            clang \
+            lld \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libxdo-dev \
+            libssl-dev \
+            build-essential
+
+      # macOS: `.cargo/config.toml` sets `-fuse-ld=lld` via per-target
+      # rustflags for faster dev builds. GitHub runners don't have lld for
+      # Mach-O, so override with RUSTFLAGS (takes precedence over config.toml
+      # target rustflags). Empty value = no extra flags → system linker.
+      - name: Override macOS linker config for CI
+        if: runner.os == 'macOS'
+        run: echo "RUSTFLAGS=" >> "$GITHUB_ENV"
+
+      # Prefer runner-installed WiX and only install via Chocolatey when the
+      # image does not already include candle.exe.
+      - name: Configure WiX toolset for bundling
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $candle = Get-Command candle.exe -ErrorAction SilentlyContinue
+          if (-not $candle) {
+            choco install wixtoolset --no-progress -y
+            $candle = Get-Command candle.exe -ErrorAction Stop
+          }
+          $wixBin = Split-Path $candle.Source
+          $wixRoot = Split-Path $wixBin
+          "WIX=$wixRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Verify manifest versions are aligned
+        shell: bash
+        run: |
+          set -euo pipefail
+          tauri_ver=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('src-tauri/tauri.conf.json','utf8')).version)")
+          pkg_ver=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('package.json','utf8')).version)")
+          cargo_ver=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)"/\1/p' src-tauri/Cargo.toml | head -1)
+          types_ver=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)"/\1/p' crates/arborist-types/Cargo.toml | head -1)
+          if [ "$tauri_ver" != "$pkg_ver" ] || [ "$tauri_ver" != "$cargo_ver" ] || [ "$tauri_ver" != "$types_ver" ]; then
+            echo "::error::Version mismatch across manifests:"
+            echo "::error::src-tauri/tauri.conf.json=$tauri_ver"
+            echo "::error::package.json=$pkg_ver"
+            echo "::error::src-tauri/Cargo.toml=$cargo_ver"
+            echo "::error::crates/arborist-types/Cargo.toml=$types_ver"
+            exit 1
+          fi
+          echo "Manifest versions aligned at $tauri_ver"
+
+      # Remove stale bundle artifacts that may have been restored from the
+      # Cargo cache. Without this, artifact checks can pick up installers from
+      # previous runs where Cargo.lock hasn't changed.
+      - name: Clean stale bundle artifacts
+        shell: bash
+        run: |
+          shopt -s nullglob
+          rm -rf target/release/bundle
+          for d in target/*/release/bundle; do
+            rm -rf "$d"
+          done
+
+      - name: Build Tauri app
+        shell: bash
+        run: pnpm tauri build --config src-tauri/tauri.bundle.conf.json ${{ matrix.platform.args }}
+
+      - name: Verify platform installers were produced
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          search_dirs=()
+          if [ -d "target/release/bundle" ]; then
+            search_dirs+=("target/release/bundle")
+          fi
+          for d in target/*/release/bundle; do
+            search_dirs+=("$d")
+          done
+          if [ ${#search_dirs[@]} -eq 0 ]; then
+            echo "::error::No bundle directories found under target/"
+            exit 1
+          fi
+
+          has_match() {
+            local pattern="$1"
+            find "${search_dirs[@]}" -type f -name "$pattern" | grep -q .
+          }
+
+          case "${{ matrix.platform.name }}" in
+            windows-x86_64)
+              has_match "*.msi" || { echo "::error::Expected a WiX .msi artifact"; exit 1; }
+              has_match "*.exe" || { echo "::error::Expected an NSIS .exe artifact"; exit 1; }
+              ;;
+            macos-universal)
+              has_match "*.dmg" || { echo "::error::Expected a macOS .dmg artifact"; exit 1; }
+              has_match "*.app.tar.gz" || { echo "::error::Expected a macOS app archive (.app.tar.gz)"; exit 1; }
+              ;;
+            linux-x86_64)
+              has_match "*.deb" || { echo "::error::Expected a Linux .deb artifact"; exit 1; }
+              has_match "*.AppImage" || { echo "::error::Expected a Linux .AppImage artifact"; exit 1; }
+              ;;
+            *)
+              echo "::error::Unknown platform '${{ matrix.platform.name }}'"
+              exit 1
+              ;;
+          esac
+
+          echo "Installer verification passed for ${{ matrix.platform.name }}"

--- a/.github/workflows/release-verify-builds.yml
+++ b/.github/workflows/release-verify-builds.yml
@@ -2,6 +2,9 @@ name: Release Verify Builds
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - claude-codex-release-troubleshoot-wix
 
 concurrency:
   group: release-verify-${{ github.ref }}

--- a/.github/workflows/release-verify-builds.yml
+++ b/.github/workflows/release-verify-builds.yml
@@ -2,9 +2,6 @@ name: Release Verify Builds
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - claude-codex-release-troubleshoot-wix
 
 concurrency:
   group: release-verify-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # We pass `--target` explicitly on every platform so the sidecar
+        # build (scripts/prepare-claude-hook-sidecar.mjs, which always uses
+        # `--target <triple>`) and the main Tauri build share the same
+        # `target/<triple>/` directory. Without this, the helper's artifacts
+        # land in `target/<triple>/release/` while Tauri's main build (no
+        # `--target`) writes to `target/release/`, forcing Cargo to recompile
+        # `arborist` and `arborist-types` from scratch a second time.
         platform:
           - name: macos-universal
             os: macos-latest
@@ -133,16 +140,16 @@ jobs:
             args: '--target universal-apple-darwin'
           - name: linux-x86_64
             os: ubuntu-22.04
-            rust-targets: ''
-            args: ''
+            rust-targets: 'x86_64-unknown-linux-gnu'
+            args: '--target x86_64-unknown-linux-gnu'
           - name: windows-x86_64
             # windows-latest currently points at a transitional image
             # (windows-2025-vs2026) where WiX v3 light.exe fails at bundle
             # time. Pin to the last known-good image until the image/tooling
             # regression is resolved upstream.
             os: windows-2025
-            rust-targets: ''
-            args: ''
+            rust-targets: 'x86_64-pc-windows-msvc'
+            args: '--target x86_64-pc-windows-msvc'
     runs-on: ${{ matrix.platform.os }}
     steps:
       # Check out the exact tag the user requested (normalized by the verify
@@ -271,7 +278,11 @@ jobs:
 
       - name: Build Tauri app
         shell: bash
-        run: pnpm tauri build --config src-tauri/tauri.bundle.conf.json ${{ matrix.platform.args }}
+        # `--verbose` makes the bundler propagate WiX `light.exe` / `candle.exe`
+        # stderr (e.g. ICE0204 / LGHT errors) to the workflow log. Without it,
+        # MSI bundling failures surface only as the opaque
+        # `failed to run … light.exe` line and the actual error is lost.
+        run: pnpm tauri build --verbose --config src-tauri/tauri.bundle.conf.json ${{ matrix.platform.args }}
 
       - name: Find release artifacts
         id: tauri

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,11 @@ jobs:
             rust-targets: ''
             args: ''
           - name: windows-x86_64
-            os: windows-latest
+            # windows-latest currently points at a transitional image
+            # (windows-2025-vs2026) where WiX v3 light.exe fails at bundle
+            # time. Pin to the last known-good image until the image/tooling
+            # regression is resolved upstream.
+            os: windows-2025
             rust-targets: ''
             args: ''
     runs-on: ${{ matrix.platform.os }}
@@ -206,10 +210,8 @@ jobs:
         if: runner.os == 'macOS'
         run: echo "RUSTFLAGS=" >> "$GITHUB_ENV"
 
-      # On windows-latest (currently windows-2025-vs2026), the auto-downloaded
-      # WiX binaries under %LOCALAPPDATA%\tauri can fail to execute. Prefer the
-      # runner-installed WiX and only install via Chocolatey if candle.exe is
-      # missing.
+      # Prefer runner-installed WiX and only install via Chocolatey when the
+      # image does not already include candle.exe.
       - name: Configure WiX toolset for bundling
         if: runner.os == 'Windows'
         shell: pwsh
@@ -220,7 +222,8 @@ jobs:
             $candle = Get-Command candle.exe -ErrorAction Stop
           }
           $wixBin = Split-Path $candle.Source
-          "WIX=$wixBin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          $wixRoot = Split-Path $wixBin
+          "WIX=$wixRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - run: pnpm install --frozen-lockfile
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arborist-claude-hook"
+version = "0.1.11"
+dependencies = [
+ "fs2",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "arborist-types"
 version = "0.1.11"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/arborist-types", "src-tauri"]
+members = ["crates/arborist-types", "crates/arborist-claude-hook", "src-tauri"]
 
 # Smaller debug info for the local crate, no debug info for deps. Speeds up
 # the link step and shrinks PDB / DWARF output without losing line numbers in

--- a/crates/arborist-claude-hook/Cargo.toml
+++ b/crates/arborist-claude-hook/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "arborist-claude-hook"
+version = "0.1.11"
+edition = "2021"
+description = "Claude Code hook handler sidecar invoked by the Arborist app to translate Claude hook payloads into the per-session events JSONL."
+authors = ["Aaron Moore", "Arborist contributors"]
+license = "MIT"
+repository = "https://github.com/mcaden/arborist"
+homepage = "https://arborist.tools"
+readme = "../../README.md"
+publish = false
+
+# Lives in its own workspace crate (not as a `[[bin]]` of the `arborist` package) on purpose. Tauri's MSI bundler
+# (`crates/tauri-bundler/src/bundle/windows/msi/mod.rs::generate_binaries_data`) emits one WiX `<Component>` per
+# entry in `settings.external_binaries()` AND another per non-main entry in `settings.binaries()` (the active
+# package's Cargo bin list). Having `arborist-claude-hook` in both lists generated two components installing the
+# same `arborist-claude-hook.exe` into `INSTALLDIR`, which `light.exe` rejects with `LGHT0204: ICE30` because
+# Windows treats `arborist_claude_hook` and `arborist_claude_hook.exe` as colliding component identities on an
+# LFN volume. Moving the sidecar out of the `arborist` package removes the second component entirely while the
+# `externalBin = ["binaries/arborist-claude-hook"]` overlay continues to bundle the staged file.
+
+[[bin]]
+name = "arborist-claude-hook"
+path = "src/main.rs"
+
+[dependencies]
+fs2 = "0.4"
+serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/arborist-claude-hook/src/main.rs
+++ b/crates/arborist-claude-hook/src/main.rs
@@ -38,6 +38,13 @@
 //!
 //! Per the implementation plan: the binary is bundled alongside `arborist.exe` so Tauri-installed deployments find it next to the main app. A
 //! subcommand of `arborist` would force every hook fire to load the Tauri runtime — pointless overhead for what should be a sub-millisecond write.
+//!
+//! ## Why a separate crate (not a `[[bin]]` of the `arborist` package)
+//!
+//! See the comment block on this crate's `Cargo.toml`. Tauri's MSI bundler emits one WiX component per entry in `settings.external_binaries()`
+//! **and** another per non-main entry in `settings.binaries()` (the active package's Cargo bin list). Keeping the sidecar in its own crate keeps
+//! it out of the latter, so the only WiX component that bundles `arborist-claude-hook.exe` is the externalBin one — avoiding the `LGHT0204:
+//! ICE30` duplicate-component error.
 
 use std::io::{Read, Write};
 use std::path::PathBuf;

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -3,6 +3,9 @@
 Arborist releases are built by the manual `Release` GitHub Actions workflow from an existing tag on `main`. The workflow uploads artifacts to a draft
 GitHub Release and generates GitHub build attestations.
 
+For branch-level validation (without publishing), use the manual `Release Verify Builds` workflow. It can be run from any branch and verifies macOS,
+Windows, and Linux installer artifacts are produced.
+
 ## Version convention
 
 The version in manifests on `main` is always the **upcoming** release version. When you're ready to release, the `release:prep` script tags the current
@@ -148,7 +151,13 @@ Attestations prove the artifact was produced by the repository workflow for the 
 
 ## Dry runs
 
-Use a throwaway tag to validate workflow changes. Delete the draft release and tag afterward.
+Use the manual `Release Verify Builds` workflow to validate release build changes without creating a draft release.
+
+```sh
+gh workflow run release-verify-builds.yml
+```
+
+Use a throwaway tag with `Release` only when you specifically need to exercise draft release creation or attestation/upload behavior.
 
 Run a dry release whenever release workflow action pins change, especially for Tauri publishing or build-attestation actions. The workflow pins every
 `uses:` dependency to a full commit SHA with an inline comment naming the upstream action ref; Dependabot opens update PRs, but maintainers should verify

--- a/scripts/prepare-claude-hook-sidecar.mjs
+++ b/scripts/prepare-claude-hook-sidecar.mjs
@@ -5,7 +5,7 @@
 // `tauri.conf.json::bundle.externalBin`. `externalBin` expects each binary to live at `<base>-<target-triple>{.exe}` relative to the
 // `tauri.conf.json` directory. This script:
 //
-//   1. Runs `cargo build --release --bin arborist-claude-hook` so the artifact exists on disk regardless of whether the surrounding `tauri build`
+//   1. Runs `cargo build --release -p arborist-claude-hook` so the artifact exists on disk regardless of whether the surrounding `tauri build`
 //      invocation passed `--bin arborist` (which it does — Tauri's CLI restricts the cargo target).
 //   2. Asks Cargo for the workspace `target_directory` (it differs between a standalone crate and a workspace member — this repo is a workspace
 //      and builds into the *repo-root* `target/`, not `src-tauri/target/`), resolves the active Tauri build target triple, and builds the helper
@@ -99,7 +99,7 @@ function helperBuildEnv() {
 
 function buildHelperForTarget(targetDir, targetTriple) {
   console.log(`[prepare-claude-hook-sidecar] building arborist-claude-hook (release, target=${targetTriple})…`);
-  execFileSync(cargoBin('cargo'), ['build', '--release', '--bin', 'arborist-claude-hook', '--target', targetTriple], {
+  execFileSync(cargoBin('cargo'), ['build', '--release', '-p', 'arborist-claude-hook', '--target', targetTriple], {
     cwd: tauriDir,
     env: helperBuildEnv(),
     stdio: 'inherit',

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -11,7 +11,7 @@
 //     binds to the right port (no env var required).
 //   - `build.devUrl` is set to the matching URL so the desktop shell loads it.
 //
-// Sidecar build: before launching `tauri dev`, we run `cargo build --bin
+// Sidecar build: before launching `tauri dev`, we run `cargo build -p
 // arborist-claude-hook` so the helper binary exists at `target/debug/` as a
 // sibling of the about-to-be-built `arborist` binary. `tauri dev` only
 // compiles the main `arborist` target via cargo, so without this step the
@@ -90,7 +90,7 @@ const projectRoot = join(__dirname, '..');
 const tauriDir = join(projectRoot, 'src-tauri');
 console.log('[arborist] building arborist-claude-hook (debug)…');
 try {
-  execFileSync(cargoBin(), ['build', '--bin', 'arborist-claude-hook'], {
+  execFileSync(cargoBin(), ['build', '-p', 'arborist-claude-hook'], {
     cwd: tauriDir,
     stdio: 'inherit',
   });

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,19 +19,18 @@ path = "src/lib.rs"
 name = "arborist"
 path = "src/main.rs"
 
-# Helper invoked by Claude Code hooks (registered via `--settings`). Reads the
-# hook payload from stdin and appends a structured JSONL line to the per-session
-# `hook-events.jsonl` that `claude_hook_events.rs` tails. Production-built and
-# shipped alongside `arborist` in the bundle. Placed under `src/bin_hook/` for
-# the same reason the test bins below live under `src/test_bin/`: Tauri's CLI
-# auto-discovers everything under `src/bin/` as a bundle target, and we want to
-# control bundling explicitly via `src-tauri/tauri.bundle.conf.json` (an
-# overlay merged in only for `pnpm tauri:build` — the base `tauri.conf.json`
-# stays free of `externalBin` so plain `cargo build` / `tauri dev` don't
-# require the helper to be pre-staged in `src-tauri/binaries/`).
-[[bin]]
-name = "arborist-claude-hook"
-path = "src/bin_hook/arborist_claude_hook.rs"
+# Helper invoked by Claude Code hooks (registered via `--settings`) lives in its own workspace crate at
+# `crates/arborist-claude-hook/` — NOT as a `[[bin]]` of this package. Tauri's MSI bundler
+# (`crates/tauri-bundler/src/bundle/windows/msi/mod.rs::generate_binaries_data`) emits one WiX
+# `<Component>` per entry in `settings.external_binaries()` AND another per non-main entry in
+# `settings.binaries()` (the active package's Cargo bin list). If the sidecar were declared here
+# both would fire, producing two components installing the same `arborist-claude-hook.exe` into
+# `INSTALLDIR` and tripping `light.exe` with `LGHT0204: ICE30` (the LFN component-collision error
+# at https://github.com/tauri-apps/tauri/issues/6209). Keeping the sidecar in its own crate keeps
+# it out of `settings.binaries()` so only the `externalBin = ["binaries/arborist-claude-hook"]`
+# overlay-driven component bundles the file. See the crate README/Cargo.toml for the staging
+# script that turns `target/<triple>/release/arborist-claude-hook[.exe]` into the
+# `src-tauri/binaries/arborist-claude-hook-<triple>[.exe]` shape `externalBin` expects.
 
 # Purpose-built deterministic child process used by the PTY-pool integration
 # tests (`tests/pty_pool.rs`). Gated behind the `test-helpers` feature so


### PR DESCRIPTION
## Summary
- pin the release Windows runner to `windows-2025` to avoid `windows-latest` WiX `light.exe` bundling failures
- set the release workflow `WIX` env var to the WiX root directory
- add a manual `Release Verify Builds` workflow that builds macOS, Windows, and Linux installers without publishing a release
- document the new validation workflow in `docs/releasing.md`

## Validation
- `pnpm run lint`
- local git hooks (pre-commit and pre-push) executed during commit/push