### PR TITLE
chore: bump version to 0.1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arborist"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "arborist-types",
  "base64 0.22.1",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "arborist-types"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "pretty_assertions",
  "serde",

--- a/crates/arborist-types/Cargo.toml
+++ b/crates/arborist-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arborist-types"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 description = "Shared serializable wire-contract types for Arborist's frontend/backend boundary."
 authors = ["Aaron Moore", "Arborist contributors"]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arborist",
   "private": true,
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Cross-platform desktop app for managing AI coding-assistant sessions across Git worktrees.",
   "license": "MIT",
   "author": "Aaron Moore",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arborist"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 description = "Cross-platform desktop app for managing AI coding-assistant sessions across Git worktrees."
 authors = ["Aaron Moore", "Arborist contributors"]

--- a/src-tauri/metainfo/io.github.mcaden.arborist.metainfo.xml
+++ b/src-tauri/metainfo/io.github.mcaden.arborist.metainfo.xml
@@ -94,6 +94,6 @@
     emits at most an info-level "release-time-missing" hint).
   -->
   <releases>
-    <release version="0.1.12" />
+    <release version="0.1.13" />
   </releases>
 </component>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Arborist",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "identifier": "io.github.mcaden.arborist",
   "build": {
     "beforeDevCommand": "pnpm run vite",


### PR DESCRIPTION
Automated version bump following the v0.1.12 release.