### PR TITLE
[worktree-add-icon] Replace worktree menu button with always-visible + button

### DIFF
--- a/docs/product.md
+++ b/docs/product.md
@@ -30,17 +30,17 @@ Success looks like:
 
 ### Sidebar and worktree tabs
 
-| ID   | Requirement                                                                                                                                                                |
-| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| S-01 | The sidebar must be a vertical tab bar on the left edge of the window.                                                                                                     |
-| S-02 | Top-level rows are worktree tabs. Child rows are AI sessions and custom-process sub-sessions.                                                                              |
-| S-03 | Clicking a worktree tab shows its dashboard unless it has an active child. Clicking a child shows that child's terminal or app-tracking view.                              |
-| S-04 | The `+` flow opens or creates a worktree tab. AI agents are launched later from the worktree context menu.                                                                 |
-| S-05 | Closing a worktree tab cascades to children. AI sessions and terminal sub-sessions terminate; application sub-sessions detach or terminate according to the chosen policy. |
-| S-06 | Active worktree and active child selection must be visually clear and keyboard navigable.                                                                                  |
-| S-07 | Top-level worktree order must persist. Child reordering can be added later.                                                                                                |
-| S-08 | Close actions that terminate processes must require confirmation.                                                                                                          |
-| S-09 | The worktree-tab context menu must expose Launch Claude, Launch Copilot, Launch Codex, enabled custom-process entries, custom-process settings, and close.                 |
+| ID   | Requirement                                                                                                                                                                                                                                    |
+| ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| S-01 | The sidebar must be a vertical tab bar on the left edge of the window.                                                                                                                                                                         |
+| S-02 | Top-level rows are worktree tabs. Child rows are AI sessions and custom-process sub-sessions.                                                                                                                                                  |
+| S-03 | Clicking a worktree tab shows its dashboard unless it has an active child. Clicking a child shows that child's terminal or app-tracking view.                                                                                                  |
+| S-04 | The `+` flow opens or creates a worktree tab. AI agents are launched later from the worktree context menu.                                                                                                                                     |
+| S-05 | Closing a worktree tab cascades to children. AI sessions and terminal sub-sessions terminate; application sub-sessions detach or terminate according to the chosen policy.                                                                     |
+| S-06 | Active worktree and active child selection must be visually clear and keyboard navigable.                                                                                                                                                      |
+| S-07 | Top-level worktree order must persist. Child reordering can be added later.                                                                                                                                                                    |
+| S-08 | Close actions that terminate processes must require confirmation.                                                                                                                                                                              |
+| S-09 | The worktree-tab context menu must expose Launch Claude, Launch Copilot, Launch Codex, enabled custom-process entries, and custom-process settings. Closing the worktree tab is handled by the row's dedicated close (×) button, not the menu. |
 
 ### Workspaces and worktrees
 

--- a/src/components/SidebarWorktreeTab.tsx
+++ b/src/components/SidebarWorktreeTab.tsx
@@ -8,11 +8,12 @@
 // The header is rendered as a plain button inside an `<li role="presentation">`
 // — it is **not** a `role="tab"` participant. The sidebar's tablist scope
 // continues to enumerate session tabs only, matching the pre-#44 keyboard
-// pattern. A vertical-ellipsis (⋮) button on the row opens the
-// `WorktreeTabContextMenu` (launch entries, custom processes, and Close
-// pinned to the bottom). Right-click is intentionally not bound — see
-// issue #49 for the rationale (discoverability). Shift+F10 / the
-// ContextMenu key still open the menu for keyboard users.
+// pattern. A plus (+) button on the row opens the
+// `WorktreeTabContextMenu` (launch entries and custom processes). The
+// plus button is always visible (not hover-gated). Right-click is
+// intentionally not bound — see issue #49 for the rationale
+// (discoverability). Shift+F10 / the ContextMenu key still open the menu
+// for keyboard users.
 //
 // Click activates the worktree tab and clears its `activeChildId` so the
 // MainArea swaps to the dashboard placeholder. Users who want to land on
