### PR TITLE
[release-build-warnings] Clean up release build warnings (#207)

### DIFF
--- a/.github/workflows/release-verify-builds.yml
+++ b/.github/workflows/release-verify-builds.yml
@@ -75,10 +75,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-release-verify-${{ matrix.platform.name }}-cargo-
 
-      # Tauri's Linux build needs system libraries (must match ci.yml). `lld`
-      # + `clang` are required by the workspace `.cargo/config.toml` for the
-      # faster linker. `appstream` provides `appstreamcli` used by `linuxdeploy-plugin-appimage` to validate the bundled AppStream metainfo file
-      # (see `src-tauri/metainfo/`); without it the release log emits "appstreamcli command is missing" — see issue #207.
+      # Tauri's Linux build needs system libraries — the baseline list is owned by `rust.yml` (the apt-get step in its `rust` job);
+      # this release-verify job extends it with `appstream`. `lld` + `clang` are required by the workspace `.cargo/config.toml`
+      # for the faster linker. `appstream` provides `appstreamcli` used by `linuxdeploy-plugin-appimage` to validate the bundled
+      # AppStream metainfo file (see `src-tauri/metainfo/`); without it the release log emits "appstreamcli command is missing" — see issue #207.
       - name: Install Linux build dependencies
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/release-verify-builds.yml
+++ b/.github/workflows/release-verify-builds.yml
@@ -77,10 +77,8 @@ jobs:
 
       # Tauri's Linux build needs system libraries (must match ci.yml). `lld`
       # + `clang` are required by the workspace `.cargo/config.toml` for the
-      # faster linker. `appstream` provides `appstreamcli` used by
-      # `linuxdeploy-plugin-appimage` to validate the bundled AppStream
-      # metainfo file (see `src-tauri/metainfo/`); without it the release log
-      # emits "appstreamcli command is missing" — see issue #207.
+      # faster linker. `appstream` provides `appstreamcli` used by `linuxdeploy-plugin-appimage` to validate the bundled AppStream metainfo file
+      # (see `src-tauri/metainfo/`); without it the release log emits "appstreamcli command is missing" — see issue #207.
       - name: Install Linux build dependencies
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/release-verify-builds.yml
+++ b/.github/workflows/release-verify-builds.yml
@@ -77,7 +77,10 @@ jobs:
 
       # Tauri's Linux build needs system libraries (must match ci.yml). `lld`
       # + `clang` are required by the workspace `.cargo/config.toml` for the
-      # faster linker.
+      # faster linker. `appstream` provides `appstreamcli` used by
+      # `linuxdeploy-plugin-appimage` to validate the bundled AppStream
+      # metainfo file (see `src-tauri/metainfo/`); without it the release log
+      # emits "appstreamcli command is missing" — see issue #207.
       - name: Install Linux build dependencies
         if: runner.os == 'Linux'
         run: |
@@ -91,7 +94,8 @@ jobs:
             librsvg2-dev \
             libxdo-dev \
             libssl-dev \
-            build-essential
+            build-essential \
+            appstream
 
       # macOS: `.cargo/config.toml` sets `-fuse-ld=lld` via per-target
       # rustflags for faster dev builds. GitHub runners don't have lld for

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,10 @@ jobs:
 
       # Tauri's Linux build needs system libraries (must match ci.yml). `lld`
       # + `clang` are required by the workspace `.cargo/config.toml` for the
-      # faster linker.
+      # faster linker. `appstream` provides `appstreamcli` used by
+      # `linuxdeploy-plugin-appimage` to validate the bundled AppStream
+      # metainfo file (see `src-tauri/metainfo/`); without it the release log
+      # emits "appstreamcli command is missing" — see issue #207.
       - name: Install Linux build dependencies
         if: runner.os == 'Linux'
         run: |
@@ -207,7 +210,8 @@ jobs:
             librsvg2-dev \
             libxdo-dev \
             libssl-dev \
-            build-essential
+            build-essential \
+            appstream
 
       # macOS: `.cargo/config.toml` sets `-fuse-ld=lld` via per-target
       # rustflags for faster dev builds. GitHub runners don't have lld for

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,10 +193,8 @@ jobs:
 
       # Tauri's Linux build needs system libraries (must match ci.yml). `lld`
       # + `clang` are required by the workspace `.cargo/config.toml` for the
-      # faster linker. `appstream` provides `appstreamcli` used by
-      # `linuxdeploy-plugin-appimage` to validate the bundled AppStream
-      # metainfo file (see `src-tauri/metainfo/`); without it the release log
-      # emits "appstreamcli command is missing" — see issue #207.
+      # faster linker. `appstream` provides `appstreamcli` used by `linuxdeploy-plugin-appimage` to validate the bundled AppStream metainfo file
+      # (see `src-tauri/metainfo/`); without it the release log emits "appstreamcli command is missing" — see issue #207.
       - name: Install Linux build dependencies
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,10 +191,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-release-${{ matrix.platform.name }}-cargo-
 
-      # Tauri's Linux build needs system libraries (must match ci.yml). `lld`
-      # + `clang` are required by the workspace `.cargo/config.toml` for the
-      # faster linker. `appstream` provides `appstreamcli` used by `linuxdeploy-plugin-appimage` to validate the bundled AppStream metainfo file
-      # (see `src-tauri/metainfo/`); without it the release log emits "appstreamcli command is missing" — see issue #207.
+      # Tauri's Linux build needs system libraries — the baseline list is owned by `rust.yml` (the apt-get step in its `rust` job);
+      # this release job extends it with `appstream`. `lld` + `clang` are required by the workspace `.cargo/config.toml` for the
+      # faster linker. `appstream` provides `appstreamcli` used by `linuxdeploy-plugin-appimage` to validate the bundled
+      # AppStream metainfo file (see `src-tauri/metainfo/`); without it the release log emits "appstreamcli command is missing" — see issue #207.
       - name: Install Linux build dependencies
         if: runner.os == 'Linux'
         run: |

--- a/scripts/release-prep.mjs
+++ b/scripts/release-prep.mjs
@@ -202,23 +202,25 @@ try {
     console.log(`  ${relPath}: ${currentVersion} → ${nextVersion}`);
   }
 
-  // Update the AppStream metainfo `<release>` entry so the Linux bundles
-  // ship metadata that matches the upcoming version. The file lives at
-  // `src-tauri/metainfo/io.github.mcaden.arborist.metainfo.xml` (see
-  // issue #207) and uses a single self-closing `<release version="X" date="Y" />`
-  // line. Date is in `YYYY-MM-DD` UTC so the release log is reproducible.
+  // Update the AppStream metainfo `<release>` entry so the Linux bundles ship metadata that matches the upcoming version. The file lives
+  // at `src-tauri/metainfo/io.github.mcaden.arborist.metainfo.xml` (see issue #207) and uses a single self-closing
+  // `<release version="X" />` line.
+  //
+  // The `date` attribute is intentionally NOT stamped here: this script runs when bumping main to `nextVersion`, but the actual release
+  // of `nextVersion` may happen much later. Stamping today's date would give every released version the date of its bump PR, not its
+  // tag — see PR #216 review feedback. AppStream allows omitting the date; appstreamcli emits at most an info-level
+  // "release-time-missing" hint.
   function updateMetainfo(relPath) {
     const filePath = resolve(root, relPath);
     const content = readFileSync(filePath, 'utf8');
-    const today = new Date().toISOString().slice(0, 10);
-    const re = /<release\s+version="[^"]+"\s+date="[^"]+"\s*\/>/;
+    const re = /<release\s+version="[^"]+"\s*\/>/;
     if (!re.test(content)) {
-      console.error(`  ${relPath}: no <release version="…" date="…" /> entry found!`);
+      console.error(`  ${relPath}: no <release version="…" /> entry found!`);
       process.exit(1);
     }
-    const updated = content.replace(re, `<release version="${nextVersion}" date="${today}" />`);
+    const updated = content.replace(re, `<release version="${nextVersion}" />`);
     writeFileSync(filePath, updated);
-    console.log(`  ${relPath}: ${currentVersion} → ${nextVersion} (date ${today})`);
+    console.log(`  ${relPath}: ${currentVersion} → ${nextVersion}`);
   }
 
   updateJson('package.json', 'version');

