### PR TITLE
[dependency-audit] chore(deps): trim unused Rust dependency features, drop fs2, bump Tauri to 2.11.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,6 @@ dependencies = [
  "arborist-types",
  "base64 0.22.1",
  "dunce",
- "fs2",
  "libc",
  "png 0.17.16",
  "portable-pty",
@@ -83,7 +82,6 @@ dependencies = [
 name = "arborist-claude-hook"
 version = "0.1.11"
 dependencies = [
- "fs2",
  "serde_json",
  "tempfile",
 ]
@@ -888,16 +886,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -1885,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae8844f63b5b118e334e205585b8c5c17b984121dbdb179d44aeb087ffad3cb"
+checksum = "47a2e3dff89cd322c66647942668faee0a2b1f88ea6cbb4d374b4a8d7e92528c"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -3383,9 +3371,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.11.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93bd86d231f0a8138f11a02a584769fe4b703dc36ae133d783228dbc4801405"
+checksum = "437404997acf375d85f1177afa7e11bb971f274ed6a7b83a2a3e339015f4cc28"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3434,9 +3422,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.6.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a318b234cc2dea65f575467bafcfb76286bce228ebc3778e337d61d03213007"
+checksum = "4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -3455,9 +3443,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.6.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd11644962add2549a60b7e7c6800f17d7020156e02f516021d8103e80cc528"
+checksum = "e4a0319528a025a38c4078e7dae2c446f4e63620ddb0659a643ede1cb38f90e9"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -3482,9 +3470,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.6.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed9d3742a37a355d2e47c9af924e9fbc112abb76f9835d35d4780e318419502"
+checksum = "ae6cb4e3896c21d2f6da5b31251d2faea0153bba56ed0e970f918115dbee4924"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3570,9 +3558,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.11.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fef478ba1d2ac21c2d528740b24d0cb315e1e8b1111aae53fafac34804371fc"
+checksum = "48222d7116c8807eaa6fe2f372e023fae125084e61e6eca6d70b7961cdf129ef"
 dependencies = [
  "cookie",
  "dpi",
@@ -3595,9 +3583,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.11.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
+checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http",
@@ -3621,9 +3609,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d57200389a2f82b4b0a40ae29ca19b6978116e8f4d4e974c3234ce40c0ffbdec"
+checksum = "092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95"
 dependencies = [
  "anyhow",
  "brotli",
@@ -3826,7 +3814,6 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/crates/arborist-claude-hook/Cargo.toml
+++ b/crates/arborist-claude-hook/Cargo.toml
@@ -24,7 +24,6 @@ name = "arborist-claude-hook"
 path = "src/main.rs"
 
 [dependencies]
-fs2 = "0.4"
 serde_json = "1"
 
 [dev-dependencies]

--- a/crates/arborist-claude-hook/src/main.rs
+++ b/crates/arborist-claude-hook/src/main.rs
@@ -32,7 +32,7 @@
 //! ## Concurrency
 //!
 //! Claude can fire multiple hooks concurrently in a session (e.g. parallel tool calls). Each invocation acquires an OS advisory write lock
-//! (`fs2::FileExt::lock_exclusive`) on the events file for the brief append, so concurrent writers serialise without losing lines.
+//! (`std::fs::File::lock`) on the events file for the brief append, so concurrent writers serialise without losing lines.
 //!
 //! ## Why a separate binary (not a subcommand of `arborist`)
 //!
@@ -50,8 +50,6 @@ use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::time::{SystemTime, UNIX_EPOCH};
-
-use fs2::FileExt;
 
 fn main() -> ExitCode {
     // Args: program, event, arborist-session-id, events-jsonl-path. Any error here is silent — see the module docs for why we always exit 0.
@@ -220,7 +218,7 @@ fn try_append_locked(path: &std::path::Path, line: &str) -> std::io::Result<()> 
         .write(true)
         .truncate(false)
         .open(path)?;
-    f.lock_exclusive()?;
+    f.lock()?;
     // Seek to end *after* taking the lock so a concurrent process that beat us to write doesn't make us overwrite its bytes.
     let res = f.seek(std::io::SeekFrom::End(0)).and_then(|_| f.write_all(line.as_bytes()));
     let _ = f.unlock();

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -69,13 +69,19 @@ arborist-types = { path = "../crates/arborist-types" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
-tokio = { version = "1", features = ["sync", "rt", "macros", "time", "rt-multi-thread", "process", "io-util"] }
+tokio = { version = "1", features = ["sync", "rt", "macros", "time", "rt-multi-thread", "process"] }
+# Note: do NOT bump to 0.9 without a strategy for the new `PSUEDOCONSOLE_INHERIT_CURSOR`
+# flag enabled in 0.9 on Windows. The flag makes ConPTY emit a DSR cursor-position query
+# (`ESC [ 6 n`) at startup and stall stdout until the terminal host responds. xterm.js in
+# production answers, but the `recording_sink` used by `tests/pty_pool.rs` does not, so all
+# real-PTY tests time out waiting on the banner. See the dependency-audit branch for the
+# investigation that revealed this. Saving the ~4 transitive crates that 0.9 drops
+# (serial/serial-core/serial-windows/memoffset) is not worth the regression.
 portable-pty = "0.8"
 uuid = { version = "1", features = ["v4", "serde"] }
 tempfile = "3"
 dunce = "1"
 sha2 = "0.10"
-fs2 = "0.4"
 # `rfd` is used directly for boot-time dialogs and the runtime `dialog_pick_directory`
 # command. Keep `default-features = false` and explicitly enable `gtk3` to avoid
 # backend auto-selection surprises on Linux.
@@ -83,7 +89,7 @@ rfd = { version = "0.17", default-features = false, features = ["gtk3"] }
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "registry"] }
-tokio-util = { version = "0.7", features = ["rt"] }
+tokio-util = "0.7"
 base64 = "0.22"
 
 [target.'cfg(unix)'.dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -70,12 +70,15 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["sync", "rt", "macros", "time", "rt-multi-thread", "process"] }
-# Note: do NOT bump to 0.9 without a strategy for the new `PSUEDOCONSOLE_INHERIT_CURSOR`
-# flag enabled in 0.9 on Windows. The flag makes ConPTY emit a DSR cursor-position query
-# (`ESC [ 6 n`) at startup and stall stdout until the terminal host responds. xterm.js in
-# production answers, but the `recording_sink` used by `tests/pty_pool.rs` does not, so all
-# real-PTY tests time out waiting on the banner. See the dependency-audit branch for the
-# investigation that revealed this. Saving the ~4 transitive crates that 0.9 drops
+# Note: do NOT bump to 0.9 without a strategy for the new `PSEUDOCONSOLE_INHERIT_CURSOR`
+# flag enabled in 0.9 on Windows. (The flag is misspelled `PSUEDOCONSOLE_INHERIT_CURSOR`
+# in portable-pty 0.9.0's `psuedocon.rs`; the canonical Microsoft Windows API name is
+# `PSEUDOCONSOLE_INHERIT_CURSOR` — use that spelling when searching upstream docs.) The
+# flag makes ConPTY emit a DSR cursor-position query (`ESC [ 6 n`) at startup and stall
+# stdout until the terminal host responds. xterm.js in production answers, but the
+# `recording_sink` used by `tests/pty_pool.rs` does not, so all real-PTY tests time out
+# waiting on the banner. See the dependency-audit branch for the investigation that
+# revealed this. Saving the ~4 transitive crates that 0.9 drops
 # (serial/serial-core/serial-windows/memoffset) is not worth the regression.
 portable-pty = "0.8"
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/src-tauri/src/workspace_lock.rs
+++ b/src-tauri/src/workspace_lock.rs
@@ -76,7 +76,7 @@ impl Drop for WorkspaceLockGuard {
 }
 
 impl WorkspaceLockGuard {
-    /// Try to acquire an exclusive lock on `lock_path`. Non-blocking (`try_lock_exclusive`); contention returns
+    /// Try to acquire an exclusive lock on `lock_path`. Non-blocking (`File::try_lock`); contention returns
     /// [`LockError::Contention`] rather than blocking.
     ///
     /// Creates `lock_path` and any missing parent directories. Hold the returned guard for the lifetime of the bound (branch, workspace) scope.
@@ -181,7 +181,7 @@ mod tests {
     }
 
     /// Same-process double-acquire MUST return `Contention` on Windows, where `LockFileEx` semantics are per-handle. On Unix, `flock(2)` is
-    /// per-process: a second `try_lock_exclusive` from the same PID against the same inode succeeds even via a separate `File` handle. The
+    /// per-process: a second `File::try_lock` from the same PID against the same inode succeeds even via a separate `File` handle. The
     /// cross-process guarantee that matters at boot is verified by the multi-process integration test in `tests/workspace_lock_multiprocess.rs`,
     /// which spawns `arborist-test-locker` as a real second process.
     #[cfg(target_os = "windows")]

--- a/src-tauri/src/workspace_lock.rs
+++ b/src-tauri/src/workspace_lock.rs
@@ -9,16 +9,16 @@
 //!
 //! ## Handle ownership (Windows footgun)
 //!
-//! Hold the locked `File` handle for the lifetime of the lock; do NOT clone or duplicate it. `fs2` documents that lock state is tied to the
-//! underlying OS handle, so duplicating it can produce surprising behaviour around release. The guard's inner `File` is private and not exposed.
+//! Hold the locked `File` handle for the lifetime of the lock; do NOT clone or duplicate it. `std::fs::File::lock` documents that lock state is tied
+//! to the underlying OS handle, so duplicating it can produce surprising behaviour around release. The guard's inner `File` is private and not
+//! exposed.
 //!
 //! ## Crash semantics
 //!
 //! When the process exits (cleanly or by crash), the OS closes its file handles, which releases the lock. There is no stale-lock cleanup needed.
 //! Verified by [`tests::acquire_after_drop_succeeds`].
 
-use fs2::FileExt as _;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, File, OpenOptions, TryLockError};
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -65,10 +65,11 @@ pub struct WorkspaceLockGuard {
 }
 
 impl Drop for WorkspaceLockGuard {
-    /// Explicitly release the OS-level advisory lock before the inner `File` is dropped. Closing the handle would also release the lock (per `fs2`'s
-    /// contract), but on some Unix platforms closing *any* fd referring to the file is sufficient to release all `flock()`s held against that inode —
-    /// calling `unlock()` here makes the release point deterministic and matches the safety note inside [`Self::acquire_inner`]. Errors are
-    /// swallowed: if the file handle is already closed or the OS rejects the request, the subsequent `File` drop will release anyway.
+    /// Explicitly release the OS-level advisory lock before the inner `File` is dropped. Closing the handle would also release the lock (per the
+    /// `std::fs::File::lock` contract), but on some Unix platforms closing *any* fd referring to the file is sufficient to release all `flock()`s
+    /// held against that inode — calling `unlock()` here makes the release point deterministic and matches the safety note inside
+    /// [`Self::acquire_inner`]. Errors are swallowed: if the file handle is already closed or the OS rejects the request, the subsequent `File` drop
+    /// will release anyway.
     fn drop(&mut self) {
         let _ = self._file.unlock();
     }
@@ -106,19 +107,23 @@ impl WorkspaceLockGuard {
             .truncate(false)
             .open(&lock_path)
             .map_err(LockError::Io)?;
-        let result = if blocking { file.lock_exclusive() } else { file.try_lock_exclusive() };
-        // SAFETY: code between a successful `lock_exclusive()` / `try_lock_exclusive()` and the `Ok(Self { ... })` return MUST NOT panic. If it did,
-        // the raw `file` would be dropped *outside* a `WorkspaceLockGuard`, so the explicit `unlock()` in `WorkspaceLockGuard::Drop` (defined below)
-        // wouldn't fire; the OS lock would still be released when the OS reclaims the handle, but the release point would no longer be deterministic.
-        // The current branches only do infallible moves; keep it that way.
-        match result {
-            Ok(()) => Ok(Self {
-                _file: file,
-                path: lock_path,
-            }),
-            Err(e) if !blocking && is_contention_error(&e) => Err(LockError::Contention),
-            Err(e) => Err(LockError::Io(e)),
+        // SAFETY: code between a successful `lock()` / `try_lock()` and the `Ok(Self { ... })` return MUST NOT panic. If it did, the raw `file` would
+        // be dropped *outside* a `WorkspaceLockGuard`, so the explicit `unlock()` in `WorkspaceLockGuard::Drop` (defined above) wouldn't fire; the OS
+        // lock would still be released when the OS reclaims the handle, but the release point would no longer be deterministic. The current branches
+        // only do infallible moves; keep it that way.
+        if blocking {
+            file.lock().map_err(LockError::Io)?;
+        } else {
+            match file.try_lock() {
+                Ok(()) => {}
+                Err(TryLockError::WouldBlock) => return Err(LockError::Contention),
+                Err(TryLockError::Error(e)) => return Err(LockError::Io(e)),
+            }
         }
+        Ok(Self {
+            _file: file,
+            path: lock_path,
+        })
     }
 
     /// Path of the lock file this guard holds. Useful for diagnostics and for log messages identifying which (branch, workspace) is bound to the
@@ -158,15 +163,9 @@ impl WorkspaceLockGuard {
     }
 }
 
-/// Cross-platform detection of "lock is held by someone else" vs a real I/O failure on `try_lock_exclusive`.
-///
-/// Unix returns `WouldBlock`; Windows returns a different OS error code (`ERROR_LOCK_VIOLATION` / `ERROR_IO_PENDING` depending on which lock API).
-/// Rather than hard-code platform-specific kinds, we compare against the platform-correct error that `fs2::lock_contended_error` constructs.
-fn is_contention_error(e: &io::Error) -> bool {
-    let contended = fs2::lock_contended_error();
-    e.kind() == contended.kind() && e.raw_os_error() == contended.raw_os_error()
-}
-
+/// Cross-platform detection of "lock is held by someone else" vs a real I/O failure is now handled directly by [`std::fs::TryLockError`] — the
+/// `WouldBlock` variant means "another holder right now", any other variant is a real I/O failure. See the `try_lock` branch in
+/// [`WorkspaceLockGuard::acquire_inner`].
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Audit of the Rust dependency graph turned up four low-risk wins that shrink the production tree without changing behaviour. Rebased onto `main` (#199) so it now runs against the new `cargo-deny` advisory job; **`cargo deny check advisories licenses` is green**.

## Changes

### Drop `tokio/io-util` feature
Nothing in the codebase uses `AsyncReadExt`/`AsyncWriteExt`. The PTY pool shuttles bytes through `std::thread` + bounded mpsc channels and never calls into tokio I/O combinators.

### Drop `tokio-util/rt` feature
We only use `tokio-util` for `CancellationToken`, which is behind default features. The `rt` feature was pulling `futures-util` into the production build for no reason. Post-change, `futures-util` is only reachable via dev-deps (`rstest`, `serial_test`).

### Replace `fs2` with stdlib file locks
`File::lock` / `File::try_lock` / `TryLockError` stabilized in Rust 1.89. This deletes the direct `fs2` dependency from **both** the main `arborist` crate and the `arborist-claude-hook` sidecar crate, and removes the transitive `fs2 v0.4.x` entirely from the production graph.
- `workspace_lock::acquire_inner` now matches explicitly on `TryLockError::WouldBlock` vs `TryLockError::Error` instead of going through a hand-rolled `is_contention_error` helper.
- `arborist_claude_hook::try_append_locked` calls `f.lock()` directly; the module-doc reference is updated to `std::fs::File::lock`.

### Bump Tauri 2.11.1 → 2.11.2
Pulls in the small upstream bugfix release and corresponding transitives:
- `tauri 2.11.1 → 2.11.2`
- `tauri-utils 2.9.1 → 2.9.2`
- `tauri-runtime` / `tauri-runtime-wry 2.11.1 → 2.11.2`
- `tauri-build` / `tauri-codegen` / `tauri-macros 2.6.1 → 2.6.2`
- `muda 0.19.1 → 0.19.2`

This does **not** address any of the RUSTSEC advisories tracked in `deny.toml` (the gtk3 and `urlpattern` stacks are unchanged), but it keeps us current.

## What's NOT included (and why)

I also tried bumping **`portable-pty` 0.8 → 0.9**, which would drop four transitive crates (`serial`, `serial-core`, `serial-windows`, `memoffset`). **Reverted** because 0.9 unconditionally enables `PSUEDOCONSOLE_INHERIT_CURSOR` on Windows ConPTY, which makes the pseudo console emit a DSR cursor-position query (`ESC [ 6 n`) at startup and stall stdout until the terminal host responds. xterm.js answers in production, but the `recording_sink` in `tests/pty_pool.rs` does not, so all seven real-PTY integration tests hang waiting on the test child's banner. A comment next to the `portable-pty = "0.8"` line documents the constraint for future bump attempts.

Other duplicate-version groups in the graph (`bitflags 1.x` & `2.x`, `thiserror 1` & `2`, `hashbrown`, `indexmap`, `toml`, `winnow`, `windows-sys`, `winreg`) are all locked by `tauri-build` / `tauri-codegen` / `tauri-utils` / `tauri-winres` / `window-vibrancy` / `tauri-plugin-dialog → rfd 0.16` — not actionable until the Tauri ecosystem moves.

## Verification

- `cargo deny check advisories licenses` → **advisories ok, licenses ok**
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets --features test-helpers -- -D warnings` ✓
- `cargo test --workspace --features test-helpers` → **815 passed, 0 failed**
- `pnpm run lint` ✓
- `pnpm test --run` → **683 passed**
- `pnpm run build` ✓

## Dep-graph delta (production normal edges only)

- `fs2 v0.4` — removed from both `arborist` and `arborist-claude-hook`
- `futures-util` — no longer in `arborist` production normal edges (still pulled by dev-deps)
- `tokio` feature set trimmed by one (`io-util` gone)
- `tokio-util` runs on default features only
- `tauri` 2.11.1 → 2.11.2 (and corresponding sub-crates)