@@ -90,14 +91,14 @@ export function SidebarWorktreeTab({ tabId, isActive, onOpenContextMenu }: Sideb
           e.stopPropagation();
           const trigger = e.currentTarget;
           const rect = trigger.getBoundingClientRect();
-          // Restore focus to the ⋮ button after the menu closes for click-path
+          // Restore focus to the + button after the menu closes for click-path
           // openers; the Shift+F10 / ContextMenu-key path on the row button
           // passes `buttonEl` so keyboard openers return focus to the row.
           onOpenContextMenu(tab.id, { x: rect.left, y: rect.bottom + 2 }, trigger);
         }}
-        className="absolute right-7 top-4 inline-flex h-5 w-5 items-center justify-center rounded leading-none text-slate-500 opacity-0 transition-opacity hover:bg-slate-200 hover:text-slate-900 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 group-hover:opacity-100 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-slate-100"
+        className="absolute right-7 top-5 inline-flex h-5 w-5 items-center justify-center rounded leading-none text-slate-500 transition-colors hover:bg-slate-200 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-slate-100"
       >
-        <span aria-hidden="true">⋮</span>
+        <span aria-hidden="true">+</span>
       </button>
       <button
         type="button"
@@ -107,7 +108,7 @@ export function SidebarWorktreeTab({ tabId, isActive, onOpenContextMenu }: Sideb
           e.stopPropagation();
           wttActions.requestClose(tab.id);
         }}
-        className="absolute right-3 top-4 inline-flex h-5 w-5 items-center justify-center rounded leading-none text-slate-500 opacity-0 transition-opacity hover:bg-slate-200 hover:text-slate-900 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 group-hover:opacity-100 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-slate-100"
+        className="absolute right-3 top-5 inline-flex h-5 w-5 items-center justify-center rounded leading-none text-slate-500 opacity-0 transition-opacity hover:bg-slate-200 hover:text-slate-900 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 group-hover:opacity-100 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-slate-100"
       >
         <span aria-hidden="true">×</span>
       </button>

--- a/src/components/WorktreeTabContextMenu.test.tsx
+++ b/src/components/WorktreeTabContextMenu.test.tsx
@@ -84,14 +84,6 @@ describe('WorktreeTabContextMenu', () => {
     expect(screen.queryByTestId('worktree-tab-context-menu-launch-copilot')).toBeNull();
   });
 