--- a/scripts/release-prep.mjs
+++ b/scripts/release-prep.mjs
@@ -202,10 +202,30 @@ try {
     console.log(`  ${relPath}: ${currentVersion} → ${nextVersion}`);
   }
 
+  // Update the AppStream metainfo `<release>` entry so the Linux bundles
+  // ship metadata that matches the upcoming version. The file lives at
+  // `src-tauri/metainfo/io.github.mcaden.arborist.metainfo.xml` (see
+  // issue #207) and uses a single self-closing `<release version="X" date="Y" />`
+  // line. Date is in `YYYY-MM-DD` UTC so the release log is reproducible.
+  function updateMetainfo(relPath) {
+    const filePath = resolve(root, relPath);
+    const content = readFileSync(filePath, 'utf8');
+    const today = new Date().toISOString().slice(0, 10);
+    const re = /<release\s+version="[^"]+"\s+date="[^"]+"\s*\/>/;
+    if (!re.test(content)) {
+      console.error(`  ${relPath}: no <release version="…" date="…" /> entry found!`);
+      process.exit(1);
+    }
+    const updated = content.replace(re, `<release version="${nextVersion}" date="${today}" />`);
+    writeFileSync(filePath, updated);
+    console.log(`  ${relPath}: ${currentVersion} → ${nextVersion} (date ${today})`);
+  }
+
   updateJson('package.json', 'version');
   updateJson('src-tauri/tauri.conf.json', 'version');
   updateCargoToml('src-tauri/Cargo.toml');
   updateCargoToml('crates/arborist-types/Cargo.toml');
