### PR TITLE
[macos-font] Bundle Nerd Font into production builds via JS-imported CSS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,3 @@
-@import './assets/fonts/fonts.css';
-
 @import 'tailwindcss';
 
 /* Tailwind v4 reads our v3 JS config (content globs + theme.extend +

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import '@xterm/xterm/css/xterm.css';
 import { App } from './App';
+import './assets/fonts/fonts.css';
 import './index.css';
 
 const rootEl = document.getElementById('root');


### PR DESCRIPTION
## Problem
The bundled CaskaydiaCove Nerd Font was not applied in installed builds (observed on macOS). The app fell back to a system font for both the UI and the xterm.js terminal.

## Root cause
`fonts.css` was pulled into `index.css` via a CSS `@import`. Vite 8's Rolldown bundler does **not** rebase/emit `url()` font assets referenced from an `@import`-ed stylesheet. As a result, production builds shipped `@font-face` rules pointing at non-existent files — a production `vite build` emitted **zero** `.ttf` files into `dist`. The fonts only appeared to work in `pnpm dev` (the dev server serves the source files live), which masked the bug on platforms run from source.

## Fix
Import `fonts.css` from `main.tsx` (JS-imported CSS) instead of via CSS `@import`. Vite then emits all 8 hashed `.ttf` assets into `dist/assets` and rewrites the `@font-face` `src` URLs to same-origin `/assets/...` paths.

## Verification
- Production build now emits all 8 `.ttf` files (previously zero).
- `@font-face` is order-independent, so import position is not a concern.
- `pnpm gate` passes (frontend + Rust).