-  it('Close requests close (sets pendingClose) and dismisses the menu', () => {
-    const onClose = vi.fn();
-    renderWithPlugins(<WorktreeTabContextMenu tabId={TAB_ID} anchor={{ x: 10, y: 10 }} onClose={onClose} />);
-    expect(screen.queryByTestId('worktree-tab-context-menu-close')).toBeNull();
-    expect(useWorktreeTabStore.getState().pendingClose).toBeUndefined();
-    expect(bridgeMock.worktreeTabClose).not.toHaveBeenCalled();
-  });
-
   it('clicking Launch Claude calls sessionCreate with this worktree path', async () => {
     bridgeMock.sessionCreate.mockResolvedValueOnce({
       id: 'new-id',

--- a/src/components/WorktreeTabContextMenu.test.tsx
+++ b/src/components/WorktreeTabContextMenu.test.tsx
@@ -45,11 +45,11 @@ afterEach(() => {
 describe('WorktreeTabContextMenu', () => {
   const noop = () => {};
 
-  it('renders Launch Claude, Launch Copilot, and Close items', () => {
+  it('renders Launch Claude and Launch Copilot items without a Close item (close lives on the row × button)', () => {
     renderWithPlugins(<WorktreeTabContextMenu tabId={TAB_ID} anchor={{ x: 10, y: 10 }} onClose={noop} />);
     expect(screen.getByTestId('worktree-tab-context-menu-launch-claude')).toBeInTheDocument();
     expect(screen.getByTestId('worktree-tab-context-menu-launch-copilot')).toBeInTheDocument();
-    expect(screen.getByTestId('worktree-tab-context-menu-close')).toBeInTheDocument();
+    expect(screen.queryByTestId('worktree-tab-context-menu-close')).toBeNull();
   });
 
   it('flags experimental AI plugins (Codex) with a warning icon and an "Experimental" tooltip, leaving stable ones unmarked', () => {
@@ -87,10 +87,9 @@ describe('WorktreeTabContextMenu', () => {
   it('Close requests close (sets pendingClose) and dismisses the menu', () => {
     const onClose = vi.fn();
     renderWithPlugins(<WorktreeTabContextMenu tabId={TAB_ID} anchor={{ x: 10, y: 10 }} onClose={onClose} />);
-    fireEvent.click(screen.getByTestId('worktree-tab-context-menu-close'));
-    expect(useWorktreeTabStore.getState().pendingClose).toBe(TAB_ID);
+    expect(screen.queryByTestId('worktree-tab-context-menu-close')).toBeNull();
+    expect(useWorktreeTabStore.getState().pendingClose).toBeUndefined();
     expect(bridgeMock.worktreeTabClose).not.toHaveBeenCalled();
-    expect(onClose).toHaveBeenCalled();
   });
 
   it('clicking Launch Claude calls sessionCreate with this worktree path', async () => {
@@ -221,7 +220,7 @@ describe('WorktreeTabContextMenu', () => {
     renderWithPlugins(<WorktreeTabContextMenu tabId={TAB_ID} anchor={{ x: 10, y: 10 }} onClose={noop} />);
     const launchClaude = screen.getByTestId('worktree-tab-context-menu-launch-claude');
     launchClaude.focus();
-    fireEvent.mouseEnter(screen.getByTestId('worktree-tab-context-menu-close'));
+    fireEvent.mouseEnter(screen.getByTestId('worktree-tab-context-menu-settings'));
     fireEvent.keyDown(launchClaude, { key: 'Enter' });
 
     await waitFor(() => expect(bridgeMock.sessionCreate).toHaveBeenCalledWith(expect.objectContaining({ tool: 'claude' })));

--- a/src/components/WorktreeTabContextMenu.tsx
+++ b/src/components/WorktreeTabContextMenu.tsx
@@ -1,4 +1,8 @@
-// WorktreeTabContextMenu — right-click menu for a worktree tab (issue #44).
+// WorktreeTabContextMenu — actions menu for a worktree tab (issue #44).
+//
+// Opened from the row's + button or the keyboard (Shift+F10 / ContextMenu key);
+// right-click is intentionally not bound — SidebarWorktreeTab suppresses the
+// native context menu (see issue #49).
 //
 // Items (flat, no submenu):
 //   * Launch <AI plugin> → creates an AI session under this worktree tab.

--- a/src/components/WorktreeTabContextMenu.tsx
+++ b/src/components/WorktreeTabContextMenu.tsx
@@ -4,7 +4,9 @@
 //   * Launch <AI plugin> → creates an AI session under this worktree tab.
 //   * <custom defs>      → one entry per enabled custom-process definition.
 //   * Settings…          → opens the Settings dialog on the Custom Processes tab.
-//   * Close              → cascades close of the worktree tab and all children (pinned to bottom).
+//
+// Close is intentionally NOT in this menu — the row's dedicated × button
+// already closes the worktree tab, so a menu entry would be redundant.
 //
 // Keyboard model: ↑/↓ cycles items, Enter activates, Esc closes and
 // restores focus to the trigger.
@@ -19,7 +21,7 @@ import { pluginEnabled, useRegistry } from '@/plugins';
 import { useEnabledCustomProcesses, useConfigStore } from '@/store/config-store';
 import { useSessionActions } from '@/store/session-store';
 import { useSubSessionActions } from '@/store/sub-session-store';
-import { useWorktreeTabActions, useWorktreeTabStore } from '@/store/worktree-tab-store';
+import { useWorktreeTabStore } from '@/store/worktree-tab-store';
 import type { CustomProcessDefId, Tool, WorktreeTabId } from '@/types/arborist';
 
 export interface WorktreeTabContextMenuProps {
@@ -32,11 +34,10 @@ export interface WorktreeTabContextMenuProps {
   onOpenSettings?: () => void;
 }
 
-type Item = 'close' | 'settings' | `launch:${Tool}` | `cp:${string}`;
+type Item = 'settings' | `launch:${Tool}` | `cp:${string}`;
 
 export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo, onOpenSettings }: WorktreeTabContextMenuProps): JSX.Element | null {
   const tab = useWorktreeTabStore((s) => s.tabs.find((t) => t.id === tabId));
-  const wttActions = useWorktreeTabActions();
   const sessionActions = useSessionActions();
   const subActions = useSubSessionActions();
   const registry = useRegistry();
@@ -48,7 +49,7 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
   const customProcesses = useEnabledCustomProcesses();
   const aiIconDataUris = useConfigStore((s) => s.config.aiLaunchCommands.iconDataUris);
 
-  // Build the full item order: launchers, custom processes, Settings…, Close.
+  // Build the full item order: launchers, custom processes, Settings…
   const itemOrder = useMemo<Item[]>(() => {
     const items: Item[] = aiPlugins.map((plugin) => `launch:${plugin.id}` as Item);
     if (customProcesses.length > 0) {
@@ -56,7 +57,7 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
         items.push(`cp:${def.id}` as Item);
       }
     }
-    items.push('settings', 'close');
+    items.push('settings');
     return items;
   }, [aiPlugins, customProcesses]);
 
@@ -108,7 +109,7 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
   const position = useMemo(() => {
     const margin = 4;
     const estW = 220;
-    const separatorCount = 2;
+    const separatorCount = 1;
     const estH = itemOrder.length * 32 + separatorCount * 9 + 8;
     const vw = typeof window !== 'undefined' ? window.innerWidth : estW * 2;
     const vh = typeof window !== 'undefined' ? window.innerHeight : estH * 2;
@@ -128,11 +129,6 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
     const nextIdx = (idx + delta + itemOrder.length) % itemOrder.length;
     const next = itemOrder[nextIdx];
     if (next) focusItem(next);
-  };
-
-  const handleClose = (): void => {
-    wttActions.requestClose(tabId);
-    closeMenu();
   };
 
   const handleLaunch = (tool: Tool): void => {
@@ -175,8 +171,7 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
   };
 
   const activateItem = (item: Item): void => {
-    if (item === 'close') handleClose();
-    else if (item.startsWith('launch:')) {
+    if (item.startsWith('launch:')) {
       const plugin = aiPlugins.find((candidate) => `launch:${candidate.id}` === item);
       if (plugin) handleLaunch(plugin.id);
     } else if (item === 'settings') handleSettings();
@@ -295,18 +290,6 @@ export function WorktreeTabContextMenu({ tabId, anchor, onClose, restoreFocusTo,
           className={itemBase}
         >
           <span>Custom Processes…</span>
-        </button>
-        <hr className="my-1 border-t border-slate-200 dark:border-slate-700" />
-        <button
-          ref={setItemRef('close')}
-          type="button"
-          role="menuitem"
-          data-testid="worktree-tab-context-menu-close"
-          onClick={handleClose}
-          onMouseEnter={() => setFocusedItem('close')}
-          className={itemBase}
-        >
-          <span>Close worktree tab</span>
         </button>
       </div>
       {actionError && (


### PR DESCRIPTION
## Summary
- Replace the per-worktree-tab three-dots (⋮) control with a plus (+) button that opens the same actions menu.
- Make the + button **always visible** instead of only on hover.
- Drop the redundant **Close worktree tab** entry from that menu — the row's dedicated × button already closes the tab.
- Nudge both the + and × buttons down (\	op-4\ → \	op-5\) so they sit correctly on the parent worktree rows. Child tabs unchanged.

## Testing
- \pnpm test --run\ (WorktreeTabContextMenu + SidebarWorktreeTab) — green
- \pnpm run lint\ — green