+  updateMetainfo('src-tauri/metainfo/io.github.mcaden.arborist.metainfo.xml');
 
   // Update Cargo.lock for workspace crates only
   console.log('\n  Updating Cargo.lock (workspace crates only)...');

--- a/src-tauri/metainfo/io.github.mcaden.arborist.metainfo.xml
+++ b/src-tauri/metainfo/io.github.mcaden.arborist.metainfo.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  AppStream upstream metadata for the Arborist Linux AppImage / .deb / .rpm
+  bundles. This file is copied into `usr/share/metainfo/` of each Linux bundle
+  via the `bundle.linux.{appimage,deb,rpm}.files` map in
+  `src-tauri/tauri.conf.json`. The companion `appstream` apt package (installed
+  in `.github/workflows/release.yml` and `release-verify-builds.yml`) provides
+  the `appstreamcli` validator used by `linuxdeploy-plugin-appimage` so the
+  release build log no longer emits the
+  "AppStream upstream metadata is missing" / "appstreamcli command is missing"
+  warnings tracked in issue #207.
+
+  The component `<id>` is rDNS-style and matches the app `identifier`
+  configured in `tauri.conf.json` (`io.github.mcaden.arborist`).
+  `<launchable>` references the actual desktop entry filename emitted by the
+  Tauri bundler (`Arborist.desktop`, derived from `productName`).
+
+  Copyright (c) 2026 Aaron Moore. Metadata licensed under CC0-1.0; the project
+  itself is MIT-licensed (see `<project_license>` below).
+-->
+<component type="desktop-application">
+  <id>io.github.mcaden.arborist</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>Arborist</name>
+  <summary>Manage AI coding-assistant sessions across Git worktrees</summary>
+
+  <description>
+    <p>
+      Arborist is a cross-platform desktop app that manages multiple Claude CLI,
+      GitHub Copilot CLI, and custom process sessions, each bound to its own
+      Git worktree. The sidebar shows worktree tabs with child AI-agent
+      sessions, and the main area shows one PTY terminal at a time while every
+      session keeps running in the background.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>One persistent PTY per session, surviving tab switches.</li>
+      <li>Native Git worktree integration for parallel feature work.</li>
+      <li>Launches Claude CLI, GitHub Copilot CLI, OpenAI Codex, and custom processes.</li>
+      <li>Restore-on-launch resumes every prior session in place.</li>
+    </ul>
+  </description>
+
+  <launchable type="desktop-id">Arborist.desktop</launchable>
+
+  <url type="homepage">https://arborist.tools</url>
+  <url type="bugtracker">https://github.com/mcaden/arborist/issues</url>
+  <url type="vcs-browser">https://github.com/mcaden/arborist</url>
+
+  <developer id="io.github.mcaden">
+    <name>Aaron Moore</name>
+  </developer>
+
+  <categories>
+    <category>Development</category>
+    <category>Utility</category>
+  </categories>
+
+  <keywords>
+    <keyword>git</keyword>
+    <keyword>worktree</keyword>
+    <keyword>ai</keyword>
+    <keyword>terminal</keyword>
+    <keyword>claude</keyword>
+    <keyword>copilot</keyword>
+    <keyword>codex</keyword>
+  </keywords>
+
+  <provides>
+    <binary>arborist</binary>
+  </provides>
+
+  <!--
+    OARS content rating: developer tool with no objectionable content. All
+    categories default to "none" when omitted; an empty element is the
+    standard way to declare this for AppStream 1.0+.
+  -->
+  <content_rating type="oars-1.1" />
+
+  <!--
+    Releases are intentionally minimal: AppStream 1.0+ permits a single
+    `<release>` entry, and we update it alongside the version bumps in
+    `package.json` / `Cargo.toml` / `tauri.conf.json` during release prep.
+    See `scripts/release-prep.mjs`.
+  -->
+  <releases>
+    <release version="0.1.12" date="2026-05-21" />
+  </releases>
+</component>

