### PR TITLE
[sesssion-dialog-close-accessibility] Add Escape handler to SettingsDialog (closes #171)

### DIFF
--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -164,8 +164,25 @@ describe('SettingsDialog', () => {
     seedConfig();
     const onClose = vi.fn();
     renderWithPlugins(<SettingsDialog onClose={onClose} />);
-    fireEvent.keyDown(screen.getByTestId('settings-dialog'), { key: 'Escape' });
+    // The dialog auto-focuses its close button on mount; fire Escape from there so the test exercises the real bubble path (focused
+    // control → onKeyDown on the wrapper) instead of synthesising the event directly on the wrapper element.
+    const focused = document.activeElement as HTMLElement | null;
+    expect(focused).toBe(screen.getByRole('button', { name: /close settings/i }));
+    fireEvent.keyDown(focused!, { key: 'Escape' });
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape during IME composition does not dismiss the dialog (CJK candidate selection)', () => {
+    seedConfig();
+    const onClose = vi.fn();
+    renderWithPlugins(<SettingsDialog onClose={onClose} />);
+    const textarea = screen.getByLabelText(/worktree prep commands/i);
+    textarea.focus();
+    // Modern path: native KeyboardEvent.isComposing is true mid-composition.
+    fireEvent.keyDown(textarea, { key: 'Escape', isComposing: true });
+    // Legacy fallback: older browsers don't surface `isComposing` reliably but do set keyCode 229 during composition.
+    fireEvent.keyDown(textarea, { key: 'Escape', keyCode: 229 });
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it('Escape is ignored while the workspace picker overlay is open (picker owns its own dismiss)', () => {
@@ -173,8 +190,14 @@ describe('SettingsDialog', () => {
     const onClose = vi.fn();
     renderWithPlugins(<SettingsDialog onClose={onClose} />);
     fireEvent.click(screen.getByRole('button', { name: /change…/i }));
-    fireEvent.keyDown(screen.getByTestId('settings-dialog'), { key: 'Escape' });
+    // The picker auto-focuses its workspace-path input. Firing Escape from there reproduces the real DOM path: the event
+    // never bubbles into the SettingsDialog wrapper (the picker is a sibling node), so the wrapper's onKeyDown stays silent.
+    const focused = document.activeElement as HTMLElement | null;
+    expect(focused?.tagName).toBe('INPUT');
+    fireEvent.keyDown(focused!, { key: 'Escape' });
     expect(onClose).not.toHaveBeenCalled();
+    // The picker itself doesn't handle Escape today (separate concern); make sure we didn't accidentally close it either.
+    expect(screen.getByRole('heading', { name: /change workspace/i })).toBeInTheDocument();
   });
 
   it('Cancel button closes the dialog without saving', () => {

--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -160,6 +160,23 @@ describe('SettingsDialog', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('Escape inside the dialog closes it (keyboard parity for backdrop click)', () => {
+    seedConfig();
+    const onClose = vi.fn();
+    renderWithPlugins(<SettingsDialog onClose={onClose} />);
+    fireEvent.keyDown(screen.getByTestId('settings-dialog'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape is ignored while the workspace picker overlay is open (picker owns its own dismiss)', () => {
+    seedConfig({ workspaceRoot: '/work' });
+    const onClose = vi.fn();
+    renderWithPlugins(<SettingsDialog onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /change…/i }));
+    fireEvent.keyDown(screen.getByTestId('settings-dialog'), { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it('Cancel button closes the dialog without saving', () => {
     seedConfig();
     const onClose = vi.fn();

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -177,6 +177,16 @@ export function SettingsDialog({ onClose, initialTab = 'general' }: SettingsDial
         onClick={(e) => {
           if (e.target === e.currentTarget) onClose();
         }}
+        onKeyDown={(e) => {
+          // Keyboard parity for the backdrop click-to-dismiss above
+          // (SonarCloud S1082 / WAI-ARIA APG modal pattern: Escape closes).
+          // Skip when the workspace picker is open — it owns its own
+          // focused surface (sibling node) and its own dismiss flow.
+          if (e.key === 'Escape' && !picking) {
+            e.preventDefault();
+            onClose();
+          }
+        }}
       >
         <div className="flex max-h-full w-full max-w-lg flex-col overflow-hidden rounded border border-slate-300 bg-white p-5 text-sm shadow-xl dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100">
           <div className="mb-4 flex shrink-0 items-start justify-between gap-3">

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -178,11 +178,12 @@ export function SettingsDialog({ onClose, initialTab = 'general' }: SettingsDial
           if (e.target === e.currentTarget) onClose();
         }}
         onKeyDown={(e) => {
-          // Keyboard parity for the backdrop click-to-dismiss above
-          // (SonarCloud S1082 / WAI-ARIA APG modal pattern: Escape closes).
-          // Skip when the workspace picker is open — it owns its own
-          // focused surface (sibling node) and its own dismiss flow.
-          if (e.key === 'Escape' && !picking) {
+          // Keyboard parity for the backdrop click-to-dismiss above (SonarCloud S1082 / WAI-ARIA APG modal pattern: Escape closes). Skip when the
+          // workspace picker is open — it owns its own focused surface (sibling node) and its own dismiss flow. Also bail out during IME composition
+          // so CJK users can press Escape to cancel candidate selection in an input/textarea without accidentally dismissing the dialog.
+          // (`isComposing` lives on the native KeyboardEvent — React's synthetic event doesn't expose it; `e.keyCode === 229` is the legacy fallback
+          // for older browsers that don't surface `isComposing` reliably.)
+          if (e.key === 'Escape' && !picking && !e.nativeEvent.isComposing && e.keyCode !== 229) {
             e.preventDefault();
             onClose();
           }


### PR DESCRIPTION
Fixes #171.

## Problem

SonarCloud rule [typescript:S1082](https://sonarcloud.io/project/issues?id=mcaden_arborist&open=AZ4pq-qKhzFqlqqrobOV) flagged the `SettingsDialog` wrapper `<div>`: it carries an `onClick` that dismisses on backdrop click, but no corresponding keyboard listener — keyboard-only users had no parity action.

## Fix

Add an `onKeyDown` to the same wrapper `<div>` that already owns the backdrop `onClick`. It calls `onClose()` when `Escape` is pressed, matching the [WAI-ARIA APG modal pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/). The listener no-ops while the workspace-picker overlay is open so the picker (a sibling node with its own dismiss flow) keeps ownership of `Escape` for its surface.

## Tests

- `Escape inside the dialog closes it (keyboard parity for backdrop click)` — new
- `Escape is ignored while the workspace picker overlay is open (picker owns its own dismiss)` — new

All existing `SettingsDialog` tests still pass (17 → 20 total).

## Verification

- `pnpm run lint` ✅
- `pnpm test --run` ✅ (685 passed)
- `pnpm exec tsc --noEmit` ✅
