### PR TITLE
[clipboard-regression] Copy terminal selection on Ctrl+C/Ctrl+Shift+C/Cmd+C

### DIFF
--- a/src/components/MainArea.test.tsx
+++ b/src/components/MainArea.test.tsx
@@ -25,6 +25,8 @@ vi.mock('@xterm/xterm', () => {
       dispose: vi.fn(),
       loadAddon: vi.fn(),
       paste: vi.fn(),
+      getSelection: vi.fn(() => ''),
+      parser: { registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })) },
       cols: 80,
       rows: 24,
     };

--- a/src/components/TerminalView.test.tsx
+++ b/src/components/TerminalView.test.tsx
@@ -25,6 +25,8 @@ vi.mock('@xterm/xterm', () => {
       dispose: vi.fn(),
       loadAddon: vi.fn(),
       paste: vi.fn(),
+      getSelection: vi.fn(() => ''),
+      parser: { registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })) },
       cols: 80,
       rows: 24,
     };

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -97,6 +97,24 @@ function makeHost(width = 600, height = 400): HTMLDivElement {
   return el;
 }
 
+// Swap globalThis.navigator for one whose `clipboard` is the provided stub, run `fn`, then restore the original — keeps every clipboard test from
+// re-rolling the same defineProperty/try-finally boilerplate. `clipboard` is passed straight through, so tests can hand in `{ readText }`,
+// `{ writeText }`, `{}`, or `undefined` to exercise the various availability branches.
+async function withNavigatorClipboard(clipboard: unknown, fn: () => void | Promise<void>): Promise<void> {
+  const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+  Object.defineProperty(globalThis, 'navigator', { value: { ...originalNav, clipboard }, configurable: true });
+  try {
+    await fn();
+  } finally {
+    Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+  }
+}
+
+// Build a bubbling, cancelable keydown event with the supplied init — the `bubbles`/`cancelable` flags are required for host dispatch in every case.
+function keydown(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init });
+}
+
 let originalResizeObserver: typeof ResizeObserver | undefined;
 
 beforeEach(() => {
@@ -266,30 +284,15 @@ describe('useTerminal', () => {
     act(() => result.current.attach(host));
 
     const readText = vi.fn().mockResolvedValue('clip-text');
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { readText } },
-      configurable: true,
-    });
-
-    try {
-      const evt = new KeyboardEvent('keydown', {
-        key: 'v',
-        code: 'KeyV',
-        ctrlKey: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      const prevented = !host.dispatchEvent(evt);
+    await withNavigatorClipboard({ readText }, async () => {
+      const prevented = !host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', ctrlKey: true }));
 
       expect(prevented).toBe(true);
       expect(readText).toHaveBeenCalled();
       await Promise.resolve();
       await Promise.resolve();
       expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('clip-text');
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
   it('Cmd+V (metaKey) on host triggers paste via navigator.clipboard.readText', async () => {
@@ -298,279 +301,135 @@ describe('useTerminal', () => {
     act(() => result.current.attach(host));
 
     const readText = vi.fn().mockResolvedValue('mac-clip');
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { readText } },
-      configurable: true,
-    });
-
-    try {
-      const evt = new KeyboardEvent('keydown', {
-        key: 'v',
-        code: 'KeyV',
-        metaKey: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      const prevented = !host.dispatchEvent(evt);
+    await withNavigatorClipboard({ readText }, async () => {
+      const prevented = !host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', metaKey: true }));
 
       expect(prevented).toBe(true);
       expect(readText).toHaveBeenCalled();
       await Promise.resolve();
       await Promise.resolve();
       expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('mac-clip');
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
-  it('Ctrl+Shift+V on host also triggers paste (Linux terminal convention)', () => {
+  it('Ctrl+Shift+V on host also triggers paste (Linux terminal convention)', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
     const readText = vi.fn().mockResolvedValue('linux-clip');
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { readText } },
-      configurable: true,
-    });
-
-    try {
-      const evt = new KeyboardEvent('keydown', {
-        key: 'v',
-        code: 'KeyV',
-        ctrlKey: true,
-        shiftKey: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      const prevented = !host.dispatchEvent(evt);
+    await withNavigatorClipboard({ readText }, () => {
+      const prevented = !host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', ctrlKey: true, shiftKey: true }));
 
       expect(prevented).toBe(true);
       expect(readText).toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
-  it('Ctrl+Alt+V is not intercepted (Alt-modifier passthrough)', () => {
+  it('Ctrl+Alt+V is not intercepted (Alt-modifier passthrough)', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
     const readText = vi.fn();
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { readText } },
-      configurable: true,
-    });
-
-    try {
-      const evt = new KeyboardEvent('keydown', {
-        key: 'v',
-        code: 'KeyV',
-        ctrlKey: true,
-        altKey: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      const dispatched = host.dispatchEvent(evt);
+    await withNavigatorClipboard({ readText }, () => {
+      const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', ctrlKey: true, altKey: true }));
 
       expect(dispatched).toBe(true);
       expect(readText).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
-  it('Cmd+Shift+V is not intercepted (passthrough; "paste and match style" on macOS)', () => {
+  it('Cmd+Shift+V is not intercepted (passthrough; "paste and match style" on macOS)', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
     const readText = vi.fn();
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { readText } },
-      configurable: true,
-    });
-
-    try {
-      const evt = new KeyboardEvent('keydown', {
-        key: 'v',
-        code: 'KeyV',
-        metaKey: true,
-        shiftKey: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      const dispatched = host.dispatchEvent(evt);
+    await withNavigatorClipboard({ readText }, () => {
+      const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', metaKey: true, shiftKey: true }));
 
       expect(dispatched).toBe(true);
       expect(readText).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
-  it('Cmd+Alt+V is not intercepted (Alt-modifier passthrough on macOS)', () => {
+  it('Cmd+Alt+V is not intercepted (Alt-modifier passthrough on macOS)', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
     const readText = vi.fn();
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { readText } },
-      configurable: true,
-    });
-
-    try {
-      const evt = new KeyboardEvent('keydown', {
-        key: 'v',
-        code: 'KeyV',
-        metaKey: true,
-        altKey: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      const dispatched = host.dispatchEvent(evt);
+    await withNavigatorClipboard({ readText }, () => {
+      const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', metaKey: true, altKey: true }));
 
       expect(dispatched).toBe(true);
       expect(readText).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
-  it('Ctrl+Cmd+V is not intercepted (both ctrl and meta together is undefined)', () => {
+  it('Ctrl+Cmd+V is not intercepted (both ctrl and meta together is undefined)', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
     const readText = vi.fn();
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { readText } },
-      configurable: true,
-    });
-
-    try {
-      const evt = new KeyboardEvent('keydown', {
-        key: 'v',
-        code: 'KeyV',
-        ctrlKey: true,
-        metaKey: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      const dispatched = host.dispatchEvent(evt);
+    await withNavigatorClipboard({ readText }, () => {
+      const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', ctrlKey: true, metaKey: true }));
 
       expect(dispatched).toBe(true);
       expect(readText).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
-  it('plain "v" keystroke (no modifier) is not intercepted', () => {
+  it('plain "v" keystroke (no modifier) is not intercepted', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
     const readText = vi.fn();
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { readText } },
-      configurable: true,
-    });
-
-    try {
-      const evt = new KeyboardEvent('keydown', {
-        key: 'v',
-        code: 'KeyV',
-        bubbles: true,
-        cancelable: true,
-      });
-      const dispatched = host.dispatchEvent(evt);
+    await withNavigatorClipboard({ readText }, () => {
+      const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV' }));
 
       expect(dispatched).toBe(true);
       expect(readText).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
   it('Ctrl+V on a non-Latin keyboard layout still triggers paste (matches by code, not key)', async () => {
-    // On a Russian QWERTY layout the V position prints `м`, so `event.key`
-    // is `'м'` — not `'v'`. We deliberately match on `event.code === 'KeyV'`
-    // (physical key) rather than `event.key` so the user's normal paste
-    // shortcut works regardless of active keyboard layout.
+    // On a Russian QWERTY layout the V position prints `м`, so `event.key` is `'м'` — not `'v'`. We deliberately match on `event.code === 'KeyV'`
+    // (physical key) rather than `event.key` so the user's normal paste shortcut works regardless of active keyboard layout.
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
     const readText = vi.fn().mockResolvedValue('layout-clip');
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { readText } },
-      configurable: true,
-    });
-
-    try {
-      const evt = new KeyboardEvent('keydown', {
-        key: 'м',
-        code: 'KeyV',
-        ctrlKey: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      const prevented = !host.dispatchEvent(evt);
+    await withNavigatorClipboard({ readText }, async () => {
+      const prevented = !host.dispatchEvent(keydown({ key: 'м', code: 'KeyV', ctrlKey: true }));
 
       expect(prevented).toBe(true);
       expect(readText).toHaveBeenCalled();
       await Promise.resolve();
       await Promise.resolve();
       expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('layout-clip');
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
-  it('Ctrl + non-V key with key:"v" is not intercepted (matches by code, not by produced character)', () => {
-    // Inverse of the layout test: on a Russian layout, the key that
-    // produces `'v'` is at a different physical position (code `KeyM`,
-    // since Cyrillic `в` is on a different key entirely — but for this
-    // test the important property is that `event.key === 'v'` does not
-    // imply the user pressed the V shortcut). Anything that isn't
-    // `code === 'KeyV'` must pass through unchanged.
+  it('Ctrl + non-V key with key:"v" is not intercepted (matches by code, not by produced character)', async () => {
+    // Inverse of the layout test: on a Russian layout the key that produces `'v'` is at a different physical position (code `KeyM`, since Cyrillic
+    // `в` is on a different key entirely) — but for this test the important property is that `event.key === 'v'` does not imply the user pressed the V
+    // shortcut. Anything that isn't `code === 'KeyV'` must pass through unchanged.
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
     const readText = vi.fn();
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { readText } },
-      configurable: true,
-    });
-
-    try {
-      const evt = new KeyboardEvent('keydown', {
-        key: 'v',
-        code: 'KeyM',
-        ctrlKey: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      const dispatched = host.dispatchEvent(evt);
+    await withNavigatorClipboard({ readText }, () => {
+      const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyM', ctrlKey: true }));
 
       expect(dispatched).toBe(true);
       expect(readText).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
   it('Ctrl+V resolved after disposeTerminal does not write to a stale terminal', async () => {
@@ -589,197 +448,98 @@ describe('useTerminal', () => {
           resolveReadText = resolve;
         }),
     );
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { readText } },
-      configurable: true,
-    });
-
-    try {
-      const evt = new KeyboardEvent('keydown', {
-        key: 'v',
-        code: 'KeyV',
-        ctrlKey: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      host.dispatchEvent(evt);
+    await withNavigatorClipboard({ readText }, async () => {
+      host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', ctrlKey: true }));
       expect(readText).toHaveBeenCalled();
 
       // Dispose the session BEFORE the clipboard read resolves.
       act(() => disposeTerminal('s1'));
 
-      // Now resolve the pending readText. The guard inside
-      // pasteFromClipboard should drop the paste because the registry
-      // entry is gone.
+      // Now resolve the pending readText. The guard inside pasteFromClipboard should drop the paste because the registry entry is gone.
       resolveReadText('stale-paste');
       await Promise.resolve();
       await Promise.resolve();
 
       expect(term.paste).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
-  it('Ctrl+C with a selection copies it to the clipboard and suppresses SIGINT', () => {
+  it('Ctrl+C with a selection copies it to the clipboard and suppresses SIGINT', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
     mockTerminals[0]!.getSelection.mockReturnValue('selected text');
 
     const writeText = vi.fn().mockResolvedValue(undefined);
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { writeText } },
-      configurable: true,
-    });
-
-    try {
-      const evt = new KeyboardEvent('keydown', {
-        key: 'c',
-        code: 'KeyC',
-        ctrlKey: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      const prevented = !host.dispatchEvent(evt);
+    await withNavigatorClipboard({ writeText }, () => {
+      const prevented = !host.dispatchEvent(keydown({ key: 'c', code: 'KeyC', ctrlKey: true }));
 
       expect(prevented).toBe(true);
       expect(writeText).toHaveBeenCalledWith('selected text');
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
-  it('Ctrl+C with no selection is not intercepted (falls through to SIGINT)', () => {
+  it('Ctrl+C with no selection is not intercepted (falls through to SIGINT)', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
     mockTerminals[0]!.getSelection.mockReturnValue('');
 
     const writeText = vi.fn();
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { writeText } },
-      configurable: true,
-    });
-
-    try {
-      const evt = new KeyboardEvent('keydown', {
-        key: 'c',
-        code: 'KeyC',
-        ctrlKey: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      const dispatched = host.dispatchEvent(evt);
+    await withNavigatorClipboard({ writeText }, () => {
+      const dispatched = host.dispatchEvent(keydown({ key: 'c', code: 'KeyC', ctrlKey: true }));
 
       expect(dispatched).toBe(true);
       expect(writeText).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
-  it('Ctrl+Shift+C copies the selection', () => {
+  it('Ctrl+Shift+C copies the selection', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
     mockTerminals[0]!.getSelection.mockReturnValue('shift-copy');
 
     const writeText = vi.fn().mockResolvedValue(undefined);
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { writeText } },
-      configurable: true,
-    });
-
-    try {
-      const evt = new KeyboardEvent('keydown', {
-        key: 'C',
-        code: 'KeyC',
-        ctrlKey: true,
-        shiftKey: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      const prevented = !host.dispatchEvent(evt);
+    await withNavigatorClipboard({ writeText }, () => {
+      const prevented = !host.dispatchEvent(keydown({ key: 'C', code: 'KeyC', ctrlKey: true, shiftKey: true }));
 
       expect(prevented).toBe(true);
       expect(writeText).toHaveBeenCalledWith('shift-copy');
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
-  it('Cmd+C copies the selection on macOS', () => {
+  it('Cmd+C copies the selection on macOS', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
     mockTerminals[0]!.getSelection.mockReturnValue('mac-copy');
 
     const writeText = vi.fn().mockResolvedValue(undefined);
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { writeText } },
-      configurable: true,
-    });
-
-    try {
-      const evt = new KeyboardEvent('keydown', {
-        key: 'c',
-        code: 'KeyC',
-        metaKey: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      const prevented = !host.dispatchEvent(evt);
+    await withNavigatorClipboard({ writeText }, () => {
+      const prevented = !host.dispatchEvent(keydown({ key: 'c', code: 'KeyC', metaKey: true }));
 
       expect(prevented).toBe(true);
       expect(writeText).toHaveBeenCalledWith('mac-copy');
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
-  it('Ctrl+C with a selection but no clipboard write API is not intercepted (preserves SIGINT)', () => {
+  it('Ctrl+C with a selection but no clipboard write API is not intercepted (preserves SIGINT)', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
     mockTerminals[0]!.getSelection.mockReturnValue('selected but no API');
 
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: {} },
-      configurable: true,
-    });
-
-    try {
-      const evt = new KeyboardEvent('keydown', {
-        key: 'c',
-        code: 'KeyC',
-        ctrlKey: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      const dispatched = host.dispatchEvent(evt);
+    await withNavigatorClipboard({}, () => {
+      const dispatched = host.dispatchEvent(keydown({ key: 'c', code: 'KeyC', ctrlKey: true }));
 
       expect(dispatched).toBe(true);
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
   it('OSC 52 clipboard write from the CLI is forwarded to the system clipboard', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { writeText } },
-      configurable: true,
-    });
-
-    try {
+    await withNavigatorClipboard({ writeText }, async () => {
       const { result } = renderHook(() => useTerminal('s1'));
       const host = makeHost();
       act(() => result.current.attach(host));
@@ -791,20 +551,12 @@ describe('useTerminal', () => {
 
       expect(handled).toBe(true);
       expect(writeText).toHaveBeenCalledWith('hi');
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
   it('OSC 52 decodes multi-byte UTF-8 correctly', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { writeText } },
-      configurable: true,
-    });
-
-    try {
+    await withNavigatorClipboard({ writeText }, async () => {
       const { result } = renderHook(() => useTerminal('s1'));
       const host = makeHost();
       act(() => result.current.attach(host));
@@ -816,20 +568,12 @@ describe('useTerminal', () => {
 
       expect(handled).toBe(true);
       expect(writeText).toHaveBeenCalledWith('café — 日本');
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
   it('OSC 52 read request ("?") is declined and never leaks the clipboard', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { writeText } },
-      configurable: true,
-    });
-
-    try {
+    await withNavigatorClipboard({ writeText }, async () => {
       const { result } = renderHook(() => useTerminal('s1'));
       const host = makeHost();
       act(() => result.current.attach(host));
@@ -839,20 +583,12 @@ describe('useTerminal', () => {
 
       expect(handled).toBe(false);
       expect(writeText).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
   it('OSC 52 with malformed base64 is declined cleanly', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { writeText } },
-      configurable: true,
-    });
-
-    try {
+    await withNavigatorClipboard({ writeText }, async () => {
       const { result } = renderHook(() => useTerminal('s1'));
       const host = makeHost();
       act(() => result.current.attach(host));
@@ -862,19 +598,11 @@ describe('useTerminal', () => {
 
       expect(handled).toBe(false);
       expect(writeText).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
   it('OSC 52 is declined when the clipboard write API is unavailable', async () => {
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: {} },
-      configurable: true,
-    });
-
-    try {
+    await withNavigatorClipboard({}, async () => {
       const { result } = renderHook(() => useTerminal('s1'));
       const host = makeHost();
       act(() => result.current.attach(host));
@@ -883,9 +611,7 @@ describe('useTerminal', () => {
       const handled = await handler('c;aGk=');
 
       expect(handled).toBe(false);
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
   it('Shift+Enter listener is removed on detach', () => {
@@ -984,128 +710,72 @@ describe('useTerminal', () => {
     act(() => result.current.attach(host));
 
     const readText = vi.fn().mockResolvedValue('from-async-clipboard');
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: { readText } },
-      configurable: true,
-    });
-
-    try {
+    await withNavigatorClipboard({ readText }, async () => {
       const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
       Object.defineProperty(evt, 'clipboardData', { value: { getData: () => '' } });
       host.dispatchEvent(evt);
 
       expect(readText).toHaveBeenCalled();
-      // Drain the microtask queue so the .then(...) on readText resolves.
-      // Two awaits: one for the readText resolution, one for the chained .then.
+      // Drain the microtask queue so the .then(...) on readText resolves. Two awaits: one for the readText resolution, one for the chained .then.
       await Promise.resolve();
       await Promise.resolve();
 
       expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('from-async-clipboard');
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
-  it('paste with empty clipboard and no async fallback does not call term.paste() and does not preventDefault', () => {
+  it('paste with empty clipboard and no async fallback does not call term.paste() and does not preventDefault', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: undefined },
-      configurable: true,
-    });
-
-    try {
+    await withNavigatorClipboard(undefined, () => {
       const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
       Object.defineProperty(evt, 'clipboardData', { value: { getData: () => '' } });
       const dispatched = host.dispatchEvent(evt);
 
       expect(mockTerminals[0]!.paste).not.toHaveBeenCalled();
-      // When we have no paste path, we MUST let the event propagate so
-      // xterm or any other listener still has a chance to handle it —
-      // otherwise we just turn paste into a silent no-op (regression).
+      // When we have no paste path, we MUST let the event propagate so xterm or any other listener still has a chance to handle it — otherwise we
+      // just turn paste into a silent no-op (regression).
       expect(dispatched).toBe(true);
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
-  it('Ctrl+V keydown does not preventDefault when navigator.clipboard.readText is unavailable', () => {
+  it('Ctrl+V keydown does not preventDefault when navigator.clipboard.readText is unavailable', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: undefined },
-      configurable: true,
-    });
+    await withNavigatorClipboard(undefined, () => {
+      const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', ctrlKey: true }));
 
-    try {
-      const evt = new KeyboardEvent('keydown', {
-        key: 'v',
-        code: 'KeyV',
-        ctrlKey: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      const dispatched = host.dispatchEvent(evt);
-
-      // Without a clipboard API, we can't paste — so we must not
-      // suppress xterm's own keydown handling. A silent no-op is a
-      // regression vs. the previous behavior (xterm sending \x16).
+      // Without a clipboard API, we can't paste — so we must not suppress xterm's own keydown handling. A silent no-op is a regression vs. the
+      // previous behavior (xterm sending \x16).
       expect(dispatched).toBe(true);
       expect(mockTerminals[0]!.paste).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
-  it('Cmd+V keydown does not preventDefault when navigator.clipboard.readText is unavailable', () => {
+  it('Cmd+V keydown does not preventDefault when navigator.clipboard.readText is unavailable', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: undefined },
-      configurable: true,
-    });
-
-    try {
-      const evt = new KeyboardEvent('keydown', {
-        key: 'v',
-        code: 'KeyV',
-        metaKey: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      const dispatched = host.dispatchEvent(evt);
+    await withNavigatorClipboard(undefined, () => {
+      const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', metaKey: true }));
 
       expect(dispatched).toBe(true);
       expect(mockTerminals[0]!.paste).not.toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
-  it('paste with inline clipboardData still preventDefaults even if async clipboard is missing', () => {
-    // Inline payload is the happy path and must always be consumed —
-    // we own the paste end-to-end here.
+  it('paste with inline clipboardData still preventDefaults even if async clipboard is missing', async () => {
+    // Inline payload is the happy path and must always be consumed — we own the paste end-to-end here.
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
-    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { ...originalNav, clipboard: undefined },
-      configurable: true,
-    });
-
-    try {
+    await withNavigatorClipboard(undefined, () => {
       const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
       Object.defineProperty(evt, 'clipboardData', {
         value: { getData: () => 'inline-text' },
@@ -1114,9 +784,7 @@ describe('useTerminal', () => {
 
       expect(prevented).toBe(true);
       expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('inline-text');
-    } finally {
-      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-    }
+    });
   });
 
   it('paste runs in capture phase, beating a descendants stopPropagation', () => {

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -14,6 +14,7 @@ const mockTerminals: Array<{
   loadAddon: ReturnType<typeof vi.fn>;
   refresh: ReturnType<typeof vi.fn>;
   paste: ReturnType<typeof vi.fn>;
+  getSelection: ReturnType<typeof vi.fn>;
   cols: number;
   rows: number;
   _dataCb?: (data: string) => void;
@@ -36,6 +37,7 @@ vi.mock('@xterm/xterm', () => {
       loadAddon: vi.fn(),
       refresh: vi.fn(),
       paste: vi.fn(),
+      getSelection: vi.fn(() => ''),
       cols: 80,
       rows: 24,
       _core: {
@@ -605,6 +607,155 @@ describe('useTerminal', () => {
       await Promise.resolve();
 
       expect(term.paste).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('Ctrl+C with a selection copies it to the clipboard and suppresses SIGINT', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+    mockTerminals[0]!.getSelection.mockReturnValue('selected text');
+
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { writeText } },
+      configurable: true,
+    });
+
+    try {
+      const evt = new KeyboardEvent('keydown', {
+        key: 'c',
+        code: 'KeyC',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const prevented = !host.dispatchEvent(evt);
+
+      expect(prevented).toBe(true);
+      expect(writeText).toHaveBeenCalledWith('selected text');
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('Ctrl+C with no selection is not intercepted (falls through to SIGINT)', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+    mockTerminals[0]!.getSelection.mockReturnValue('');
+
+    const writeText = vi.fn();
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { writeText } },
+      configurable: true,
+    });
+
+    try {
+      const evt = new KeyboardEvent('keydown', {
+        key: 'c',
+        code: 'KeyC',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const dispatched = host.dispatchEvent(evt);
+
+      expect(dispatched).toBe(true);
+      expect(writeText).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('Ctrl+Shift+C copies the selection', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+    mockTerminals[0]!.getSelection.mockReturnValue('shift-copy');
+
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { writeText } },
+      configurable: true,
+    });
+
+    try {
+      const evt = new KeyboardEvent('keydown', {
+        key: 'C',
+        code: 'KeyC',
+        ctrlKey: true,
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const prevented = !host.dispatchEvent(evt);
+
+      expect(prevented).toBe(true);
+      expect(writeText).toHaveBeenCalledWith('shift-copy');
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('Cmd+C copies the selection on macOS', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+    mockTerminals[0]!.getSelection.mockReturnValue('mac-copy');
+
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { writeText } },
+      configurable: true,
+    });
+
+    try {
+      const evt = new KeyboardEvent('keydown', {
+        key: 'c',
+        code: 'KeyC',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const prevented = !host.dispatchEvent(evt);
+
+      expect(prevented).toBe(true);
+      expect(writeText).toHaveBeenCalledWith('mac-copy');
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('Ctrl+C with a selection but no clipboard write API is not intercepted (preserves SIGINT)', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+    mockTerminals[0]!.getSelection.mockReturnValue('selected but no API');
+
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: {} },
+      configurable: true,
+    });
+
+    try {
+      const evt = new KeyboardEvent('keydown', {
+        key: 'c',
+        code: 'KeyC',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const dispatched = host.dispatchEvent(evt);
+
+      expect(dispatched).toBe(true);
     } finally {
       Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
     }

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -18,6 +18,8 @@ const mockTerminals: Array<{
   cols: number;
   rows: number;
   _dataCb?: (data: string) => void;
+  _oscHandlers: Map<number, (data: string) => boolean | Promise<boolean>>;
+  parser: { registerOscHandler: ReturnType<typeof vi.fn> };
   _core: {
     _renderService: {
       clear: ReturnType<typeof vi.fn>;
@@ -40,6 +42,10 @@ vi.mock('@xterm/xterm', () => {
       getSelection: vi.fn(() => ''),
       cols: 80,
       rows: 24,
+      _oscHandlers: new Map<number, (data: string) => boolean | Promise<boolean>>(),
+      parser: {
+        registerOscHandler: vi.fn(),
+      },
       _core: {
         _renderService: {
           clear: vi.fn(),
@@ -49,6 +55,10 @@ vi.mock('@xterm/xterm', () => {
     });
     this.onData.mockImplementation((cb: (data: string) => void) => {
       this._dataCb = cb;
+    });
+    this.parser.registerOscHandler.mockImplementation((ident: number, handler: (data: string) => boolean | Promise<boolean>) => {
+      this._oscHandlers.set(ident, handler);
+      return { dispose: vi.fn() };
     });
     mockTerminals.push(this);
   });
@@ -756,6 +766,123 @@ describe('useTerminal', () => {
       const dispatched = host.dispatchEvent(evt);
 
       expect(dispatched).toBe(true);
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('OSC 52 clipboard write from the CLI is forwarded to the system clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { writeText } },
+      configurable: true,
+    });
+
+    try {
+      const { result } = renderHook(() => useTerminal('s1'));
+      const host = makeHost();
+      act(() => result.current.attach(host));
+      const handler = mockTerminals[0]!._oscHandlers.get(52);
+      expect(handler).toBeDefined();
+
+      // OSC 52 payload: "<selection>;<base64>". "hi" → "aGk=".
+      const handled = await handler!('c;aGk=');
+
+      expect(handled).toBe(true);
+      expect(writeText).toHaveBeenCalledWith('hi');
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('OSC 52 decodes multi-byte UTF-8 correctly', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { writeText } },
+      configurable: true,
+    });
+
+    try {
+      const { result } = renderHook(() => useTerminal('s1'));
+      const host = makeHost();
+      act(() => result.current.attach(host));
+      const handler = mockTerminals[0]!._oscHandlers.get(52)!;
+
+      // "café — 日本" base64-encoded from its UTF-8 bytes.
+      const b64 = Buffer.from('café — 日本', 'utf-8').toString('base64');
+      const handled = await handler(`c;${b64}`);
+
+      expect(handled).toBe(true);
+      expect(writeText).toHaveBeenCalledWith('café — 日本');
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('OSC 52 read request ("?") is declined and never leaks the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { writeText } },
+      configurable: true,
+    });
+
+    try {
+      const { result } = renderHook(() => useTerminal('s1'));
+      const host = makeHost();
+      act(() => result.current.attach(host));
+      const handler = mockTerminals[0]!._oscHandlers.get(52)!;
+
+      const handled = await handler('c;?');
+
+      expect(handled).toBe(false);
+      expect(writeText).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('OSC 52 with malformed base64 is declined cleanly', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: { writeText } },
+      configurable: true,
+    });
+
+    try {
+      const { result } = renderHook(() => useTerminal('s1'));
+      const host = makeHost();
+      act(() => result.current.attach(host));
+      const handler = mockTerminals[0]!._oscHandlers.get(52)!;
+
+      const handled = await handler('c;@@not-base64@@');
+
+      expect(handled).toBe(false);
+      expect(writeText).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+    }
+  });
+
+  it('OSC 52 is declined when the clipboard write API is unavailable', async () => {
+    const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { ...originalNav, clipboard: {} },
+      configurable: true,
+    });
+
+    try {
+      const { result } = renderHook(() => useTerminal('s1'));
+      const host = makeHost();
+      act(() => result.current.attach(host));
+      const handler = mockTerminals[0]!._oscHandlers.get(52)!;
+
+      const handled = await handler('c;aGk=');
+
+      expect(handled).toBe(false);
     } finally {
       Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
     }

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -388,6 +388,11 @@ function createEntry(id: string, ioKind: IoKind): RegistryEntry {
   const fitAddon = new FitAddon();
   term.loadAddon(fitAddon);
 
+  // Service OSC 52 clipboard writes from the running CLI (e.g. Copilot
+  // CLI's in-app copy). xterm drops OSC 52 by default, which silently
+  // breaks copy from inside the TUI even though it reports success.
+  term.parser.registerOscHandler(52, handleOsc52);
+
   term.onData((data) => {
     const sendInput = ioKind === 'session' ? sessionInput({ sessionId: id, data }) : subSessionInput({ id: id as SubSessionId, data });
     void sendInput.catch((err: unknown) => {
@@ -515,10 +520,71 @@ function copySelectionToClipboard(entry: RegistryEntry): boolean {
   const selection = entry.term.getSelection();
   if (!selection) return false;
   if (!canWriteClipboard()) return false;
-  void navigator.clipboard.writeText(selection).catch((err: unknown) => {
+  writeTextToClipboard(selection);
+  return true;
+}
+
+/**
+ * Fire-and-forget write to the system clipboard via
+ * `navigator.clipboard.writeText()`. Shared by the Ctrl/Cmd+C selection
+ * copy and the OSC 52 handler. Callers gate on [`canWriteClipboard`]
+ * first; failures are logged but never surfaced to the user.
+ */
+function writeTextToClipboard(text: string): void {
+  void navigator.clipboard.writeText(text).catch((err: unknown) => {
     const message = err instanceof Error ? err.message : String(err);
     console.warn(`[use-terminal] clipboard.writeText() failed: ${message}`);
   });
+}
+
+/**
+ * Decode an OSC 52 base64 payload into a UTF-8 string. The payload is
+ * base64 of the raw UTF-8 bytes, so we cannot use `atob` alone (it would
+ * mangle any multi-byte character) — we re-interpret the binary string
+ * as bytes and run them through `TextDecoder`. Returns `null` on any
+ * malformed input so the handler can decline the sequence cleanly.
+ */
+function decodeOsc52Payload(b64: string): string | null {
+  try {
+    const binary = atob(b64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Handle an OSC 52 clipboard sequence emitted by the running CLI.
+ *
+ * TUI programs (notably GitHub Copilot CLI's in-app "copy" action) put
+ * text on the system clipboard by emitting `OSC 52 ; <selection> ; <b64> ST`
+ * rather than going through any browser copy event. xterm.js does NOT
+ * service OSC 52 by default — it silently drops the sequence — so the
+ * CLI reports "copy successful" while the system clipboard never
+ * actually changes. We register this handler to close that gap.
+ *
+ * `data` is the parser payload after the `52;` identifier, i.e.
+ * `"<selection>;<base64-or-?>"`. We ignore the selection target (we
+ * always write the system clipboard) and decline read requests
+ * (`payload === '?'`) — servicing those would let the remote program
+ * exfiltrate the user's clipboard, which we deliberately do not allow.
+ *
+ * Returns `true` only when we actually wrote, so xterm knows the
+ * sequence was consumed; otherwise `false` so xterm falls back to its
+ * default (drop) behaviour.
+ */
+function handleOsc52(data: string): boolean {
+  const sep = data.indexOf(';');
+  if (sep === -1) return false;
+  const payload = data.slice(sep + 1);
+  // `?` is a paste/read request — decline it (never leak the clipboard to the program).
+  if (payload === '?' || payload === '') return false;
+  if (!canWriteClipboard()) return false;
+  const text = decodeOsc52Payload(payload);
+  if (text === null) return false;
+  writeTextToClipboard(text);
   return true;
 }
 

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -2,68 +2,39 @@
 //
 // Design notes
 // ------------
-// * One `Terminal` instance per `sessionId` lives in a **module-scoped Map**
-//   (`registry`) so it survives any React component unmount — including the
-//   tab-switch case (see docs/product.md T-03). The hook returned by `useTerminal()` only
-//   ever attaches / detaches a terminal from the DOM; it never disposes.
-// * Disposal is tied to *session lifetime*, not component lifetime. A single
-//   subscription to the session store fires `disposeTerminal()` when an id
+// * One `Terminal` instance per `sessionId` lives in a **module-scoped Map** (`registry`) so it survives any React component unmount — including the
+//   tab-switch case (see docs/product.md T-03). The hook returned by `useTerminal()` only ever attaches / detaches a terminal from the DOM; it never
+//   disposes.
+// * Disposal is tied to *session lifetime*, not component lifetime. A single subscription to the session store fires `disposeTerminal()` when an id
 //   disappears from `sessions`.
-// * Output bypasses Zustand entirely (see docs/architecture.md): a single
-//   `onSessionOutput` listener is attached at boot via the explicit
-//   `initTerminalRouter()` (called from `App.tsx`) and demuxes by
-//   `sessionId` to the relevant `Terminal`. The lazy fallback inside
-//   `useTerminal` remains for safety so any code path that creates a
-//   terminal without going through boot still sees output.
-// * `attach` is idempotent: a second call with the same host element is a
-//   no-op; a call with a different host implicitly re-parents.
-// * `ResizeObserver` is debounced ~50 ms, then drives `fitAddon.fit()` →
-//   `session_resize`. The observer is owned per-attachment (i.e. lives until
+// * Output bypasses Zustand entirely (see docs/architecture.md): a single `onSessionOutput` listener is attached at boot via the explicit
+//   `initTerminalRouter()` (called from `App.tsx`) and demuxes by `sessionId` to the relevant `Terminal`. The lazy fallback inside `useTerminal`
+//   remains for safety so any code path that creates a terminal without going through boot still sees output.
+// * `attach` is idempotent: a second call with the same host element is a no-op; a call with a different host implicitly re-parents.
+// * `ResizeObserver` is debounced ~50 ms, then drives `fitAddon.fit()` → `session_resize`. The observer is owned per-attachment (i.e. lives until
 //   `detach()`); the terminal itself outlives it.
-// * `refit()` is exposed so callers can imperatively re-measure + repaint the
-//   terminal — used on tab activation (the host doesn't change size on tab
-//   switch, so ResizeObserver wouldn't otherwise fire) and after web fonts
-//   resolve. It runs `fit()` + `term.refresh()` to recover from any stale
-//   renderer state (e.g. measurements taken pre-font-load or while the
-//   panel was `visibility: hidden`).
-// * Wake/visibility/DPI refit: when the OS sleeps, WebView2 can suspend its
-//   renderer; on resume the canvas/inline-size state can be stale even
-//   though the host's CSS box never changed (so `ResizeObserver` doesn't
-//   fire). We listen for `document.visibilitychange` (visible again),
-//   `window.focus` (covers WebView2 cases where focus returns without a
-//   visibility transition) and `matchMedia('(resolution: <DPR>dppx)')`
-//   `change` (DPI change from docking/undocking), and refit only the
-//   *active* terminal. Hidden terminals (kept mounted by `MainArea` with
-//   `visibility: hidden`) are deliberately skipped — `TerminalView`'s
-//   `isActive` effect already runs `refit()` on tab activation, so they
-//   self-heal when the user switches to them. This keeps the wake pass
-//   O(1) regardless of how many sessions are open. All triggers are
-//   coalesced through a single `rAF` so a sleep→wake that fires multiple
-//   events still only does one refit pass.
+// * `refit()` is exposed so callers can imperatively re-measure + repaint the terminal — used on tab activation (the host doesn't change size on tab
+//   switch, so ResizeObserver wouldn't otherwise fire) and after web fonts resolve. It runs `fit()` + `term.refresh()` to recover from any stale
+//   renderer state (e.g. measurements taken pre-font-load or while the panel was `visibility: hidden`).
+// * Wake/visibility/DPI refit: when the OS sleeps, WebView2 can suspend its renderer; on resume the canvas/inline-size state can be stale even though
+//   the host's CSS box never changed (so `ResizeObserver` doesn't fire). We listen for `document.visibilitychange` (visible again), `window.focus`
+//   (covers WebView2 cases where focus returns without a visibility transition) and `matchMedia('(resolution: <DPR>dppx)')` `change` (DPI change from
+//   docking/undocking), and refit only the *active* terminal. Hidden terminals (kept mounted by `MainArea` with `visibility: hidden`) are
+//   deliberately skipped — `TerminalView`'s `isActive` effect already runs `refit()` on tab activation, so they self-heal when the user switches to
+//   them. This keeps the wake pass O(1) regardless of how many sessions are open. All triggers are coalesced through a single `rAF` so a sleep→wake
+//   that fires multiple events still only does one refit pass.
 //
-//   Workspace-switch safety (see docs/runtime-flows.md#workspace-switching):
-//   `workspace_switch` parks every session in the outgoing workspace
-//   (PTY killed, persisted record preserved) and inline-restores the new
-//   workspace's sessions under a write barrier. The session-store
-//   subscription disposes each terminal entry as its id leaves the
-//   store, then `adoptWorkspace` atomically swaps in the new session
-//   list + reconciled `activeId`. Wake-refit must remain safe across
-//   that transition without any explicit teardown of the install-once
-//   wake listeners. Three guards make this true:
-//     1. `scheduleWakeRefit` reads `useSessionStore.getState().activeId`
-//        *inside* its `rAF` callback (not at install time), so it sees
-//        the post-`adoptWorkspace` value.
-//     2. Before calling `refitEntry` it checks
-//        `entry.wrapper.isConnected`; parked / disposed entries either
-//        return `undefined` from `registry.get` (no entry) or fail the
-//        `isConnected` check, and the callback no-ops.
-//     3. `refitEntry` itself re-checks `entry.wrapper.isConnected` and
-//        the surrounding call site is wrapped in `try/catch`.
-//   A wake event firing in the orphan window between disposal and
-//   adopt is therefore a benign no-op; the next wake event after
-//   `adoptWorkspace` refits the new active session. Pinned by the
-//   "survives a workspace-switch orphan window" test in
-//   `use-terminal.test.tsx`.
+//   Workspace-switch safety (see docs/runtime-flows.md#workspace-switching): `workspace_switch` parks every session in the outgoing workspace (PTY
+//   killed, persisted record preserved) and inline-restores the new workspace's sessions under a write barrier. The session-store subscription
+//   disposes each terminal entry as its id leaves the store, then `adoptWorkspace` atomically swaps in the new session list + reconciled `activeId`.
+//   Wake-refit must remain safe across that transition without any explicit teardown of the install-once wake listeners. Three guards make this true:
+//     1. `scheduleWakeRefit` reads `useSessionStore.getState().activeId` *inside* its `rAF` callback (not at install time), so it sees the
+//        post-`adoptWorkspace` value.
+//     2. Before calling `refitEntry` it checks `entry.wrapper.isConnected`; parked / disposed entries either return `undefined` from `registry.get`
+//        (no entry) or fail the `isConnected` check, and the callback no-ops.
+//     3. `refitEntry` itself re-checks `entry.wrapper.isConnected` and the surrounding call site is wrapped in `try/catch`.
+//   A wake event firing in the orphan window between disposal and adopt is therefore a benign no-op; the next wake event after `adoptWorkspace`
+//   refits the new active session. Pinned by the "survives a workspace-switch orphan window" test in `use-terminal.test.tsx`.
 
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
@@ -114,15 +85,11 @@ let storeUnsubscribe: (() => void) | null = null;
 let subStoreUnsubscribe: (() => void) | null = null;
 let fontsReadyAttached = false;
 
-// Wake-refit listener state. All module-scope state in this block —
-// the install flag, the rAF/timer coalescing handles, the visibility/
-// focus listener references, and the DPI media query plus its
-// API-agnostic detach closure — is owned by `ensureWakeListeners()`
-// (install) and `teardownWakeListeners()` (test-only cleanup); no other
-// site reads or mutates it. The DPI media query is re-attached against
-// the new DPR after every fire because `(resolution: Xdppx)` queries
-// are pinned to a specific value — so we listen for the *current* DPR
-// transitioning false, then re-arm.
+// Wake-refit listener state. All module-scope state in this block — the install flag, the rAF/timer coalescing handles, the visibility/focus listener
+// references, and the DPI media query plus its API-agnostic detach closure — is owned by `ensureWakeListeners()` (install) and
+// `teardownWakeListeners()` (test-only cleanup); no other site reads or mutates it. The DPI media query is re-attached against the new DPR after
+// every fire because `(resolution: Xdppx)` queries are pinned to a specific value — so we listen for the *current* DPR transitioning false, then
+// re-arm.
 let wakeListenersInstalled = false;
 let wakeRefitPending = false;
 let wakeRefitFrame: number | null = null;
@@ -130,19 +97,14 @@ let wakeRefitFallbackTimer: ReturnType<typeof setTimeout> | null = null;
 let visibilityListener: (() => void) | null = null;
 let focusListener: (() => void) | null = null;
 let dpiMediaQuery: MediaQueryList | null = null;
-// Detach closure captured at install time — invokes either
-// `removeEventListener('change', ...)` (modern) or `removeListener(...)`
-// (legacy WebView fallback) so teardown doesn't have to know which API
-// the runtime supports.
+// Detach closure captured at install time — invokes either `removeEventListener('change', ...)` (modern) or `removeListener(...)` (legacy WebView
+// fallback) so teardown doesn't have to know which API the runtime supports.
 let dpiMediaQueryDetach: (() => void) | null = null;
 
 /**
- * Coalesce multiple wake triggers (visibility, focus, DPI) into a single
- * refit pass per animation frame. Only refits the *active* session;
- * hidden sessions (kept mounted by `MainArea` with `visibility: hidden`)
- * are skipped because `TerminalView`'s `isActive` effect already runs
- * `refit()` when the user switches to them — so they self-heal lazily.
- * This keeps wake work O(1) regardless of session count.
+ * Coalesce multiple wake triggers (visibility, focus, DPI) into a single refit pass per animation frame. Only refits the *active* session; hidden
+ * sessions (kept mounted by `MainArea` with `visibility: hidden`) are skipped because `TerminalView`'s `isActive` effect already runs `refit()` when
+ * the user switches to them — so they self-heal lazily. This keeps wake work O(1) regardless of session count.
  */
 function scheduleWakeRefit(): void {
   if (wakeRefitPending) return;
@@ -174,13 +136,10 @@ function scheduleWakeRefit(): void {
 }
 
 /**
- * Install/refresh the DPI media-query listener. We pin to the current DPR;
- * when it transitions (docking/undocking, monitor change during sleep) we
- * refit and re-arm against the new DPR. Idempotent w.r.t. an already-armed
- * query — the caller is expected to clear `dpiMediaQuery` before re-arming.
+ * Install/refresh the DPI media-query listener. We pin to the current DPR; when it transitions (docking/undocking, monitor change during sleep) we
+ * refit and re-arm against the new DPR. Idempotent w.r.t. an already-armed query — the caller is expected to clear `dpiMediaQuery` before re-arming.
  *
- * Older WebViews only expose the legacy `addListener`/`removeListener` API
- * on `MediaQueryList` (no `addEventListener`); we mirror the fallback used
+ * Older WebViews only expose the legacy `addListener`/`removeListener` API on `MediaQueryList` (no `addEventListener`); we mirror the fallback used
  * in `App.tsx` for the dark-mode media query.
  */
 function installDpiListener(): void {
@@ -190,8 +149,7 @@ function installDpiListener(): void {
   try {
     mq = window.matchMedia(`(resolution: ${dpr}dppx)`);
   } catch {
-    // Some older WebViews don't support `resolution` in matchMedia syntax.
-    // DPI changes are best-effort; visibility/focus still cover sleep/wake.
+    // Some older WebViews don't support `resolution` in matchMedia syntax. DPI changes are best-effort; visibility/focus still cover sleep/wake.
     return;
   }
   let detach: (() => void) | null = null;
@@ -227,8 +185,7 @@ function installDpiListener(): void {
     }
     detach = (): void => mq.removeListener(listener);
   } else {
-    // Neither API available — DPI changes will go unhandled, but
-    // visibility/focus still cover sleep/wake.
+    // Neither API available — DPI changes will go unhandled, but visibility/focus still cover sleep/wake.
     return;
   }
   dpiMediaQuery = mq;
@@ -236,9 +193,8 @@ function installDpiListener(): void {
 }
 
 /**
- * Wire up wake/visibility/DPI listeners that recover the renderer after
- * the OS suspends WebView2 (system sleep, monitor unplug, etc). Idempotent;
- * a second call is a no-op. See file header for the design rationale.
+ * Wire up wake/visibility/DPI listeners that recover the renderer after the OS suspends WebView2 (system sleep, monitor unplug, etc). Idempotent; a
+ * second call is a no-op. See file header for the design rationale.
  */
 function ensureWakeListeners(): void {
   if (wakeListenersInstalled) return;
@@ -259,8 +215,8 @@ function ensureWakeListeners(): void {
 }
 
 /**
- * Test-only: tear down the wake listeners installed by `ensureWakeListeners`.
- * Called from `__resetTerminalRegistryForTests` so each test starts clean.
+ * Test-only: tear down the wake listeners installed by `ensureWakeListeners`. Called from `__resetTerminalRegistryForTests` so each test starts
+ * clean.
  */
 function teardownWakeListeners(): void {
   if (typeof document !== 'undefined' && visibilityListener) {
@@ -297,21 +253,17 @@ function ensureGlobalSubscriptions(): void {
     outputUnlisten = onSessionOutput((payload) => {
       const entry = registry.get(payload.sessionId);
       if (!entry) {
-        // Race: output for a session not (yet) tracked. Tolerable — the
-        // session-create handshake is synchronous so the only way to land
-        // here is for output to arrive after the terminal has been
-        // disposed, which by definition no one cares about.
+        // Race: output for a session not (yet) tracked. Tolerable — the session-create handshake is synchronous so the only way to land here is for
+        // output to arrive after the terminal has been disposed, which by definition no one cares about.
         if (typeof console !== 'undefined') {
           console.debug(`[use-terminal] dropping output for unknown session ${payload.sessionId}`);
         }
         return;
       }
       entry.term.write(payload.data);
-      // Tier-4 unread indicator. `noteUnread` is a no-op for unknown ids
-      // (e.g. sub-session output, which shares the `session://output`
-      // channel) and for already-flagged sessions, so this stays cheap on
-      // the hot path. Skip outright for non-session entries to make the
-      // intent obvious and keep the store untouched on sub-session traffic.
+      // Tier-4 unread indicator. `noteUnread` is a no-op for unknown ids (e.g. sub-session output, which shares the `session://output` channel) and
+      // for already-flagged sessions, so this stays cheap on the hot path. Skip outright for non-session entries to make the intent obvious and keep
+      // the store untouched on sub-session traffic.
       if (entry.ioKind === 'session') {
         useSessionStore.getState().actions.noteUnread(payload.sessionId);
       }
@@ -344,11 +296,9 @@ function ensureGlobalSubscriptions(): void {
     });
   }
 
-  // Best-effort: once web fonts have settled, refit every attached terminal.
-  // Initial fits taken before the monospace font fully loaded can produce
-  // wrong cell metrics, leaving the renderer "squished" until the next
-  // window resize. Guarded — the FontFaceSet API isn't available in older
-  // WebViews and may not exist in jsdom.
+  // Best-effort: once web fonts have settled, refit every attached terminal. Initial fits taken before the monospace font fully loaded can produce
+  // wrong cell metrics, leaving the renderer "squished" until the next window resize. Guarded — the FontFaceSet API isn't available in older WebViews
+  // and may not exist in jsdom.
   if (!fontsReadyAttached && typeof document !== 'undefined' && 'fonts' in document && document.fonts && typeof document.fonts.ready === 'object') {
     fontsReadyAttached = true;
     void document.fonts.ready
@@ -368,10 +318,8 @@ function ensureGlobalSubscriptions(): void {
 }
 
 /**
- * Explicit boot-time entry point that wires the global `session://output`
- * listener and the session-store subscription that disposes terminals when
- * their session is removed. Idempotent: a second call does nothing. Called
- * from `App.tsx` once hydrate completes; the lazy fallback inside
+ * Explicit boot-time entry point that wires the global `session://output` listener and the session-store subscription that disposes terminals when
+ * their session is removed. Idempotent: a second call does nothing. Called from `App.tsx` once hydrate completes; the lazy fallback inside
  * `useTerminal` remains as a safety net for tests / non-boot code paths.
  */
 export function initTerminalRouter(): void {
@@ -421,10 +369,8 @@ function getOrCreate(id: string, ioKind: IoKind): RegistryEntry {
     entry = createEntry(id, ioKind);
     registry.set(id, entry);
   } else if (entry.ioKind !== ioKind) {
-    // Defensive: a UUID collision across the session and sub-session id
-    // spaces would be a load-bearing bug — both routes share the registry,
-    // and the input/resize callbacks are baked into the entry on creation.
-    // Surface it loudly rather than silently mis-routing input.
+    // Defensive: a UUID collision across the session and sub-session id spaces would be a load-bearing bug — both routes share the registry, and the
+    // input/resize callbacks are baked into the entry on creation. Surface it loudly rather than silently mis-routing input.
     throw new Error(`[use-terminal] id ${id} already registered as ${entry.ioKind}, requested ${ioKind}`);
   }
   return entry;
@@ -458,12 +404,9 @@ function teardownKeydownListener(entry: RegistryEntry): void {
 /**
  * Whether the async clipboard read API is available in this runtime.
  *
- * Used by both Ctrl/Cmd+V interception and the `paste` event listener
- * fallback to decide *up front* whether they have any chance of
- * actually pasting. If this returns `false`, the listeners must NOT
- * cancel the event — letting the event propagate gives xterm (or any
- * other interested handler) a chance to act on it instead of leaving
- * the user with a silent no-op.
+ * Used by both Ctrl/Cmd+V interception and the `paste` event listener fallback to decide *up front* whether they have any chance of actually pasting.
+ * If this returns `false`, the listeners must NOT cancel the event — letting the event propagate gives xterm (or any other interested handler) a
+ * chance to act on it instead of leaving the user with a silent no-op.
  */
 function canReadClipboard(): boolean {
   return typeof navigator !== 'undefined' && typeof navigator.clipboard?.readText === 'function';
@@ -633,9 +576,8 @@ function handleCopyShortcut(event: KeyboardEvent, entry: RegistryEntry): boolean
 }
 
 /**
- * Shape of the bits of xterm's `_core` we poke at via private API to fix
- * fit-time DOM-sizing quirks (see `refitEntry`). Any missing piece is
- * silently skipped — every call site uses optional chaining.
+ * Shape of the bits of xterm's `_core` we poke at via private API to fix fit-time DOM-sizing quirks (see `refitEntry`). Any missing piece is silently
+ * skipped — every call site uses optional chaining.
  */
 interface XtermCorePeek {
   _core?: {
@@ -647,43 +589,30 @@ interface XtermCorePeek {
 }
 
 /**
- * Re-measure + repaint a single terminal. Safe to call on an unattached or
- * zero-size terminal (no-ops). Only emits `sessionResize` when cols/rows
+ * Re-measure + repaint a single terminal. Safe to call on an unattached or zero-size terminal (no-ops). Only emits `sessionResize` when cols/rows
  * have actually changed since the last successful fit.
  *
  * Why this is more than just `fitAddon.fit()` plus `refresh()`:
  *
- * The renderer writes the `.xterm-screen` and row elements' size as
- * **inline styles** in pixels (DomRenderer._updateDimensions: width =
- * `cols × cell.width`, height = `rows × cell.height`). Those inline sizes
- * are only refreshed by four code paths inside xterm: `term.resize()`,
- * the `onCharSizeChange` event, the `onDevicePixelRatioChange` handler,
- * and an option change. When the renderer's inline sizes drift out of
- * sync with the host's actual CSS box (the easy way: any sequence where
- * the host's box is sized AFTER the renderer first wrote inline pixels —
- * visibility transition, late layout pass, parent flex resolving after
- * mount) the terminal looks "squished" or "doesn't fit" until something
- * triggers one of those four paths.
+ * The renderer writes the `.xterm-screen` and row elements' size as **inline styles** in pixels (DomRenderer._updateDimensions: width = `cols ×
+ * cell.width`, height = `rows × cell.height`). Those inline sizes are only refreshed by four code paths inside xterm: `term.resize()`, the
+ * `onCharSizeChange` event, the `onDevicePixelRatioChange` handler, and an option change. When the renderer's inline sizes drift out of sync with the
+ * host's actual CSS box (the easy way: any sequence where the host's box is sized AFTER the renderer first wrote inline pixels — visibility
+ * transition, late layout pass, parent flex resolving after mount) the terminal looks "squished" or "doesn't fit" until something triggers one of
+ * those four paths.
  *
- * `FitAddon.fit()` only triggers `term.resize()` when proposed cols/rows
- * differ from current. Window resizes naturally take that branch (the
- * host's CSS width genuinely changes); tab activation, fonts.ready, and
- * the manual force-refit hit the no-op branch and leave stale inline
- * sizes intact. We mirror what fit() *would* have done by:
+ * `FitAddon.fit()` only triggers `term.resize()` when proposed cols/rows differ from current. Window resizes naturally take that branch (the host's
+ * CSS width genuinely changes); tab activation, fonts.ready, and the manual force-refit hit the no-op branch and leave stale inline sizes intact. We
+ * mirror
+ * what fit() *would* have done by:
  *
- *   1. Calling `_renderService.handleCharSizeChanged()` after fit() —
- *      forces `_updateDimensions` to re-apply `cols × cell.width` and
- *      `rows × cell.height` to every row + `.xterm-screen` element.
- *      Cheap when nothing actually changed; effective when the inline
- *      sizes were stale.
- *   2. Calling `_renderService.clear()` so the renderer drops any cached
- *      paint state from the previous (stale) layout — same call FitAddon
- *      itself uses internally on the resize branch.
+ *   1. Calling `_renderService.handleCharSizeChanged()` after fit() — forces `_updateDimensions` to re-apply `cols × cell.width` and `rows ×
+ *      cell.height` to every row + `.xterm-screen` element. Cheap when nothing actually changed; effective when the inline sizes were stale.
+ *   2. Calling `_renderService.clear()` so the renderer drops any cached paint state from the previous (stale) layout — same call FitAddon itself
+ *      uses internally on the resize branch.
  *
- * Both pokes use private xterm APIs that `FitAddon` itself uses
- * internally. They are guarded with optional chaining so a future xterm
- * major that renames or removes them simply degrades to today's
- * stale-state behavior rather than crashing.
+ * Both pokes use private xterm APIs that `FitAddon` itself uses internally. They are guarded with optional chaining so a future xterm major that
+ * renames or removes them simply degrades to today's stale-state behavior rather than crashing.
  */
 function refitEntry(id: string, entry: RegistryEntry): void {
   if (!entry.wrapper || !entry.wrapper.isConnected) return;
@@ -691,17 +620,14 @@ function refitEntry(id: string, entry: RegistryEntry): void {
   try {
     entry.fitAddon.fit();
   } catch {
-    // fit() throws on zero-size hosts (e.g. an ancestor is display:none).
-    // Bail without clearing any pending debounced fit — that fit was
-    // queued for a reason (a real ResizeObserver tick) and may still be
-    // wanted once the host is sized again. The next observer tick when
-    // the host gains a non-zero rect will also reschedule.
+    // fit() throws on zero-size hosts (e.g. an ancestor is display:none). Bail without clearing any pending debounced fit — that fit was queued for a
+    // reason (a real ResizeObserver tick) and may still be wanted once the host is sized again. The next observer tick when the host gains a non-zero
+    // rect will also reschedule.
     return;
   }
 
-  // Successful fit — we own the freshly-measured state, so any pending
-  // debounced fit is now redundant. Clear it before any further bail-outs
-  // so the invariant "successful fit ⇒ no stale debounce" always holds.
+  // Successful fit — we own the freshly-measured state, so any pending debounced fit is now redundant. Clear it before any further bail-outs so the
+  // invariant "successful fit ⇒ no stale debounce" always holds.
   if (entry.resizeTimer !== null) {
     clearTimeout(entry.resizeTimer);
     entry.resizeTimer = null;
@@ -713,27 +639,23 @@ function refitEntry(id: string, entry: RegistryEntry): void {
 
   const renderService = (entry.term as unknown as XtermCorePeek)._core?._renderService;
 
-  // (1) Force re-application of the renderer's inline sizes
-  // (.xterm-screen + row elements) from current cols × cell.width. See
-  // the doc comment above for why this is the missing piece that makes a
-  // programmatic refit behave like a window resize.
+  // (1) Force re-application of the renderer's inline sizes (.xterm-screen + row elements) from current cols × cell.width. See the doc comment above
+  // for why this is the missing piece that makes a programmatic refit behave like a window resize.
   try {
     renderService?.handleCharSizeChanged?.();
   } catch {
     // Ignore — best-effort.
   }
 
-  // (2) Drop any cached paint state so the next render frame starts
-  // fresh. Same call FitAddon uses on its resize branch.
+  // (2) Drop any cached paint state so the next render frame starts fresh. Same call FitAddon uses on its resize branch.
   try {
     renderService?.clear?.();
   } catch {
     // Ignore — best-effort.
   }
 
-  // Belt-and-suspenders: refresh the visible viewport so any renderer
-  // that ignored clear() (or that batches dirty rows) still repaints.
-  // Bounded to viewport (not scrollback) so this is cheap.
+  // Belt-and-suspenders: refresh the visible viewport so any renderer that ignored clear() (or that batches dirty rows) still repaints. Bounded to
+  // viewport (not scrollback) so this is cheap.
   try {
     entry.term.refresh(0, rows - 1);
   } catch {
@@ -777,9 +699,8 @@ function attachToHost(id: string, entry: RegistryEntry, host: HTMLDivElement): v
     entry.term.open(wrapper);
   }
 
-  // Synchronous initial fit — don't rely on ResizeObserver's first tick
-  // (which races with font loading and can leave the renderer in a stale
-  // state if it fires too early).
+  // Synchronous initial fit — don't rely on ResizeObserver's first tick (which races with font loading and can leave the renderer in a stale state if
+  // it fires too early).
   refitEntry(id, entry);
 
   // Capture-phase keydown listener on the host with three responsibilities, each delegated to a helper that returns whether it consumed the event:
@@ -801,23 +722,15 @@ function attachToHost(id: string, entry: RegistryEntry, host: HTMLDivElement): v
   host.addEventListener('keydown', keydownListener as EventListener, true);
   entry.keydownListener = keydownListener;
 
-  // Paste support. xterm.js installs its own paste listeners on the
-  // textarea AND on its element (`xterm/src/browser/Clipboard.ts`), and
-  // its handler calls `event.stopPropagation()` — so a bubble-phase
-  // listener at the host **never fires**. Worse, in the Tauri/WebView2
-  // environment the `clipboardData` xterm receives via that path is
-  // sometimes empty (Ctrl+V / right-click → Paste / X11 middle-click all
-  // silently no-op). We capture at the host, which runs before any
-  // descendant listener; we own the event end-to-end. If `clipboardData`
-  // is populated we use it directly (works without permission, since the
-  // user gesture supplies the data). Otherwise we fall back to the async
-  // `navigator.clipboard.readText()` — slower, may prompt in some
-  // environments, but recovers when the WebView won't fill clipboardData.
+  // Paste support. xterm.js installs its own paste listeners on the textarea AND on its element (`xterm/src/browser/Clipboard.ts`), and its handler
+  // calls `event.stopPropagation()` — so a bubble-phase listener at the host **never fires**. Worse, in the Tauri/WebView2 environment the
+  // `clipboardData` xterm receives via that path is sometimes empty (Ctrl+V / right-click → Paste / X11 middle-click all silently no-op). We capture
+  // at the host, which runs before any descendant listener; we own the event end-to-end. If `clipboardData` is populated we use it directly (works
+  // without permission, since the user gesture supplies the data). Otherwise we fall back to the async `navigator.clipboard.readText()` — slower, may
+  // prompt in some environments, but recovers when the WebView won't fill clipboardData.
   //
-  // Cancellation policy: only call `preventDefault`/`stopPropagation`
-  // when we have something to paste (inline payload) or a viable async
-  // fallback. If both are unavailable we let the event continue so
-  // xterm or any other listener still has a shot at handling it.
+  // Cancellation policy: only call `preventDefault`/`stopPropagation` when we have something to paste (inline payload) or a viable async fallback. If
+  // both are unavailable we let the event continue so xterm or any other listener still has a shot at handling it.
   const pasteListener = (event: ClipboardEvent): void => {
     const inline = event.clipboardData?.getData('text/plain') ?? '';
     if (inline) {
@@ -852,8 +765,7 @@ function detachFromHost(entry: RegistryEntry): void {
     entry.wrapper.parentElement.removeChild(entry.wrapper);
   }
   entry.host = null;
-  // Keep `entry.wrapper` so `attach` can re-parent without re-running
-  // `term.open`, which would re-initialise xterm's renderer state.
+  // Keep `entry.wrapper` so `attach` can re-parent without re-running `term.open`, which would re-initialise xterm's renderer state.
 }
 
 export interface UseTerminalApi {
@@ -861,29 +773,21 @@ export interface UseTerminalApi {
   detach: () => void;
   focus: () => void;
   /**
-   * Imperatively re-measure + repaint the terminal. Use after a parent
-   * visibility transition (e.g. tab activation) — the host's CSS box
-   * doesn't change size on `visibility: hidden` ↔ `visible`, so
-   * ResizeObserver wouldn't fire on its own. No-op if the terminal isn't
-   * attached or has zero dimensions.
+   * Imperatively re-measure + repaint the terminal. Use after a parent visibility transition (e.g. tab activation) — the host's CSS box doesn't
+   * change size on `visibility: hidden` ↔ `visible`, so ResizeObserver wouldn't fire on its own. No-op if the terminal isn't attached or has zero
+   * dimensions.
    */
   refit: () => void;
   /**
-   * Clear the visible viewport AND scrollback. Lighter than
-   * `term.reset()` (which also resets parsing state and rebuilds the
-   * renderer); we only want to wipe what the user sees so the next
-   * session starts clean. No-op when there's no entry yet.
+   * Clear the visible viewport AND scrollback. Lighter than `term.reset()` (which also resets parsing state and rebuilds the renderer); we only want
+   * to wipe what the user sees so the next session starts clean. No-op when there's no entry yet.
    *
-   * Used by `SubTerminalView` on the exited→starting transition so a
-   * relaunched terminal doesn't begin atop the previous run's final
-   * frame.
+   * Used by `SubTerminalView` on the exited→starting transition so a relaunched terminal doesn't begin atop the previous run's final frame.
    */
   clear: () => void;
   /**
-   * Current xterm `cols`/`rows` for this session, or `null` if the
-   * terminal has no entry yet (created lazily on first `attach`/render).
-   * Used by callers that need to drive a backend respawn at the right
-   * size (e.g. `session_restart` after a crash).
+   * Current xterm `cols`/`rows` for this session, or `null` if the terminal has no entry yet (created lazily on first `attach`/render). Used by
+   * callers that need to drive a backend respawn at the right size (e.g. `session_restart` after a crash).
    */
   getDimensions: () => InitialPtyDims | null;
 }
@@ -931,17 +835,14 @@ function useTerminalInternal(id: string, ioKind: IoKind): UseTerminalApi {
   const clear = useCallback(() => {
     const entry = registry.get(idRef.current);
     if (!entry) return;
-    // xterm's `clear()` wipes viewport + scrollback but preserves
-    // renderer/state — exactly what we want for a sub-session
-    // relaunch (heavier `reset()` would re-init the renderer and
-    // briefly flash).
+    // xterm's `clear()` wipes viewport + scrollback but preserves renderer/state — exactly what we want for a sub-session relaunch (heavier `reset()`
+    // would re-init the renderer and briefly flash).
     entry.term.clear();
   }, []);
 
   const getDimensions = useCallback(() => getTerminalDimensions(idRef.current), []);
 
-  // Eagerly create the terminal so `session://output` events are buffered
-  // by xterm even before `attach` runs.
+  // Eagerly create the terminal so `session://output` events are buffered by xterm even before `attach` runs.
   useEffect(() => {
     getOrCreate(id, ioKind);
   }, [id, ioKind]);
@@ -950,21 +851,15 @@ function useTerminalInternal(id: string, ioKind: IoKind): UseTerminalApi {
 }
 
 /**
- * Initial PTY dimensions handed to `session_create` / `session_restart`
- * before the frontend has a chance to mount + fit the xterm Terminal.
+ * Initial PTY dimensions handed to `session_create` / `session_restart` before the frontend has a chance to mount + fit the xterm Terminal.
  *
- * The pre-fix bug: the backend always opened the PTY at
- * `DEFAULT_PTY_SIZE` (80×24), so the CLI's first paint (the splash, the
- * first prompt) was rendered at 80 cols regardless of how wide the
- * actual host turned out to be. The eventual `session_resize` from
- * `fitAddon.fit()` came after the splash had already been drawn into
- * scrollback at 80-col layout. Frontend code now passes the real
- * intended dims at create/restart time so the child's first byte sees
- * the right width.
+ * The pre-fix bug: the backend always opened the PTY at `DEFAULT_PTY_SIZE` (80×24), so the CLI's first paint (the splash, the first prompt) was
+ * rendered at 80 cols regardless of how wide the actual host turned out to be. The eventual `session_resize` from `fitAddon.fit()` came after the
+ * splash had already been drawn into scrollback at 80-col layout. Frontend code now passes the real intended dims at create/restart time so the
+ * child's first byte sees the right width.
  *
- * This file is the right home because the per-session xterm registry
- * (where existing terminals can be sampled for accurate dims) is
- * module-private here.
+ * This file is the right home because the per-session xterm registry (where existing terminals can be sampled for accurate dims) is module-private
+ * here.
  */
 export interface InitialPtyDims {
   cols: number;
@@ -972,12 +867,9 @@ export interface InitialPtyDims {
 }
 
 /**
- * Conservative starting point used when no live terminal exists to
- * sample (very-first-session boot) and the DOM probe also fails. Wider
- * than the historical 80-col default so the splash isn't artificially
- * narrow on the rare bad-measure path; the post-mount `fitAddon.fit()`
- * will issue a `session_resize` to the true host width within a frame
- * either way.
+ * Conservative starting point used when no live terminal exists to sample (very-first-session boot) and the DOM probe also fails. Wider than the
+ * historical 80-col default so the splash isn't artificially narrow on the rare bad-measure path; the post-mount `fitAddon.fit()` will issue a
+ * `session_resize` to the true host width within a frame either way.
  */
 export const FALLBACK_PTY_DIMS: Readonly<InitialPtyDims> = Object.freeze({
   cols: 132,
@@ -990,16 +882,12 @@ const PROBE_SAMPLE_TEXT = 'M'.repeat(80);
 const TERMINAL_HOST_INNER_PADDING_PX = 8;
 
 /**
- * Read the *measured* cols/rows of an existing terminal entry. Returns
- * `null` unless the entry is attached to a connected host AND has been
+ * Read the *measured* cols/rows of an existing terminal entry. Returns `null` unless the entry is attached to a connected host AND has been
  * successfully fit at least once.
  *
- * Why the strict gate: a fresh `Terminal` defaults to 80×24 even before
- * `open()`/`fit()`, so a naive `term.cols/term.rows` read can leak the
- * old hardcoded default into `session_restart`. We use `entry.lastCols`
- * /`lastRows` as the proven-fit signal — those are written only by a
- * successful `refitEntry()` (which itself requires a connected wrapper
- * and a non-throwing `fit()`).
+ * Why the strict gate: a fresh `Terminal` defaults to 80×24 even before `open()`/`fit()`, so a naive `term.cols/term.rows` read can leak the old
+ * hardcoded default into `session_restart`. We use `entry.lastCols`/`lastRows` as the proven-fit signal — those are written only by a successful
+ * `refitEntry()` (which itself requires a connected wrapper and a non-throwing `fit()`).
  */
 export function getTerminalDimensions(sessionId: SessionId): InitialPtyDims | null {
   const entry = registry.get(sessionId);
@@ -1012,31 +900,22 @@ export function getTerminalDimensions(sessionId: SessionId): InitialPtyDims | nu
 }
 
 /**
- * Estimate the cols/rows a brand-new session's PTY should be opened at
- * so the CLI's first paint matches the eventual `fitAddon.fit()` size.
+ * Estimate the cols/rows a brand-new session's PTY should be opened at so the CLI's first paint matches the eventual `fitAddon.fit()` size.
  *
  * Strategy, in order:
- *   1. Reuse any *proven-fit* terminal's measured cols/rows (delegates
- *      to [`getTerminalDimensions`], which gates on a successful fit
- *      so the xterm 80×24 default never leaks out). All sessions share
- *      the same `<main>` host, so cell metrics (and therefore cols/rows)
- *      are identical between proven-fit entries.
- *   2. Fall back to a one-off DOM probe: measure a hidden monospace
- *      `<span>` for cell-width × cell-height and divide the `<main>`
- *      element's rect (minus `TerminalView`'s 8-px padding) by it.
- *   3. If the DOM isn't available (jsdom without a `<main>`, or any
- *      probe failure), return [`FALLBACK_PTY_DIMS`].
+ *   1. Reuse any *proven-fit* terminal's measured cols/rows (delegates to [`getTerminalDimensions`], which gates on a successful fit so the xterm
+ *      80×24 default never leaks out). All sessions share the same `<main>` host, so cell metrics (and therefore cols/rows) are identical between
+ *      proven-fit entries.
+ *   2. Fall back to a one-off DOM probe: measure a hidden monospace `<span>` for cell-width × cell-height and divide the `<main>` element's rect
+ *      (minus `TerminalView`'s 8-px padding) by it.
+ *   3. If the DOM isn't available (jsdom without a `<main>`, or any probe failure), return [`FALLBACK_PTY_DIMS`].
  */
 export function measureInitialPtyDimensions(): InitialPtyDims {
-  // Reuse fast-path: any *proven-fit* terminal entry. We delegate to
-  // `getTerminalDimensions`, which gates on `wrapper.isConnected` AND
-  // `entry.lastCols/lastRows > 0`. A plain `entry.term.cols/rows`
-  // check here would silently hand back the xterm 80×24 default for
-  // an entry whose host is connected but currently zero-size (so its
-  // first `fitAddon.fit()` threw and `lastCols/lastRows` stayed 0) —
-  // exactly the splash-too-narrow regression we're guarding against.
-  // Cell metrics are identical across entries (all share the same
-  // `<main>` font), so any proven-fit entry is as good as another.
+  // Reuse fast-path: any *proven-fit* terminal entry. We delegate to `getTerminalDimensions`, which gates on `wrapper.isConnected` AND
+  // `entry.lastCols/lastRows > 0`. A plain `entry.term.cols/rows` check here would silently hand back the xterm 80×24 default for an entry whose host
+  // is connected but currently zero-size (so its first `fitAddon.fit()` threw and `lastCols/lastRows` stayed 0) — exactly the splash-too-narrow
+  // regression we're guarding against. Cell metrics are identical across entries (all share the same `<main>` font), so any proven-fit entry is as
+  // good as another.
   for (const id of registry.keys()) {
     const dims = getTerminalDimensions(id);
     if (dims !== null) return dims;
@@ -1051,11 +930,9 @@ export function measureInitialPtyDimensions(): InitialPtyDims {
 
   const rect = main.getBoundingClientRect();
   if (rect.width <= 0 || rect.height <= 0) {
-    // `<main>` is in the tree but laid out at 0×0 (e.g. an ancestor is
-    // `display: none` mid-transition). Clamping `0/cellW` to a 20-col
-    // floor would silently produce a tiny PTY — the very thing the
-    // splash-too-narrow regression test guards against. Bail to the
-    // fallback so the post-mount `fitAddon.fit()` corrects it.
+    // `<main>` is in the tree but laid out at 0×0 (e.g. an ancestor is `display: none` mid-transition). Clamping `0/cellW` to a 20-col floor would
+    // silently produce a tiny PTY — the very thing the splash-too-narrow regression test guards against. Bail to the fallback so the post-mount
+    // `fitAddon.fit()` corrects it.
     return { ...FALLBACK_PTY_DIMS };
   }
 
@@ -1094,10 +971,8 @@ export function disposeTerminal(id: string): void {
 }
 
 /**
- * Test-only: clear the registry and tear down both global subscriptions so
- * the next hook use re-initialises from scratch. Production code never calls
- * this — terminals are disposed individually via the session-store
- * subscription.
+ * Test-only: clear the registry and tear down both global subscriptions so the next hook use re-initialises from scratch. Production code never calls
+ * this — terminals are disposed individually via the session-store subscription.
  */
 export function __resetTerminalRegistryForTests(): void {
   for (const [, entry] of registry) {

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -488,6 +488,40 @@ function canReadClipboard(): boolean {
  * recovery and we don't want to spam the user with toasts every time
  * they paste an empty clipboard.
  */
+/**
+ * Whether the async clipboard write API is available in this runtime.
+ *
+ * Gates Ctrl/Cmd+C copy interception the same way [`canReadClipboard`]
+ * gates paste: if this returns `false` the copy branch must NOT cancel
+ * the event, so that plain Ctrl+C still falls through to xterm and
+ * sends SIGINT instead of becoming a silent no-op.
+ */
+function canWriteClipboard(): boolean {
+  return typeof navigator !== 'undefined' && typeof navigator.clipboard?.writeText === 'function';
+}
+
+/**
+ * Copy the terminal's current selection to the system clipboard via
+ * `navigator.clipboard.writeText()`. Returns `true` only when there was
+ * a non-empty selection AND the write API is available — i.e. when the
+ * caller should cancel the originating keystroke.
+ *
+ * Returning `false` is what keeps Ctrl+C working as interrupt: with no
+ * selection (or no clipboard API) the caller leaves the event alone and
+ * xterm sends the SIGINT byte (`\x03`) as usual. The write itself is
+ * fire-and-forget; failures are logged but never surfaced to the user.
+ */
+function copySelectionToClipboard(entry: RegistryEntry): boolean {
+  const selection = entry.term.getSelection();
+  if (!selection) return false;
+  if (!canWriteClipboard()) return false;
+  void navigator.clipboard.writeText(selection).catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[use-terminal] clipboard.writeText() failed: ${message}`);
+  });
+  return true;
+}
+
 function pasteFromClipboard(id: string, entry: RegistryEntry): void {
   if (!canReadClipboard()) return;
   void navigator.clipboard
@@ -656,7 +690,7 @@ function attachToHost(id: string, entry: RegistryEntry, host: HTMLDivElement): v
   // state if it fires too early).
   refitEntry(id, entry);
 
-  // Capture-phase keydown listener on the host. Two responsibilities:
+  // Capture-phase keydown listener on the host. Three responsibilities:
   //
   // 1. Shift+Enter → ESC + CR (`\x1b\r`). xterm.js by default sends a
   //    plain `\r` for both Enter and Shift+Enter, which CLIs like Claude
@@ -670,6 +704,11 @@ function attachToHost(id: string, entry: RegistryEntry, host: HTMLDivElement): v
   //    `\x16` SYN byte to the PTY) and the browser never fires a `paste`
   //    event, so our capture-phase paste listener has nothing to handle.
   //    Right-click → Paste still goes through the paste listener below.
+  //
+  // 3. Ctrl+C / Ctrl+Shift+C / Cmd+C → copy the current selection to the
+  //    clipboard, but ONLY when there is a selection. With no selection,
+  //    plain Ctrl+C must fall through so xterm sends SIGINT (`\x03`) —
+  //    the Windows Terminal / VS Code convention. We never break interrupt.
   //
   // We listen at the **host** in the **capture** phase so we run before
   // xterm's own keydown listener (registered on its hidden textarea, also
@@ -727,6 +766,27 @@ function attachToHost(id: string, entry: RegistryEntry, host: HTMLDivElement): v
         event.preventDefault();
         event.stopPropagation();
         pasteFromClipboard(id, entry);
+      }
+      return;
+    }
+    // Copy shortcuts. Matched on physical `event.code === 'KeyC'` for the
+    // same layout-independence reason as paste above. Accepted chords:
+    //   - Ctrl+C         (Windows/Linux; copy-on-selection-else-SIGINT)
+    //   - Ctrl+Shift+C   (Linux terminal convention)
+    //   - Cmd+C          (macOS convention; **without** Shift)
+    // We only cancel the keystroke when there is actually a selection to
+    // copy (see copySelectionToClipboard). For plain Ctrl+C with nothing
+    // selected this leaves the event untouched so xterm sends the SIGINT
+    // byte — interrupt is never broken. Cmd+Shift+C / Alt-modified chords
+    // pass through unchanged.
+    const c = event.code === 'KeyC';
+    const isCtrlCopy = c && event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey;
+    const isCtrlShiftCopy = c && event.ctrlKey && event.shiftKey && !event.metaKey && !event.altKey;
+    const isMetaCopy = c && event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
+    if (isCtrlCopy || isCtrlShiftCopy || isMetaCopy) {
+      if (copySelectionToClipboard(entry)) {
+        event.preventDefault();
+        event.stopPropagation();
       }
     }
   };

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -388,9 +388,8 @@ function createEntry(id: string, ioKind: IoKind): RegistryEntry {
   const fitAddon = new FitAddon();
   term.loadAddon(fitAddon);
 
-  // Service OSC 52 clipboard writes from the running CLI (e.g. Copilot
-  // CLI's in-app copy). xterm drops OSC 52 by default, which silently
-  // breaks copy from inside the TUI even though it reports success.
+  // Service OSC 52 clipboard writes from the running CLI (e.g. Copilot CLI's in-app copy). xterm drops OSC 52 by default, which silently breaks copy
+  // from inside the TUI even though it reports success.
   term.parser.registerOscHandler(52, handleOsc52);
 
   term.onData((data) => {
@@ -471,50 +470,19 @@ function canReadClipboard(): boolean {
 }
 
 /**
- * Read text from the system clipboard via `navigator.clipboard.readText()`
- * and forward it to the terminal via `term.paste()`. Used by both the
- * Ctrl/Cmd+V keydown branch (where xterm's keydown handler would
- * otherwise eat the keystroke before any `paste` event fires) and the
- * `paste` event listener fallback (when `clipboardData` is empty, as
- * happens in some WebView2 right-click → Paste flows).
- *
- * Callers must gate cancellation of the original event on
- * [`canReadClipboard`] — this function silently no-ops if the API is
- * missing, and unconditionally cancelling the event in that case
- * would block xterm from handling the keystroke / paste itself.
- *
- * The async resolution of `readText()` is racy with session disposal:
- * the user could dispatch Ctrl+V and then close the tab before the
- * clipboard read resolves. We re-check the registry by `sessionId`
- * before calling `term.paste(text)` so we don't write into a disposed
- * (or replaced) terminal.
- *
- * Failures are logged but otherwise silent — there's no useful UI
- * recovery and we don't want to spam the user with toasts every time
- * they paste an empty clipboard.
- */
-/**
- * Whether the async clipboard write API is available in this runtime.
- *
- * Gates Ctrl/Cmd+C copy interception the same way [`canReadClipboard`]
- * gates paste: if this returns `false` the copy branch must NOT cancel
- * the event, so that plain Ctrl+C still falls through to xterm and
- * sends SIGINT instead of becoming a silent no-op.
+ * Whether the async clipboard write API is available in this runtime. Gates Ctrl/Cmd+C copy interception the same way [`canReadClipboard`] gates
+ * paste: if this returns `false` the copy branch must NOT cancel the event, so that plain Ctrl+C still falls through to xterm and sends SIGINT
+ * instead of becoming a silent no-op.
  */
 function canWriteClipboard(): boolean {
   return typeof navigator !== 'undefined' && typeof navigator.clipboard?.writeText === 'function';
 }
 
 /**
- * Copy the terminal's current selection to the system clipboard via
- * `navigator.clipboard.writeText()`. Returns `true` only when there was
- * a non-empty selection AND the write API is available — i.e. when the
- * caller should cancel the originating keystroke.
- *
- * Returning `false` is what keeps Ctrl+C working as interrupt: with no
- * selection (or no clipboard API) the caller leaves the event alone and
- * xterm sends the SIGINT byte (`\x03`) as usual. The write itself is
- * fire-and-forget; failures are logged but never surfaced to the user.
+ * Copy the terminal's current selection to the system clipboard via `navigator.clipboard.writeText()`. Returns `true` only when there was a
+ * non-empty selection AND the write API is available — i.e. when the caller should cancel the originating keystroke. Returning `false` is what
+ * keeps Ctrl+C working as interrupt: with no selection (or no clipboard API) the caller leaves the event alone and xterm sends the SIGINT byte
+ * (`\x03`) as usual. The write itself is fire-and-forget; failures are logged but never surfaced to the user.
  */
 function copySelectionToClipboard(entry: RegistryEntry): boolean {
   const selection = entry.term.getSelection();
@@ -525,10 +493,8 @@ function copySelectionToClipboard(entry: RegistryEntry): boolean {
 }
 
 /**
- * Fire-and-forget write to the system clipboard via
- * `navigator.clipboard.writeText()`. Shared by the Ctrl/Cmd+C selection
- * copy and the OSC 52 handler. Callers gate on [`canWriteClipboard`]
- * first; failures are logged but never surfaced to the user.
+ * Fire-and-forget write to the system clipboard via `navigator.clipboard.writeText()`. Shared by the Ctrl/Cmd+C selection copy and the OSC 52
+ * handler. Callers gate on [`canWriteClipboard`] first; failures are logged but never surfaced to the user.
  */
 function writeTextToClipboard(text: string): void {
   void navigator.clipboard.writeText(text).catch((err: unknown) => {
@@ -538,17 +504,15 @@ function writeTextToClipboard(text: string): void {
 }
 
 /**
- * Decode an OSC 52 base64 payload into a UTF-8 string. The payload is
- * base64 of the raw UTF-8 bytes, so we cannot use `atob` alone (it would
- * mangle any multi-byte character) — we re-interpret the binary string
- * as bytes and run them through `TextDecoder`. Returns `null` on any
- * malformed input so the handler can decline the sequence cleanly.
+ * Decode an OSC 52 base64 payload into a UTF-8 string. The payload is base64 of the raw UTF-8 bytes, so we cannot use `atob` alone (it would mangle
+ * any multi-byte character) — we re-interpret the binary string as bytes and run them through `TextDecoder`. Returns `null` on any malformed input
+ * so the handler can decline the sequence cleanly.
  */
 function decodeOsc52Payload(b64: string): string | null {
   try {
     const binary = atob(b64);
-    const bytes = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    // Each char of an `atob` result is a single byte (code point 0-255), so `codePointAt(0)` and `charCodeAt(0)` are equivalent here.
+    const bytes = Uint8Array.from(binary, (ch) => ch.codePointAt(0) ?? 0);
     return new TextDecoder().decode(bytes);
   } catch {
     return null;
@@ -556,24 +520,15 @@ function decodeOsc52Payload(b64: string): string | null {
 }
 
 /**
- * Handle an OSC 52 clipboard sequence emitted by the running CLI.
+ * Handle an OSC 52 clipboard sequence emitted by the running CLI. TUI programs (notably GitHub Copilot CLI's in-app "copy" action) put text on the
+ * system clipboard by emitting `OSC 52 ; <selection> ; <b64> ST` rather than going through any browser copy event. xterm.js does NOT service OSC 52
+ * by default — it silently drops the sequence — so the CLI reports "copy successful" while the system clipboard never actually changes. We register
+ * this handler to close that gap.
  *
- * TUI programs (notably GitHub Copilot CLI's in-app "copy" action) put
- * text on the system clipboard by emitting `OSC 52 ; <selection> ; <b64> ST`
- * rather than going through any browser copy event. xterm.js does NOT
- * service OSC 52 by default — it silently drops the sequence — so the
- * CLI reports "copy successful" while the system clipboard never
- * actually changes. We register this handler to close that gap.
- *
- * `data` is the parser payload after the `52;` identifier, i.e.
- * `"<selection>;<base64-or-?>"`. We ignore the selection target (we
- * always write the system clipboard) and decline read requests
- * (`payload === '?'`) — servicing those would let the remote program
- * exfiltrate the user's clipboard, which we deliberately do not allow.
- *
- * Returns `true` only when we actually wrote, so xterm knows the
- * sequence was consumed; otherwise `false` so xterm falls back to its
- * default (drop) behaviour.
+ * `data` is the parser payload after the `52;` identifier, i.e. `"<selection>;<base64-or-?>"`. We ignore the selection target (we always write the
+ * system clipboard) and decline read requests (`payload === '?'`) — servicing those would let the remote program exfiltrate the user's clipboard,
+ * which we deliberately do not allow. Returns `true` only when we actually wrote, so xterm knows the sequence was consumed; otherwise `false` so
+ * xterm falls back to its default (drop) behaviour.
  */
 function handleOsc52(data: string): boolean {
   const sep = data.indexOf(';');
@@ -588,15 +543,27 @@ function handleOsc52(data: string): boolean {
   return true;
 }
 
+/**
+ * Read text from the system clipboard via `navigator.clipboard.readText()` and forward it to the terminal via `term.paste()`. Used by both the
+ * Ctrl/Cmd+V keydown branch (where xterm's keydown handler would otherwise eat the keystroke before any `paste` event fires) and the `paste` event
+ * listener fallback (when `clipboardData` is empty, as happens in some WebView2 right-click → Paste flows).
+ *
+ * Callers must gate cancellation of the original event on [`canReadClipboard`] — this function silently no-ops if the API is missing, and
+ * unconditionally cancelling the event in that case would block xterm from handling the keystroke / paste itself.
+ *
+ * The async resolution of `readText()` is racy with session disposal: the user could dispatch Ctrl+V and then close the tab before the clipboard
+ * read resolves. We re-check the registry by `sessionId` before calling `term.paste(text)` so we don't write into a disposed (or replaced)
+ * terminal. Failures are logged but otherwise silent — there's no useful UI recovery and we don't want to spam the user with toasts every time they
+ * paste an empty clipboard.
+ */
 function pasteFromClipboard(id: string, entry: RegistryEntry): void {
   if (!canReadClipboard()) return;
   void navigator.clipboard
     .readText()
     .then((text) => {
       if (!text) return;
-      // Guard against a concurrent disposeTerminal(): if the registry
-      // entry for this id is gone or has been replaced, drop the
-      // paste rather than writing to a stale Terminal instance.
+      // Guard against a concurrent disposeTerminal(): if the registry entry for this id is gone or has been replaced, drop the paste rather than
+      // writing to a stale Terminal instance.
       if (registry.get(id) !== entry) return;
       entry.term.paste(text);
     })
@@ -604,6 +571,65 @@ function pasteFromClipboard(id: string, entry: RegistryEntry): void {
       const message = err instanceof Error ? err.message : String(err);
       console.warn(`[use-terminal] clipboard.readText() failed: ${message}`);
     });
+}
+
+/**
+ * Handle the Shift+Enter chord: send ESC + CR (`\x1b\r`) instead of the bare `\r` xterm emits by default. CLIs like Claude Code and GitHub Copilot
+ * CLI interpret a bare `\r` as "submit"; the de-facto convention (matching what `claude /terminal-setup` configures in iTerm2) is ESC-prefixed CR
+ * for "newline without submit". Dispatches through the same kind-aware switch the `term.onData` handler uses so it works for both parent sessions
+ * and terminal sub-sessions. Returns `true` when the chord was consumed so the caller stops processing the event.
+ */
+function handleShiftEnterKey(event: KeyboardEvent, id: string, entry: RegistryEntry): boolean {
+  if (!(event.key === 'Enter' && event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey)) return false;
+  event.preventDefault();
+  event.stopPropagation();
+  const inputPromise =
+    entry.ioKind === 'session'
+      ? sessionInput({ sessionId: id as SessionId, data: '\x1b\r' })
+      : subSessionInput({ id: id as SubSessionId, data: '\x1b\r' });
+  void inputPromise.catch((err: unknown) => {
+    const message = formatError(err);
+    console.warn(`[use-terminal] ${entry.ioKind} input(${id}) failed: ${message}`);
+  });
+  return true;
+}
+
+/**
+ * Handle paste chords (Ctrl+V, Ctrl+Shift+V, Cmd+V) by reading the clipboard and writing through `term.paste()`. We intercept here because xterm's
+ * own keydown handler would otherwise eat the keypress (sending the literal `\x16` SYN byte) and the browser would never fire a `paste` event.
+ * Cmd+Shift+V (macOS "paste and match style") and any Alt-modified chord are deliberately not accepted and pass through. We match on the physical
+ * `event.code === 'KeyV'` rather than `event.key`, so the shortcut is layout-independent (on a Russian layout the V position prints `м`). Returns
+ * `true` only when we actually consumed the event — when no clipboard read API is available we leave the event alone (swallowing it would turn
+ * Ctrl+V into a silent no-op) so xterm can fall back to its own handling.
+ */
+function handlePasteShortcut(event: KeyboardEvent, id: string, entry: RegistryEntry): boolean {
+  const v = event.code === 'KeyV';
+  const isCtrlPaste = v && event.ctrlKey && !event.metaKey && !event.altKey;
+  const isMetaPaste = v && event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
+  if (!isCtrlPaste && !isMetaPaste) return false;
+  if (!canReadClipboard()) return false;
+  event.preventDefault();
+  event.stopPropagation();
+  pasteFromClipboard(id, entry);
+  return true;
+}
+
+/**
+ * Handle copy chords (Ctrl+C, Ctrl+Shift+C, Cmd+C) by copying the current selection to the clipboard — but only when there is a selection. With
+ * nothing selected, plain Ctrl+C must fall through so xterm sends SIGINT (`\x03`), matching the Windows Terminal / VS Code convention; interrupt is
+ * never broken. Cmd+Shift+C and Alt-modified chords pass through unchanged. Matched on the physical `event.code === 'KeyC'` for the same
+ * layout-independence reason as paste. Returns `true` only when a selection was copied and the event consumed.
+ */
+function handleCopyShortcut(event: KeyboardEvent, entry: RegistryEntry): boolean {
+  const c = event.code === 'KeyC';
+  const isCtrlCopy = c && event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey;
+  const isCtrlShiftCopy = c && event.ctrlKey && event.shiftKey && !event.metaKey && !event.altKey;
+  const isMetaCopy = c && event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
+  if (!isCtrlCopy && !isCtrlShiftCopy && !isMetaCopy) return false;
+  if (!copySelectionToClipboard(entry)) return false;
+  event.preventDefault();
+  event.stopPropagation();
+  return true;
 }
 
 /**
@@ -756,105 +782,21 @@ function attachToHost(id: string, entry: RegistryEntry, host: HTMLDivElement): v
   // state if it fires too early).
   refitEntry(id, entry);
 
-  // Capture-phase keydown listener on the host. Three responsibilities:
+  // Capture-phase keydown listener on the host with three responsibilities, each delegated to a helper that returns whether it consumed the event:
+  // (1) Shift+Enter → ESC + CR for "newline without submit" ([`handleShiftEnterKey`]); (2) Ctrl/Cmd+V paste ([`handlePasteShortcut`]); and
+  // (3) Ctrl/Ctrl+Shift/Cmd+C copy-on-selection-else-SIGINT ([`handleCopyShortcut`]).
   //
-  // 1. Shift+Enter → ESC + CR (`\x1b\r`). xterm.js by default sends a
-  //    plain `\r` for both Enter and Shift+Enter, which CLIs like Claude
-  //    Code and GitHub Copilot CLI interpret as "submit". The de-facto
-  //    convention (matching what `claude /terminal-setup` configures in
-  //    iTerm2) is to send ESC-prefixed CR for "newline without submit".
-  //
-  // 2. Ctrl+V / Cmd+V → trigger paste via `navigator.clipboard.readText()`
-  //    and write the result through `term.paste()`. If we don't intercept,
-  //    xterm's own keydown handler eats the keypress (sending the literal
-  //    `\x16` SYN byte to the PTY) and the browser never fires a `paste`
-  //    event, so our capture-phase paste listener has nothing to handle.
-  //    Right-click → Paste still goes through the paste listener below.
-  //
-  // 3. Ctrl+C / Ctrl+Shift+C / Cmd+C → copy the current selection to the
-  //    clipboard, but ONLY when there is a selection. With no selection,
-  //    plain Ctrl+C must fall through so xterm sends SIGINT (`\x03`) —
-  //    the Windows Terminal / VS Code convention. We never break interrupt.
-  //
-  // We listen at the **host** in the **capture** phase so we run before
-  // xterm's own keydown listener (registered on its hidden textarea, also
-  // capture-phase). xterm's `attachCustomKeyEventHandler` is unreliable
-  // here because by the time it runs the textarea may already have
-  // committed default behaviour, and we cannot from inside it
-  // `preventDefault()` the textarea's own newline insertion. Capturing on
-  // the host fully owns the event before any descendant listener.
+  // We listen at the **host** in the **capture** phase so we run before xterm's own keydown listener (registered on its hidden textarea, also
+  // capture-phase). xterm's `attachCustomKeyEventHandler` is unreliable here because by the time it runs the textarea may already have committed
+  // default behaviour, and we cannot from inside it `preventDefault()` the textarea's own newline insertion. Capturing on the host fully owns the
+  // event before any descendant listener.
   const keydownListener = (event: KeyboardEvent): void => {
-    // Skip IME composition: Enter/Shift+Enter during candidate selection
-    // belongs to the IME, not to the terminal. `keyCode === 229` is the
-    // legacy Chromium/WebView signal for "still composing".
+    // Skip IME composition: Enter/Shift+Enter during candidate selection belongs to the IME, not the terminal. `keyCode === 229` is the legacy
+    // Chromium/WebView "still composing" signal.
     if (event.isComposing || event.keyCode === 229) return;
-    if (event.key === 'Enter' && event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey) {
-      event.preventDefault();
-      event.stopPropagation();
-      // Dispatch through the same kind-aware switch the term.onData
-      // handler uses (see createEntry) so Shift+Enter works for both
-      // parent sessions and terminal sub-sessions.
-      const inputPromise =
-        entry.ioKind === 'session'
-          ? sessionInput({ sessionId: id as SessionId, data: '\x1b\r' })
-          : subSessionInput({ id: id as SubSessionId, data: '\x1b\r' });
-      void inputPromise.catch((err: unknown) => {
-        const message = formatError(err);
-        console.warn(`[use-terminal] ${entry.ioKind} input(${id}) failed: ${message}`);
-      });
-      return;
-    }
-    // Paste shortcuts. The accepted matrix is asymmetric on purpose:
-    //   - Ctrl+V         (Windows/Linux convention)
-    //   - Ctrl+Shift+V   (Linux terminal convention — many emulators)
-    //   - Cmd+V          (macOS convention; **without** Shift)
-    // Cmd+Shift+V on macOS is "paste and match style" in apps that
-    // implement formatted clipboard semantics; it has no useful meaning
-    // in a terminal and we leave it to pass through unchanged. Alt is
-    // never accepted (Ctrl+Alt+V / Cmd+Alt+V / Alt+V are not paste).
-    //
-    // We match on `event.code === 'KeyV'` rather than `event.key`. `key`
-    // is the produced character — on a Russian keyboard layout the
-    // physical V position prints `м`, so a `key === 'v'` test would miss
-    // the user's normal paste shortcut. `code` reflects the **physical**
-    // key location and is layout-independent, which is what every other
-    // major terminal app keys off for shortcut matching.
-    const v = event.code === 'KeyV';
-    const isCtrlPaste = v && event.ctrlKey && !event.metaKey && !event.altKey;
-    const isMetaPaste = v && event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
-    if (isCtrlPaste || isMetaPaste) {
-      // Only suppress xterm's default handling when we have a paste path
-      // that might actually succeed. If `navigator.clipboard.readText`
-      // is unavailable, swallowing the event would just turn Ctrl+V
-      // into a silent no-op; instead, let it propagate so xterm can do
-      // whatever it would have done.
-      if (canReadClipboard()) {
-        event.preventDefault();
-        event.stopPropagation();
-        pasteFromClipboard(id, entry);
-      }
-      return;
-    }
-    // Copy shortcuts. Matched on physical `event.code === 'KeyC'` for the
-    // same layout-independence reason as paste above. Accepted chords:
-    //   - Ctrl+C         (Windows/Linux; copy-on-selection-else-SIGINT)
-    //   - Ctrl+Shift+C   (Linux terminal convention)
-    //   - Cmd+C          (macOS convention; **without** Shift)
-    // We only cancel the keystroke when there is actually a selection to
-    // copy (see copySelectionToClipboard). For plain Ctrl+C with nothing
-    // selected this leaves the event untouched so xterm sends the SIGINT
-    // byte — interrupt is never broken. Cmd+Shift+C / Alt-modified chords
-    // pass through unchanged.
-    const c = event.code === 'KeyC';
-    const isCtrlCopy = c && event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey;
-    const isCtrlShiftCopy = c && event.ctrlKey && event.shiftKey && !event.metaKey && !event.altKey;
-    const isMetaCopy = c && event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
-    if (isCtrlCopy || isCtrlShiftCopy || isMetaCopy) {
-      if (copySelectionToClipboard(entry)) {
-        event.preventDefault();
-        event.stopPropagation();
-      }
-    }
+    if (handleShiftEnterKey(event, id, entry)) return;
+    if (handlePasteShortcut(event, id, entry)) return;
+    handleCopyShortcut(event, entry);
   };
   host.addEventListener('keydown', keydownListener as EventListener, true);
   entry.keydownListener = keydownListener;


### PR DESCRIPTION
## Problem

Ctrl+C never copied a terminal selection — the terminal hook only handled paste (Ctrl/Cmd+V), so Ctrl+C only ever sent SIGINT.

## Fix

Add copy-on-selection to the shared `use-terminal` hook (works for both sessions and sub-sessions):

- **Ctrl+C** — copies when text is selected; otherwise falls through to xterm so SIGINT still works (Windows Terminal / VS Code convention).
- **Ctrl+Shift+C** (Linux convention) and **Cmd+C** (macOS) — copy the selection.

Matched on physical `event.code === 'KeyC'` for layout independence, mirroring the existing paste matrix. Cancellation (`preventDefault`/`stopPropagation`) is gated on both a non-empty selection **and** an available `navigator.clipboard.writeText` API, so with no selection (or no API) Ctrl+C falls through and interrupt is never broken.

## Tests

5 regression tests added: selection→copy+suppress, no-selection→passthrough/SIGINT, Ctrl+Shift+C, Cmd+C, and selection-but-no-clipboard-API→passthrough. All 70 `use-terminal` tests pass; lint and build clean.