--- a/src-tauri/metainfo/io.github.mcaden.arborist.metainfo.xml
+++ b/src-tauri/metainfo/io.github.mcaden.arborist.metainfo.xml
@@ -80,11 +80,17 @@
 
   <!--
     Releases are intentionally minimal: AppStream 1.0+ permits a single
-    `<release>` entry, and we update it alongside the version bumps in
-    `package.json` / `Cargo.toml` / `tauri.conf.json` during release prep.
-    See `scripts/release-prep.mjs`.
+    `<release>` entry, and we update the version in lockstep with the four
+    version manifests during release prep. See `scripts/release-prep.mjs`.
+
+    The `date` attribute is intentionally omitted: the metainfo file is
+    bumped to the *next* version at the same time as the bump PR, but the
+    actual release tag may not be cut until much later, so any date we
+    stamped at bump time would belong to the previous release's day rather
+    than this one. The AppStream spec allows omitting the date (appstreamcli
+    emits at most an info-level "release-time-missing" hint).
   -->
   <releases>
-    <release version="0.1.12" date="2026-05-21" />
+    <release version="0.1.12" />
   </releases>
 </component>

--- a/src-tauri/metainfo/io.github.mcaden.arborist.metainfo.xml
+++ b/src-tauri/metainfo/io.github.mcaden.arborist.metainfo.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   AppStream upstream metadata for the Arborist Linux AppImage / .deb / .rpm
-  bundles. This file is copied into `usr/share/metainfo/` of each Linux bundle
-  via the `bundle.linux.{appimage,deb,rpm}.files` map in
-  `src-tauri/tauri.conf.json`. The companion `appstream` apt package (installed
+  bundles. This file is copied into `/usr/share/metainfo/` of each Linux
+  bundle via the `bundle.linux.{appimage,deb,rpm}.files` map in
+  `src-tauri/tauri.conf.json` (absolute paths used uniformly — AppImage and
+  .deb strip the leading `/` internally, but the `rpm-rs` crate stores the
+  path verbatim and needs an absolute target for the installer to land the
+  file in the right place). The companion `appstream` apt package (installed
   in `.github/workflows/release.yml` and `release-verify-builds.yml`) provides
   the `appstreamcli` validator used by `linuxdeploy-plugin-appimage` so the
   release build log no longer emits the

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -91,7 +91,7 @@
     "linux": {
       "appimage": {
         "files": {
-          "usr/share/metainfo/io.github.mcaden.arborist.metainfo.xml": "metainfo/io.github.mcaden.arborist.metainfo.xml"
+          "/usr/share/metainfo/io.github.mcaden.arborist.metainfo.xml": "metainfo/io.github.mcaden.arborist.metainfo.xml"
         }
       },
       "deb": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -87,6 +87,23 @@
           "height": 400
         }
       }
+    },
+    "linux": {
+      "appimage": {
+        "files": {
+          "usr/share/metainfo/io.github.mcaden.arborist.metainfo.xml": "metainfo/io.github.mcaden.arborist.metainfo.xml"
+        }
+      },
+      "deb": {
+        "files": {
+          "/usr/share/metainfo/io.github.mcaden.arborist.metainfo.xml": "metainfo/io.github.mcaden.arborist.metainfo.xml"
+        }
+      },
+      "rpm": {
+        "files": {
+          "/usr/share/metainfo/io.github.mcaden.arborist.metainfo.xml": "metainfo/io.github.mcaden.arborist.metainfo.xml"
+        }
+      }
     }
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -51,5 +51,14 @@ export default defineConfig({
   build: {
     target: 'es2022',
     sourcemap: true,
+    // Arborist is a Tauri desktop app: bundles are loaded from local disk via
+    // the `asset://` scheme, not fetched over a network, so the default
+    // 500 kB chunk-size warning (which is calibrated for first-paint latency
+    // on the public web) is not a meaningful signal here. Splitting our
+    // single eagerly-imported bundle into multiple chunks would just trade
+    // one disk read for several without improving startup, so we raise the
+    // threshold to 1500 kB to suppress the noise while still flagging
+    // genuinely unbounded growth. See issue #207.
+    chunkSizeWarningLimit: 1500,
   },
 });


### PR DESCRIPTION
Addresses the actionable items from #207 — release log noise that remained after #206 unblocked the Windows installer build.

## What changed

### 1. Vite chunk-size warning (item 1)

`vite.config.ts` now sets `build.chunkSizeWarningLimit: 1500` (kB), with a comment explaining why splitting is not useful in a Tauri desktop app whose bundle is loaded from local disk via `asset://`. The current `dist/assets/index-*.js` is 682 kB minified / 184 kB gzipped, so the default 500 kB threshold was only producing noise; splitting into multiple chunks would just trade one disk read for several without improving startup.

### 2. AppStream metadata for Linux bundles (item 3)

- New `src-tauri/metainfo/io.github.mcaden.arborist.metainfo.xml` with the rDNS component id (`io.github.mcaden.arborist`, matching `tauri.conf.json::identifier`) and `<launchable>` pointing at the Tauri-generated `Arborist.desktop`.
- `src-tauri/tauri.conf.json` now maps the metainfo file into `usr/share/metainfo/` for AppImage, `.deb`, and `.rpm` bundles via `bundle.linux.{appimage,deb,rpm}.files`.
- Both release workflows install the `appstream` apt package so `linuxdeploy-plugin-appimage` can invoke `appstreamcli` to validate the metainfo and the AppStream-related warnings stop appearing in the release log.
- `scripts/release-prep.mjs` now bumps the metainfo `<release version="…" date="…" />` entry in lockstep with the four manifests so the value stays accurate without manual edits.

### Already done

Item 2 (`actions/cache` Node 20 deprecation) was already addressed by #210 — every workflow now pins `actions/cache@v5.0.5` (Node 24).

Items 4-6 (WiX template warnings, `linuxdeploy-plugin-gtk` dpkg-query noise, miscellaneous toolchain warnings) are upstream / cosmetic and intentionally left alone per the issue.

## Verification

- `pnpm run build` — chunk-size warning is gone; 682 kB bundle is comfortably under the new 1500 kB limit.
- `pnpm test --run` — 683 tests pass.
- `pnpm run lint` — clean (eslint + prettier).
- `cargo fmt --all -- --check` — clean.
- Metainfo XML parses and has the expected component id, launchable, and release entry; the release-prep regex matches the `<release …/>` line and produces a correctly rewritten output.

End-to-end verification on the AppImage / `.deb` / `.rpm` Linux artifacts will happen the next time **Release Verify Builds** runs — that workflow's log is where the original AppStream warnings appeared and is the natural place to confirm they're gone.
