### PR TITLE
[metrics-parsing] Encapsulate AI metrics parsing inside each AiPlugin (#242)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,29 +56,29 @@ flowchart TB
 
 ## Backend modules
 
-| Module                                                    | Responsibility                                                                                                                      |
-| --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `lib.rs`                                                  | Tauri app setup, tracing, workspace boot binding, plugin registry, managed state, command registration, and production sink wiring. |
-| `boot.rs`                                                 | CLI parsing, boot-time workspace resolution, primary-clone validation, native failure dialogs, and workspace binding.               |
-| `store_layout.rs`                                         | Per-branch and per-workspace app-data path layout.                                                                                  |
-| `workspace_lock.rs`                                       | `fs2` advisory lock for one process per `(branch, workspace)` store.                                                                |
-| `workspace_scope.rs`                                      | Current workspace binding and `ConfigStore` handle.                                                                                 |
-| `config_store.rs`                                         | Atomic JSON persistence, migrations, quarantine, config merge, session records, and worktree tabs.                                  |
-| `commands/mod.rs`                                         | Thin `#[tauri::command]` wrappers and production event sinks.                                                                       |
-| `commands/session.rs`                                     | Session, workspace, worktree-create, restore, and switch implementation logic.                                                      |
-| `commands/worktree_tab.rs`                                | Worktree tab open, close, focus, reorder, and active-child logic.                                                                   |
-| `commands/subsession.rs`                                  | Custom-process sub-session lifecycle and restore logic.                                                                             |
-| `compose.rs`                                              | CLI command composition, path validation, worktree-name validation, shell quoting, and tool-specific launch behavior.               |
-| `session_temp.rs`                                         | Hardened per-session temp directory and Copilot OTel file creation, reset, orphan cleanup, and symlink/reparse refusal.             |
-| `pty_pool.rs`                                             | PTY spawn/read/write/resize/kill, deferred spawn, backpressure, wait threads, and orphan cleanup.                                   |
-| `sub_sessions.rs`                                         | Parallel PTY/app runtime for custom-process sub-tabs.                                                                               |
-| `app_launcher.rs`                                         | Detached application process spawning and app close/kill support.                                                                   |
-| `window_focus.rs`                                         | Platform-specific focus implementation for application sub-sessions.                                                                |
-| `git.rs`                                                  | `GitRunner` seam and parsing of `git worktree list --porcelain`.                                                                    |
-| `worktree_prep.rs`                                        | One-shot prep process spawning, logging, and `worktree://prep` events.                                                              |
-| `session_metrics.rs`                                      | Claude/Copilot metrics watchers, AI session id discovery, and activity event generation.                                            |
-| `plugins/`                                                | Built-in AI, custom-process, and dashboard-widget plugin registration.                                                              |
-| `process_icon.rs`, `icon_backfill.rs`, `worktree_icon.rs` | Icon extraction, cached icon data URIs, and worktree icon assignment.                                                               |
+| Module                                                    | Responsibility                                                                                                                                 |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lib.rs`                                                  | Tauri app setup, tracing, workspace boot binding, plugin registry, managed state, command registration, and production sink wiring.            |
+| `boot.rs`                                                 | CLI parsing, boot-time workspace resolution, primary-clone validation, native failure dialogs, and workspace binding.                          |
+| `store_layout.rs`                                         | Per-branch and per-workspace app-data path layout.                                                                                             |
+| `workspace_lock.rs`                                       | `fs2` advisory lock for one process per `(branch, workspace)` store.                                                                           |
+| `workspace_scope.rs`                                      | Current workspace binding and `ConfigStore` handle.                                                                                            |
+| `config_store.rs`                                         | Atomic JSON persistence, migrations, quarantine, config merge, session records, and worktree tabs.                                             |
+| `commands/mod.rs`                                         | Thin `#[tauri::command]` wrappers and production event sinks.                                                                                  |
+| `commands/session.rs`                                     | Session, workspace, worktree-create, restore, and switch implementation logic.                                                                 |
+| `commands/worktree_tab.rs`                                | Worktree tab open, close, focus, reorder, and active-child logic.                                                                              |
+| `commands/subsession.rs`                                  | Custom-process sub-session lifecycle and restore logic.                                                                                        |
+| `compose.rs`                                              | CLI command composition, path validation, worktree-name validation, shell quoting, and tool-specific launch behavior.                          |
+| `session_temp.rs`                                         | Hardened per-session temp directory and Copilot OTel file creation, reset, orphan cleanup, and symlink/reparse refusal.                        |
+| `pty_pool.rs`                                             | PTY spawn/read/write/resize/kill, deferred spawn, backpressure, wait threads, and orphan cleanup.                                              |
+| `sub_sessions.rs`                                         | Parallel PTY/app runtime for custom-process sub-tabs.                                                                                          |
+| `app_launcher.rs`                                         | Detached application process spawning and app close/kill support.                                                                              |
+| `window_focus.rs`                                         | Platform-specific focus implementation for application sub-sessions.                                                                           |
+| `git.rs`                                                  | `GitRunner` seam and parsing of `git worktree list --porcelain`.                                                                               |
+| `worktree_prep.rs`                                        | One-shot prep process spawning, logging, and `worktree://prep` events.                                                                         |
+| `session_metrics.rs`                                      | Generic metrics-watcher engine (threading, file tailing, discovery backoff, dedup) driving per-tool `MetricsParser`s; AI session id discovery. |
+| `plugins/`                                                | Built-in AI, custom-process, and dashboard-widget plugin registration.                                                                         |
+| `process_icon.rs`, `icon_backfill.rs`, `worktree_icon.rs` | Icon extraction, cached icon data URIs, and worktree icon assignment.                                                                          |
 
 ## Frontend modules
 

--- a/src-tauri/src/compose.rs
+++ b/src-tauri/src/compose.rs
@@ -232,7 +232,7 @@ pub fn copilot_otel_path(session_id: &SessionId) -> PathBuf {
 /// * `Tool::Copilot` — enable Copilot's OpenTelemetry **file exporter**
 ///   pointing at `<session_temp_dir>/otel.jsonl`. Arborist tails that file to
 ///   surface real-time token usage / context-window state in the sidebar (see
-///   [`crate::session_metrics::run_copilot_watcher`]). The
+///   [`crate::plugins::ai::copilot::metrics`]). The
 ///   `OTEL_BSP_SCHEDULE_DELAY=1000` (ms) tightens the SDK's batch flush from
 ///   its 5s default to ~1Hz so the sidebar updates feel live. Older Copilot
 ///   CLIs that don't recognise these vars silently ignore them.

--- a/src-tauri/src/plugins/ai/claude/metrics.rs
+++ b/src-tauri/src/plugins/ai/claude/metrics.rs
@@ -1,0 +1,492 @@
+//! Claude metrics parsing.
+//!
+//! Claude Code persists every session as a JSONL transcript at `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`. Each `assistant`-type line
+//! carries a `message.usage` object with `input_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens` and `output_tokens`. The model's
+//! context-window limit can be read from `~/.claude/token_usage.json::actual_limit`, with a fallback table for when that file does not exist yet.
+//!
+//! The generic engine in [`crate::session_metrics`] drives a [`ClaudeMetricsParser`]: it periodically scans the project directory matching the
+//! session's `cwd`, picks the JSONL file with the most recent mtime that's >= the session's spawn instant, tails new lines through
+//! [`ClaudeMetricsParser::ingest_line`], and emits a snapshot on change.
+//!
+//! Limitation: two same-tool sessions in the same worktree cannot be disambiguated by cwd + mtime alone — both would observe the most-
+//! recently-written JSONL. See follow-up issue #4 for the hook-driven authoritative version.
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use serde::Deserialize;
+
+use crate::session_metrics::{context_used_pct, encode_cwd, now_unix_seconds, LocatedFile, MetricsParser, TurnCb};
+use crate::types::{SessionId, SessionMetricsEvent};
+
+#[derive(Debug, Default, Deserialize, Clone, Copy)]
+pub(crate) struct UsageBlock {
+    #[serde(default)]
+    input_tokens: u64,
+    #[serde(default)]
+    output_tokens: u64,
+    #[serde(default)]
+    cache_creation_input_tokens: u64,
+    #[serde(default)]
+    cache_read_input_tokens: u64,
+}
+
+#[derive(Debug, Default)]
+struct TurnTotals {
+    /// Most recent observed turn — these reset to the values from the latest assistant line (each line is the cumulative state of that turn, not a
+    /// delta).
+    last_input: u64,
+    last_output: u64,
+    last_cache_creation: u64,
+    last_cache_read: u64,
+    /// Cumulative input/output across all observed assistant lines (sum of per-turn values). Useful for "session totals".
+    sum_input: u64,
+    sum_output: u64,
+    /// Set true once we've ingested at least one usage block.
+    seen: bool,
+}
+
+impl TurnTotals {
+    fn add(&mut self, u: &UsageBlock) {
+        self.sum_input = self.sum_input.saturating_add(u.input_tokens);
+        self.sum_output = self.sum_output.saturating_add(u.output_tokens);
+        self.last_input = u.input_tokens;
+        self.last_output = u.output_tokens;
+        self.last_cache_creation = u.cache_creation_input_tokens;
+        self.last_cache_read = u.cache_read_input_tokens;
+        self.seen = true;
+    }
+
+    fn has_any(&self) -> bool {
+        self.seen
+    }
+
+    fn context_tokens_used(&self) -> u64 {
+        self.last_input
+            .saturating_add(self.last_cache_creation)
+            .saturating_add(self.last_cache_read)
+            .saturating_add(self.last_output)
+    }
+}
+
+/// Try to parse a single JSONL line and return its `(usage, model)` if it is an `assistant` event with a `message.usage` block. Returns `None` for
+/// any other line (system, user, sub-event, malformed, etc.). Never panics.
+pub(crate) fn extract_assistant_usage(line: &[u8]) -> Option<(UsageBlock, Option<String>)> {
+    #[derive(Deserialize)]
+    struct Outer {
+        #[serde(default)]
+        r#type: String,
+        #[serde(default)]
+        message: Option<Message>,
+    }
+    #[derive(Deserialize)]
+    struct Message {
+        #[serde(default)]
+        model: Option<String>,
+        #[serde(default)]
+        usage: Option<UsageBlock>,
+    }
+    let outer: Outer = serde_json::from_slice(line).ok()?;
+    if outer.r#type != "assistant" {
+        return None;
+    }
+    let msg = outer.message?;
+    let usage = msg.usage?;
+    Some((usage, msg.model))
+}
+
+#[derive(Deserialize)]
+struct TokenUsageFile {
+    #[serde(default)]
+    actual_limit: Option<u64>,
+    #[serde(default)]
+    expected_limit: Option<u64>,
+}
+
+/// Resolve the model's context-window limit. Tries `~/.claude/token_usage.json` first, then falls back to a small built-in table for known Anthropic
+/// models. Returns `None` when neither source recognises the model.
+pub(crate) fn resolve_limit(token_usage_path: &Path, model: Option<&str>) -> Option<u64> {
+    if let Ok(bytes) = std::fs::read(token_usage_path) {
+        if let Ok(file) = serde_json::from_slice::<TokenUsageFile>(&bytes) {
+            if let Some(v) = file.actual_limit.or(file.expected_limit) {
+                if v > 0 {
+                    return Some(v);
+                }
+            }
+        }
+    }
+    model.and_then(fallback_limit_for_model)
+}
+
+/// Fallback table for known model families. Keys match the substring form because Claude reports e.g. `"claude-sonnet-4-6"` while Anthropic also uses
+/// `"claude-3-5-sonnet"`-style names.
+fn fallback_limit_for_model(model: &str) -> Option<u64> {
+    let m = model.to_ascii_lowercase();
+    if m.contains("opus") || m.contains("sonnet") || m.contains("haiku") {
+        // All current Anthropic models default to 200k context.
+        return Some(200_000);
+    }
+    None
+}
+
+fn build_snapshot(session_id: SessionId, totals: &TurnTotals, model: Option<String>, limit: Option<u64>) -> SessionMetricsEvent {
+    let used = totals.context_tokens_used();
+    let pct = context_used_pct(Some(used), limit);
+    SessionMetricsEvent {
+        session_id,
+        model,
+        context_used_pct: pct,
+        context_tokens_used: Some(used),
+        context_tokens_limit: limit,
+        input_tokens: Some(totals.sum_input),
+        output_tokens: Some(totals.sum_output),
+        observed_at: now_unix_seconds(),
+    }
+}
+
+/// Discover the newest `.jsonl` directly under `dir` whose mtime is >= `after` (with a small clock-skew slack window). Returns its full path.
+fn newest_jsonl_after(dir: &Path, after: SystemTime) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(dir).ok()?;
+    let mut best: Option<(SystemTime, PathBuf)> = None;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else { continue };
+        let Ok(mtime) = meta.modified() else { continue };
+        // Allow a small clock-skew slack window (5s) so the very first line — which can land before our spawn_instant due to mtime resolution / clock
+        // differences — is still picked up.
+        let slack = std::time::Duration::from_secs(5);
+        let cutoff = after.checked_sub(slack).unwrap_or(after);
+        if mtime < cutoff {
+            continue;
+        }
+        match &best {
+            Some((bt, _)) if *bt >= mtime => {}
+            _ => best = Some((mtime, path)),
+        }
+    }
+    best.map(|(_, p)| p)
+}
+
+/// Claude transcript metrics parser. Owns the project-dir scan and the per-turn usage accumulation; the engine owns the polling/tailing loop.
+pub struct ClaudeMetricsParser {
+    project_dir: PathBuf,
+    token_usage_path: PathBuf,
+    totals: TurnTotals,
+    last_model: Option<String>,
+}
+
+impl ClaudeMetricsParser {
+    #[must_use]
+    pub fn new(home: &Path, cwd: &Path) -> Self {
+        Self {
+            project_dir: home.join(".claude").join("projects").join(encode_cwd(cwd)),
+            token_usage_path: home.join(".claude").join("token_usage.json"),
+            totals: TurnTotals::default(),
+            last_model: None,
+        }
+    }
+}
+
+impl MetricsParser for ClaudeMetricsParser {
+    fn relocate_each_poll(&self) -> bool {
+        // A `/clear` makes Claude start a brand-new transcript file; the engine must rebind to the freshest matching JSONL each poll.
+        true
+    }
+
+    fn rebind_on_disappear(&self) -> bool {
+        false
+    }
+
+    fn locate(&mut self, spawn_instant: SystemTime) -> Option<LocatedFile> {
+        let path = newest_jsonl_after(&self.project_dir, spawn_instant)?;
+        // The tracked file's stem is Claude's session id (`<encoded-cwd>/<sessionId>.jsonl`).
+        let ai_session_id = path.file_stem().and_then(|s| s.to_str()).map(str::to_owned);
+        Some(LocatedFile { path, ai_session_id })
+    }
+
+    fn reset(&mut self) {
+        self.totals = TurnTotals::default();
+        self.last_model = None;
+    }
+
+    fn ingest_line(&mut self, line: &[u8], _session_id: SessionId, _emit_turn: &TurnCb) {
+        if let Some((usage, model)) = extract_assistant_usage(line) {
+            self.totals.add(&usage);
+            if let Some(m) = model {
+                self.last_model = Some(m);
+            }
+            // Intentionally do NOT emit a TurnEnd here. Claude's transcript writes one `assistant` line per round-trip with the model — so a single
+            // user turn that goes user → assistant(tool_use) → user(tool_result) → assistant(tool_use) → user(tool_result) → assistant(end_turn)
+            // produces three assistant lines. The original code (pre-hook-integration) emitted TurnEnd on each, which would clear `inTurn` and
+            // promote the sidebar to `awaiting` between tool calls — exactly the "thinking → zzz while reading file" symptom users see. Authoritative
+            // turn boundaries now come from the Claude hook-events tailer ([`crate::claude_hook_events`]) via `UserPromptSubmit` (turnStart) and
+            // `Stop` (turnEnd). For sessions where hooks aren't active (sidecar missing, partial install) we lose the `awaiting` promotion entirely;
+            // PTY-byte heuristics still drive `working` / `idle` so the sidebar remains informative, just without the explicit "agent finished" cue.
+        }
+    }
+
+    fn snapshot(&self, session_id: SessionId) -> Option<SessionMetricsEvent> {
+        if !self.totals.has_any() {
+            return None;
+        }
+        let limit = resolve_limit(&self.token_usage_path, self.last_model.as_deref());
+        Some(build_snapshot(session_id, &self.totals, self.last_model.clone(), limit))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[test]
+    fn extract_assistant_usage_happy_path() {
+        let line = br#"{"type":"assistant","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":12,"output_tokens":34,"cache_creation_input_tokens":56,"cache_read_input_tokens":78}}}"#;
+        let (u, m) = extract_assistant_usage(line).expect("parsed");
+        assert_eq!(u.input_tokens, 12);
+        assert_eq!(u.output_tokens, 34);
+        assert_eq!(u.cache_creation_input_tokens, 56);
+        assert_eq!(u.cache_read_input_tokens, 78);
+        assert_eq!(m.as_deref(), Some("claude-sonnet-4-6"));
+    }
+
+    #[test]
+    fn extract_assistant_usage_returns_none_for_user_lines() {
+        let line = br#"{"type":"user","message":{"role":"user","content":"hi"}}"#;
+        assert!(extract_assistant_usage(line).is_none());
+    }
+
+    #[test]
+    fn extract_assistant_usage_returns_none_for_system_lines() {
+        let line = br#"{"type":"system","subtype":"turn_duration","durationMs":42}"#;
+        assert!(extract_assistant_usage(line).is_none());
+    }
+
+    #[test]
+    fn extract_assistant_usage_tolerates_missing_optional_fields() {
+        // No cache fields present — should default to 0.
+        let line = br#"{"type":"assistant","message":{"usage":{"input_tokens":1,"output_tokens":2}}}"#;
+        let (u, m) = extract_assistant_usage(line).expect("parsed");
+        assert_eq!(u.input_tokens, 1);
+        assert_eq!(u.output_tokens, 2);
+        assert_eq!(u.cache_creation_input_tokens, 0);
+        assert_eq!(u.cache_read_input_tokens, 0);
+        assert!(m.is_none());
+    }
+
+    #[test]
+    fn extract_assistant_usage_returns_none_for_garbage() {
+        assert!(extract_assistant_usage(b"not json").is_none());
+        assert!(extract_assistant_usage(b"{}").is_none());
+    }
+
+    #[test]
+    fn turn_totals_track_last_and_sum() {
+        let mut t = TurnTotals::default();
+        t.add(&UsageBlock {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_creation_input_tokens: 100,
+            cache_read_input_tokens: 200,
+        });
+        t.add(&UsageBlock {
+            input_tokens: 20,
+            output_tokens: 7,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 500,
+        });
+        // Last = the second turn.
+        assert_eq!(t.last_input, 20);
+        assert_eq!(t.last_output, 7);
+        assert_eq!(t.last_cache_read, 500);
+        assert_eq!(t.last_cache_creation, 0);
+        // Sums accumulate input+output (cache fields aren't summed — they're per-turn state).
+        assert_eq!(t.sum_input, 30);
+        assert_eq!(t.sum_output, 12);
+        // Context tokens used = sum of the LAST turn's four fields.
+        assert_eq!(t.context_tokens_used(), 20 + 500 + 7);
+        assert!(t.has_any());
+    }
+
+    #[test]
+    fn fallback_limit_known_models() {
+        assert_eq!(fallback_limit_for_model("claude-sonnet-4-6"), Some(200_000));
+        assert_eq!(fallback_limit_for_model("claude-opus-4-7"), Some(200_000));
+        assert_eq!(fallback_limit_for_model("claude-haiku-4-5"), Some(200_000));
+        assert_eq!(fallback_limit_for_model("gpt-4"), None);
+    }
+
+    #[test]
+    fn resolve_limit_prefers_token_usage_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let p = dir.path().join("token_usage.json");
+        let mut f = std::fs::File::create(&p).unwrap();
+        f.write_all(br#"{"actual_limit":128000,"expected_limit":200000}"#).unwrap();
+        assert_eq!(resolve_limit(&p, Some("claude-opus-4-7")), Some(128_000));
+    }
+
+    #[test]
+    fn resolve_limit_falls_back_when_file_missing() {
+        let p = std::path::Path::new("/nonexistent/arborist-test/token_usage.json");
+        assert_eq!(resolve_limit(p, Some("claude-sonnet-4-6")), Some(200_000));
+        assert_eq!(resolve_limit(p, Some("unknown-model")), None);
+        assert_eq!(resolve_limit(p, None), None);
+    }
+
+    #[test]
+    fn resolve_limit_ignores_zero_in_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let p = dir.path().join("token_usage.json");
+        let mut f = std::fs::File::create(&p).unwrap();
+        f.write_all(br#"{"actual_limit":0}"#).unwrap();
+        // Falls through to fallback table.
+        assert_eq!(resolve_limit(&p, Some("claude-sonnet-4-6")), Some(200_000));
+    }
+
+    #[test]
+    fn build_snapshot_computes_pct_when_limit_known() {
+        let mut totals = TurnTotals::default();
+        totals.add(&UsageBlock {
+            input_tokens: 50_000,
+            output_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+        });
+        let snap = build_snapshot(SessionId::new(), &totals, Some("claude-sonnet-4-6".into()), Some(200_000));
+        assert_eq!(snap.context_used_pct, Some(25));
+        assert_eq!(snap.context_tokens_used, Some(50_000));
+        assert_eq!(snap.context_tokens_limit, Some(200_000));
+        assert_eq!(snap.input_tokens, Some(50_000));
+        assert_eq!(snap.output_tokens, Some(0));
+    }
+
+    #[test]
+    fn build_snapshot_caps_pct_at_100() {
+        let mut totals = TurnTotals::default();
+        totals.add(&UsageBlock {
+            input_tokens: 999_999,
+            output_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+        });
+        let snap = build_snapshot(SessionId::new(), &totals, None, Some(200_000));
+        assert_eq!(snap.context_used_pct, Some(100));
+    }
+
+    #[test]
+    fn build_snapshot_omits_pct_when_limit_unknown() {
+        let mut totals = TurnTotals::default();
+        totals.add(&UsageBlock {
+            input_tokens: 100,
+            output_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+        });
+        let snap = build_snapshot(SessionId::new(), &totals, None, None);
+        assert!(snap.context_used_pct.is_none());
+        assert_eq!(snap.context_tokens_used, Some(100));
+        assert!(snap.context_tokens_limit.is_none());
+    }
+
+    #[test]
+    fn newest_jsonl_after_picks_freshest_eligible_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let a = dir.path().join("aaa.jsonl");
+        let b = dir.path().join("bbb.jsonl");
+        let c = dir.path().join("not-a-transcript.txt");
+        std::fs::write(&a, b"x").unwrap();
+        std::thread::sleep(Duration::from_millis(20));
+        std::fs::write(&b, b"y").unwrap();
+        std::fs::write(&c, b"z").unwrap();
+
+        // After=epoch-far-past => both eligible; b is newer => picked.
+        let picked = newest_jsonl_after(dir.path(), SystemTime::UNIX_EPOCH).expect("some");
+        assert_eq!(picked, b);
+
+        // After=now+1day => nothing eligible.
+        let future = SystemTime::now() + Duration::from_secs(86_400);
+        assert!(newest_jsonl_after(dir.path(), future).is_none());
+    }
+
+    /// Regression for the gap noted in PR review: a half-written trailing JSON line at EOF must NOT be silently dropped. The watcher must only
+    /// advance its cursor up to the last complete `\n`, so the rest of the line is re-read after the writer finishes it.
+    #[test]
+    fn claude_watcher_does_not_drop_partial_trailing_line() {
+        use std::sync::mpsc;
+
+        // Set up a fake $HOME so the parser's project_dir resolves into our tempdir. encode_cwd of the cwd we pass becomes the dir name.
+        let home = tempfile::tempdir().expect("home");
+        let cwd_dir = tempfile::tempdir().expect("cwd");
+        let cwd = cwd_dir.path().to_path_buf();
+        let project_dir = home.path().join(".claude").join("projects").join(encode_cwd(&cwd));
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let jsonl = project_dir.join("session.jsonl");
+        std::fs::write(&jsonl, b"").unwrap();
+
+        let session_id = SessionId::new();
+        let running = Arc::new(AtomicBool::new(true));
+        let running_for_thread = Arc::clone(&running);
+        let (tx, rx) = mpsc::channel::<SessionMetricsEvent>();
+        let cb: crate::session_metrics::MetricsCb = Arc::new(move |ev| {
+            let _ = tx.send(ev);
+        });
+        let home_path = home.path().to_path_buf();
+        let cwd_for_thread = cwd.clone();
+        let spawn_instant = SystemTime::now() - Duration::from_secs(60);
+        let handle = std::thread::spawn(move || {
+            let parser = Box::new(ClaudeMetricsParser::new(&home_path, &cwd_for_thread));
+            crate::session_metrics::run_metrics_watcher(
+                session_id,
+                parser,
+                spawn_instant,
+                cb,
+                Arc::new(|_, _| {}),
+                Arc::new(|_, _| {}),
+                running_for_thread,
+            );
+        });
+
+        // 1) Write one complete line + a partial second line (no newline).
+        let complete = br#"{"type":"assistant","message":{"model":"claude-opus-4.7","usage":{"input_tokens":10,"output_tokens":2}}}"#;
+        let partial = br#"{"type":"assistant","message":{"model":"claude-opus-4.7","usage":{"input_tokens":99"#;
+        {
+            let mut f = std::fs::OpenOptions::new().append(true).open(&jsonl).unwrap();
+            f.write_all(complete).unwrap();
+            f.write_all(b"\n").unwrap();
+            f.write_all(partial).unwrap();
+        }
+
+        // First emission must reflect ONLY the complete line.
+        let first = rx.recv_timeout(Duration::from_secs(8)).expect("first snapshot");
+        assert_eq!(first.input_tokens, Some(10));
+        assert_eq!(first.output_tokens, Some(2));
+
+        // 2) Finish the partial line. The cursor must have stayed at the end of the first line, so the now-complete second line gets parsed in full
+        //    and added to the totals.
+        {
+            let mut f = std::fs::OpenOptions::new().append(true).open(&jsonl).unwrap();
+            f.write_all(b",\"output_tokens\":7}}}\n").unwrap();
+        }
+
+        // Drain until totals jump to 10+99 = 109 in.
+        let deadline = std::time::Instant::now() + Duration::from_secs(8);
+        let snap = loop {
+            assert!(std::time::Instant::now() < deadline, "timed out");
+            let s = rx.recv_timeout(Duration::from_secs(8)).expect("post-completion snapshot");
+            if s.input_tokens == Some(109) {
+                break s;
+            }
+        };
+        assert_eq!(snap.input_tokens, Some(109), "partial line was re-read");
+        assert_eq!(snap.output_tokens, Some(9));
+
+        running.store(false, Ordering::SeqCst);
+        handle.join().expect("watcher thread joined");
+    }
+}

--- a/src-tauri/src/plugins/ai/claude/mod.rs
+++ b/src-tauri/src/plugins/ai/claude/mod.rs
@@ -10,6 +10,7 @@ use crate::types::SessionId;
 use crate::types::Tool;
 
 pub mod hooks;
+pub mod metrics;
 
 /// Filename of the per-session `--settings` JSON we hand to Claude (`<session_temp_dir>/claude-settings.json`). Single source of truth — the
 /// structured-argv router in `commands::session::default_structured_command` matches on this basename to decide when to add `--settings <path>`,
@@ -55,11 +56,14 @@ impl AiPlugin for ClaudePlugin {
         }
     }
 
-    fn metrics_watcher_kind(&self, _session_id: SessionId, cwd: &std::path::Path) -> Option<crate::plugins::ai::MetricsWatcherKind> {
-        crate::session_metrics::home_dir().map(|home| crate::plugins::ai::MetricsWatcherKind::Claude {
-            home,
-            cwd: cwd.to_path_buf(),
-        })
+    fn metrics_parser(
+        &self,
+        _session_id: SessionId,
+        cwd: &std::path::Path,
+        _spawn_instant: std::time::SystemTime,
+    ) -> Option<Box<dyn crate::session_metrics::MetricsParser>> {
+        let home = crate::session_metrics::home_dir()?;
+        Some(Box::new(metrics::ClaudeMetricsParser::new(&home, cwd)))
     }
 
     fn starts_activity_events_watcher(&self) -> bool {

--- a/src-tauri/src/plugins/ai/codex/metrics.rs
+++ b/src-tauri/src/plugins/ai/codex/metrics.rs
@@ -1,0 +1,691 @@
+//! Codex metrics parsing (rollout JSONL).
+//!
+//! Codex persists every session as a JSONL "rollout" file under `<CODEX_HOME>/sessions/` (default `~/.codex/sessions/`), optionally nested in
+//! `YYYY/MM/DD/` date subdirectories. Filenames follow `rollout-<TIMESTAMP>-<UUID>.jsonl`. The first line is a `session_meta` envelope carrying the
+//! thread id and `cwd`; subsequent lines are `event_msg` / `turn_context` envelopes. The generic engine in [`crate::session_metrics`] discovers the
+//! file by matching `cwd` and spawn instant (with backoff between misses), fires the AI-session discovery callback with the thread id, then tails
+//! `token_count` (cumulative usage) and `turn_complete` (turn duration) events through [`CodexMetricsParser`]. `RolloutItem` is adjacently tagged
+//! (`{"type":...,"payload":...}`) but the inner `EventMsg` is internally tagged, so token fields live at `payload.info.*`, not `payload.payload.info.*`.
+//! Only token usage and model name are surfaced to the sidebar — feature parity with the Claude and Copilot watchers.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use serde::Deserialize;
+
+use crate::session_metrics::{context_used_pct, now_unix_seconds, LocatedFile, MetricsParser, TurnCb};
+use crate::types::{SessionId, SessionMetricsEvent};
+
+/// Outer envelope for every rollout JSONL line: `{"timestamp": "...", "type": "...", "payload": {...}}`. Inner-payload shape varies by `type` and is
+/// inspected as `serde_json::Value` to avoid a deserialize match per variant.
+#[derive(Deserialize)]
+struct CodexRolloutLine {
+    #[serde(default)]
+    r#type: String,
+    #[serde(default)]
+    payload: Option<serde_json::Value>,
+}
+
+/// Normalize a path into comparable components for cross-platform matching. On Windows, slashes are unified and each component is lowercased so
+/// `C:\Repos\X` and `c:/repos/x/` normalize to the same `Vec<String>`. On Unix, components are preserved as-is.
+fn normalize_path_components(path: &Path) -> Vec<String> {
+    path.components()
+        .map(|c| {
+            let raw = c.as_os_str().to_string_lossy();
+            if cfg!(windows) {
+                raw.replace('/', "\\").to_ascii_lowercase()
+            } else {
+                raw.into_owned()
+            }
+        })
+        .collect()
+}
+
+/// Discover the newest rollout JSONL under `sessions_dir` (including date-nested subdirs) whose first-line `SessionMeta.cwd` matches `cwd` and whose
+/// mtime is >= `after`. Returns the full path when found. Called during rollout discovery while no file is bound; the engine applies a backoff
+/// between misses to avoid re-scanning the entire Codex sessions tree on every poll tick.
+fn newest_codex_rollout(sessions_dir: &Path, cwd: &Path, after: SystemTime) -> Option<PathBuf> {
+    let slack = Duration::from_secs(5);
+    let cutoff = after.checked_sub(slack).unwrap_or(after);
+    let expected_norm = normalize_path_components(cwd);
+    let mut best: Option<(SystemTime, PathBuf)> = None;
+
+    // Helper to check a single directory for rollout files.
+    fn scan_dir(dir: &Path, expected_norm: &[String], cutoff: SystemTime, best: &mut Option<(SystemTime, PathBuf)>) {
+        let Ok(entries) = std::fs::read_dir(dir) else { return };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let fname = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if !fname.starts_with("rollout-") {
+                continue;
+            }
+            let Ok(meta) = entry.metadata() else { continue };
+            let Ok(mtime) = meta.modified() else { continue };
+            if mtime < cutoff {
+                continue;
+            }
+            // Check if the cwd matches by reading the first line (SessionMeta).
+            if !codex_rollout_cwd_matches_norm(&path, expected_norm) {
+                continue;
+            }
+            match best {
+                Some((bt, _)) if *bt >= mtime => {}
+                _ => *best = Some((mtime, path)),
+            }
+        }
+    }
+
+    // Scan top-level `sessions/` directory.
+    scan_dir(sessions_dir, &expected_norm, cutoff, &mut best);
+
+    // Also scan three-level nested subdirs (Codex commonly uses YYYY/MM/DD).
+    if let Ok(years) = std::fs::read_dir(sessions_dir) {
+        for year_entry in years.flatten() {
+            let year_path = year_entry.path();
+            if !year_path.is_dir() {
+                continue;
+            }
+            if let Ok(months) = std::fs::read_dir(&year_path) {
+                for month_entry in months.flatten() {
+                    let month_path = month_entry.path();
+                    if !month_path.is_dir() {
+                        continue;
+                    }
+                    if let Ok(days) = std::fs::read_dir(&month_path) {
+                        for day_entry in days.flatten() {
+                            let day_path = day_entry.path();
+                            if day_path.is_dir() {
+                                scan_dir(&day_path, &expected_norm, cutoff, &mut best);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    best.map(|(_, p)| p)
+}
+
+/// Read a rollout file's first line and decode it as a `session_meta` `CodexRolloutLine`. Returns the payload (a JSON object) when the line is
+/// well-formed and the type matches; `None` otherwise. Shared by `codex_rollout_cwd_matches_norm` and `codex_rollout_thread_id`.
+fn read_codex_session_meta(path: &Path) -> Option<serde_json::Value> {
+    use std::io::{BufRead, BufReader};
+    let f = std::fs::File::open(path).ok()?;
+    let mut reader = BufReader::new(f);
+    let mut first_line = String::new();
+    reader.read_line(&mut first_line).ok()?;
+    if first_line.is_empty() {
+        return None;
+    }
+    let line: CodexRolloutLine = serde_json::from_str(&first_line).ok()?;
+    if line.r#type != "session_meta" {
+        return None;
+    }
+    line.payload
+}
+
+/// Check whether a rollout file's `SessionMeta.cwd` matches the (already-normalized) expected cwd.
+fn codex_rollout_cwd_matches_norm(path: &Path, expected_norm: &[String]) -> bool {
+    let Some(payload) = read_codex_session_meta(path) else { return false };
+    let Some(cwd_str) = payload.get("cwd").and_then(|v| v.as_str()) else {
+        return false;
+    };
+    normalize_path_components(Path::new(cwd_str)) == expected_norm
+}
+
+/// Test-only wrapper around [`codex_rollout_cwd_matches_norm`] that normalizes `expected_cwd` per call. Kept for the unit tests that don't want to
+/// pre-normalize.
+#[cfg(test)]
+fn codex_rollout_cwd_matches(path: &Path, expected_cwd: &Path) -> bool {
+    codex_rollout_cwd_matches_norm(path, &normalize_path_components(expected_cwd))
+}
+
+/// Extract the thread_id from the first line of a Codex rollout file.
+fn codex_rollout_thread_id(path: &Path) -> Option<String> {
+    let payload = read_codex_session_meta(path)?;
+    payload
+        .get("thread_id")
+        .or_else(|| payload.get("id"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_owned())
+}
+
+/// Codex rollout watcher state accumulated from `TokenCount` and `TurnContext` events.
+#[derive(Debug, Default)]
+struct CodexState {
+    /// Cumulative input tokens (from total_token_usage.input_tokens).
+    sum_input: u64,
+    /// Cumulative output tokens (from total_token_usage.output_tokens).
+    sum_output: u64,
+    /// Model context window limit (from model_context_window or TurnStarted).
+    context_window: Option<u64>,
+    /// Current tokens occupying the context window — sourced from `last_token_usage.total_tokens` (the most recent turn),
+    /// NOT the cumulative session counter `total_token_usage`. This mirrors Codex's own status card, which drives the
+    /// context gauge from `last_token_usage`; using the cumulative total would pin the gauge at 100% after enough turns.
+    context_tokens_used: Option<u64>,
+    /// Most recent model name (from TurnContext).
+    last_model: Option<String>,
+    /// True once at least one TokenCount event has been ingested.
+    seen: bool,
+}
+
+impl CodexState {
+    fn has_any(&self) -> bool {
+        self.seen
+    }
+
+    fn snapshot(&self, session_id: SessionId) -> SessionMetricsEvent {
+        let used = self.context_tokens_used;
+        let pct = context_used_pct(used, self.context_window);
+        SessionMetricsEvent {
+            session_id,
+            model: self.last_model.clone(),
+            context_used_pct: pct,
+            context_tokens_used: used,
+            context_tokens_limit: self.context_window,
+            input_tokens: Some(self.sum_input),
+            output_tokens: Some(self.sum_output),
+            observed_at: now_unix_seconds(),
+        }
+    }
+}
+
+/// Extract token-count fields from a `token_count` event's `info` object. Returns a tuple of
+/// `(input, output, context_tokens, model_context_window)`, each `Some` when present and well-typed. Missing info returns
+/// an all-`None` tuple early.
+///
+/// Codex's `EventMsg` is *internally* tagged, so `TokenCountEvent`'s fields are inlined directly under the rollout
+/// line's `payload` (i.e. `payload.info`). We still accept the legacy `payload.payload.info` shape defensively in case
+/// an older CLI build emitted an extra wrapper.
+///
+/// `input`/`output` come from `total_token_usage` (Codex's cumulative session counters), while `context_tokens` — the
+/// value that drives the context-window gauge — comes from `last_token_usage.total_tokens` (the live occupancy of the
+/// window), falling back to the cumulative total only if `last_token_usage` is absent.
+fn extract_codex_token_count(payload: &serde_json::Value) -> (Option<u64>, Option<u64>, Option<u64>, Option<u64>) {
+    let Some(info) = payload.get("info").or_else(|| payload.get("payload").and_then(|p| p.get("info"))) else {
+        return (None, None, None, None);
+    };
+    let total = info.get("total_token_usage");
+    let input = total.and_then(|t| t.get("input_tokens")).and_then(|v| v.as_u64());
+    let output = total.and_then(|t| t.get("output_tokens")).and_then(|v| v.as_u64());
+    let context_tokens = info
+        .get("last_token_usage")
+        .and_then(|t| t.get("total_tokens"))
+        .and_then(|v| v.as_u64())
+        .or_else(|| total.and_then(|t| t.get("total_tokens")).and_then(|v| v.as_u64()));
+    let mcw = info.get("model_context_window").and_then(|v| v.as_u64()).filter(|&v| v > 0);
+    (input, output, context_tokens, mcw)
+}
+
+/// Ingest a single Codex rollout JSONL line. Extracts token usage from `EventMsg::TokenCount` and model from `TurnContext`.
+fn ingest_codex_rollout_line(line: &[u8], state: &mut CodexState) {
+    // Lines in the rollout are `{"timestamp":"...","type":"<variant>","payload":{...}}`.
+    // We care about:
+    // - type = "event_msg" with payload.type = "token_count" → token usage
+    // - type = "turn_context" → model name
+    //
+    // Codex's `RolloutItem` is adjacently tagged (`tag = "type", content = "payload"`) while the inner `EventMsg` is
+    // internally tagged (`tag = "type"`, no content), and both use `rename_all = "snake_case"`. So the real event tag is
+    // `token_count` / `task_started`, not the PascalCase `TokenCount` / `TurnStarted`. We accept both spellings so a
+    // format change in either direction doesn't silently zero out the sidebar.
+    let Ok(outer) = serde_json::from_slice::<CodexRolloutLine>(line) else {
+        return;
+    };
+
+    match outer.r#type.as_str() {
+        "event_msg" => {
+            let Some(payload) = outer.payload else { return };
+            // EventMsg is tagged: {"type":"token_count", ...inlined TokenCountEvent fields}
+            let Some(event_type) = payload.get("type").and_then(|v| v.as_str()) else {
+                return;
+            };
+            match event_type {
+                "token_count" | "TokenCount" => {
+                    let (input, output, total, mcw) = extract_codex_token_count(&payload);
+                    if let Some(v) = input {
+                        state.sum_input = v;
+                    }
+                    if let Some(v) = output {
+                        state.sum_output = v;
+                    }
+                    if let Some(v) = total {
+                        state.context_tokens_used = Some(v);
+                    }
+                    if let Some(v) = mcw {
+                        state.context_window = Some(v);
+                    }
+                    state.seen = true;
+                }
+                "task_started" | "turn_started" | "TurnStarted" => {
+                    // `TurnStartedEvent.model_context_window` is inlined under `payload` (internally-tagged EventMsg); the
+                    // legacy `payload.payload.model_context_window` shape is accepted defensively.
+                    if let Some(mcw) = payload
+                        .get("model_context_window")
+                        .or_else(|| payload.get("payload").and_then(|p| p.get("model_context_window")))
+                        .and_then(|v| v.as_u64())
+                        .filter(|&v| v > 0)
+                    {
+                        state.context_window = Some(mcw);
+                    }
+                }
+                _ => {}
+            }
+        }
+        "turn_context" => {
+            let Some(payload) = outer.payload else { return };
+            if let Some(model) = payload.get("model").and_then(|v| v.as_str()) {
+                if !model.is_empty() {
+                    state.last_model = Some(model.to_owned());
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Cheap byte-level prefilter to detect a `TurnComplete` event in a Codex rollout line. Avoids full JSON parse on the majority of lines.
+fn maybe_codex_turn_complete(line: &[u8]) -> bool {
+    fn contains(hay: &[u8], needle: &[u8]) -> bool {
+        hay.len() >= needle.len() && hay.windows(needle.len()).any(|w| w == needle)
+    }
+    contains(line, b"\"TurnComplete\"") || contains(line, b"\"task_complete\"") || contains(line, b"\"turn_complete\"")
+}
+
+/// Parse a Codex turn-complete event.
+///
+/// Returns:
+/// - `Some(Some(duration_ms))` for a real turn-complete event with duration
+/// - `Some(None)` for a real turn-complete event without duration
+/// - `None` when the line is not a turn-complete event (or cannot be parsed)
+fn parse_codex_turn_duration_ms(line: &[u8]) -> Option<Option<u64>> {
+    let outer: CodexRolloutLine = serde_json::from_slice(line).ok()?;
+    if outer.r#type != "event_msg" {
+        return None;
+    }
+    let payload = outer.payload?;
+    let event_type = payload.get("type").and_then(|v| v.as_str())?;
+    if event_type != "TurnComplete" && event_type != "task_complete" && event_type != "turn_complete" {
+        return None;
+    }
+    let duration_ms = payload
+        .get("duration_ms")
+        .or_else(|| payload.get("payload").and_then(|inner| inner.get("duration_ms")))
+        .and_then(|v| v.as_u64());
+    Some(duration_ms)
+}
+
+/// Codex rollout metrics parser. Owns the rollout-tree scan (binding by `cwd` + spawn instant) and the token accumulation; the engine owns the
+/// polling/tailing loop, the discovery backoff timer, and rebind-on-disappearance.
+pub struct CodexMetricsParser {
+    sessions_dir: PathBuf,
+    cwd: PathBuf,
+    state: CodexState,
+}
+
+impl CodexMetricsParser {
+    #[must_use]
+    pub fn new(codex_home: &Path, cwd: &Path) -> Self {
+        Self {
+            sessions_dir: codex_home.join("sessions"),
+            cwd: cwd.to_path_buf(),
+            state: CodexState::default(),
+        }
+    }
+}
+
+impl MetricsParser for CodexMetricsParser {
+    fn relocate_each_poll(&self) -> bool {
+        // Codex shares one `~/.codex/sessions/` tree across projects and nests files in dated subdirs, so a cold scan is O(N) over rollout history.
+        // The engine binds once and only rediscovers after the bound file disappears, applying backoff between misses.
+        false
+    }
+
+    fn rebind_on_disappear(&self) -> bool {
+        true
+    }
+
+    fn locate(&mut self, spawn_instant: SystemTime) -> Option<LocatedFile> {
+        let path = newest_codex_rollout(&self.sessions_dir, &self.cwd, spawn_instant)?;
+        let ai_session_id = codex_rollout_thread_id(&path);
+        Some(LocatedFile { path, ai_session_id })
+    }
+
+    fn reset(&mut self) {
+        self.state = CodexState::default();
+    }
+
+    fn ingest_line(&mut self, line: &[u8], session_id: SessionId, emit_turn: &TurnCb) {
+        ingest_codex_rollout_line(line, &mut self.state);
+        if maybe_codex_turn_complete(line) {
+            if let Some(duration) = parse_codex_turn_duration_ms(line) {
+                emit_turn(session_id, duration);
+            }
+        }
+    }
+
+    fn snapshot(&self, session_id: SessionId) -> Option<SessionMetricsEvent> {
+        if !self.state.has_any() {
+            return None;
+        }
+        Some(self.state.snapshot(session_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ingest_codex_token_count_event() {
+        // Real Codex format: `RolloutItem` is adjacently tagged (`payload`), `EventMsg` is internally tagged
+        // (`token_count`), so `info` is inlined directly under `payload` — there is no second `payload` wrapper.
+        // Context occupancy is the LAST turn's total (950), while input/output are the cumulative session totals.
+        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1500,"cached_input_tokens":200,"output_tokens":800,"reasoning_output_tokens":100,"total_tokens":2600},"last_token_usage":{"input_tokens":500,"cached_input_tokens":100,"output_tokens":300,"reasoning_output_tokens":50,"total_tokens":950},"model_context_window":128000},"rate_limits":null}}"#;
+        let mut state = CodexState::default();
+        ingest_codex_rollout_line(line, &mut state);
+        assert!(state.seen);
+        assert_eq!(state.sum_input, 1500);
+        assert_eq!(state.sum_output, 800);
+        assert_eq!(state.context_tokens_used, Some(950));
+        assert_eq!(state.context_window, Some(128000));
+    }
+
+    #[test]
+    fn ingest_codex_token_count_event_legacy_double_payload() {
+        // Defensive: an older/alternative shape with PascalCase tag and a nested `payload.payload.info` wrapper.
+        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"TokenCount","payload":{"info":{"total_token_usage":{"input_tokens":1500,"cached_input_tokens":200,"output_tokens":800,"reasoning_output_tokens":100,"total_tokens":2600},"last_token_usage":{"input_tokens":500,"cached_input_tokens":100,"output_tokens":300,"reasoning_output_tokens":50,"total_tokens":950},"model_context_window":128000}}}}"#;
+        let mut state = CodexState::default();
+        ingest_codex_rollout_line(line, &mut state);
+        assert!(state.seen);
+        assert_eq!(state.sum_input, 1500);
+        assert_eq!(state.sum_output, 800);
+        assert_eq!(state.context_tokens_used, Some(950));
+        assert_eq!(state.context_window, Some(128000));
+    }
+
+    #[test]
+    fn ingest_codex_context_occupancy_tracks_last_turn_not_cumulative() {
+        // Across turns, `total_token_usage` accumulates without bound while `last_token_usage` reflects the live window.
+        // The context gauge must follow the latter, so it can never get pinned at 100% once the session exceeds the window.
+        let window = 100_000u64;
+        let turn1 = br#"{"timestamp":"t1","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":60000,"output_tokens":20000,"total_tokens":80000},"last_token_usage":{"input_tokens":60000,"output_tokens":20000,"total_tokens":80000},"model_context_window":100000}}}"#;
+        // After a /compact the cumulative session total (190000) exceeds the window, but only 30000 tokens occupy it.
+        let turn2 = br#"{"timestamp":"t2","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":140000,"output_tokens":50000,"total_tokens":190000},"last_token_usage":{"input_tokens":25000,"output_tokens":5000,"total_tokens":30000},"model_context_window":100000}}}"#;
+        let mut state = CodexState::default();
+        ingest_codex_rollout_line(turn1, &mut state);
+        ingest_codex_rollout_line(turn2, &mut state);
+        assert_eq!(state.context_tokens_used, Some(30_000));
+        assert_eq!(state.context_window, Some(window));
+        let snap = state.snapshot(SessionId::new());
+        assert_eq!(snap.context_used_pct, Some(30));
+        // Cumulative session totals still surface for the input/output displays.
+        assert_eq!(snap.input_tokens, Some(140_000));
+        assert_eq!(snap.output_tokens, Some(50_000));
+    }
+
+    #[test]
+    fn ingest_codex_turn_context_extracts_model() {
+        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"turn_context","payload":{"model":"o3-mini","cwd":"/tmp","approval_policy":"OnRequest","sandbox_policy":{"type":"workspace-write"},"summary":"auto"}}"#;
+        let mut state = CodexState::default();
+        ingest_codex_rollout_line(line, &mut state);
+        assert_eq!(state.last_model.as_deref(), Some("o3-mini"));
+    }
+
+    #[test]
+    fn ingest_codex_turn_started_extracts_context_window() {
+        // Real Codex format: `task_started` tag, `model_context_window` inlined under `payload`.
+        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"task_started","turn_id":"abc","model_context_window":200000}}"#;
+        let mut state = CodexState::default();
+        ingest_codex_rollout_line(line, &mut state);
+        assert_eq!(state.context_window, Some(200000));
+    }
+
+    #[test]
+    fn ingest_codex_turn_started_extracts_context_window_legacy() {
+        // Defensive: PascalCase tag with a nested `payload.payload.model_context_window`.
+        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"TurnStarted","payload":{"turn_id":"abc","model_context_window":200000}}}"#;
+        let mut state = CodexState::default();
+        ingest_codex_rollout_line(line, &mut state);
+        assert_eq!(state.context_window, Some(200000));
+    }
+
+    #[test]
+    fn codex_state_snapshot_computes_pct() {
+        let state = CodexState {
+            sum_input: 1000,
+            sum_output: 500,
+            context_window: Some(100_000),
+            context_tokens_used: Some(50_000),
+            last_model: Some("o3".into()),
+            seen: true,
+        };
+        let snap = state.snapshot(SessionId::new());
+        assert_eq!(snap.context_used_pct, Some(50));
+        assert_eq!(snap.model.as_deref(), Some("o3"));
+        assert_eq!(snap.input_tokens, Some(1000));
+        assert_eq!(snap.output_tokens, Some(500));
+    }
+
+    #[test]
+    fn codex_state_snapshot_pct_handles_large_values_without_overflow() {
+        let state = CodexState {
+            sum_input: 1000,
+            sum_output: 500,
+            context_window: Some(10_000_000_000_000_000_000),
+            context_tokens_used: Some(5_000_000_000_000_000_000),
+            last_model: Some("o3".into()),
+            seen: true,
+        };
+        let snap = state.snapshot(SessionId::new());
+        assert_eq!(snap.context_used_pct, Some(50));
+    }
+
+    #[test]
+    fn parse_codex_turn_complete_duration() {
+        // Real Codex format: `turn_complete` tag, `duration_ms` inlined under `payload`.
+        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"turn_complete","turn_id":"t1","duration_ms":4200}}"#;
+        assert_eq!(parse_codex_turn_duration_ms(line), Some(Some(4200)));
+    }
+
+    #[test]
+    fn parse_codex_turn_complete_duration_legacy_double_payload() {
+        // Defensive: PascalCase tag with a nested `payload.payload.duration_ms`.
+        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"TurnComplete","payload":{"turn_id":"t1","last_agent_message":"done","duration_ms":4200}}}"#;
+        assert_eq!(parse_codex_turn_duration_ms(line), Some(Some(4200)));
+    }
+
+    #[test]
+    fn parse_codex_turn_complete_no_duration() {
+        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"turn_complete","turn_id":"t1"}}"#;
+        assert_eq!(parse_codex_turn_duration_ms(line), Some(None));
+    }
+
+    #[test]
+    fn parse_codex_turn_complete_ignores_non_turn_complete_event_with_keyword() {
+        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"token_count","note":"TurnComplete"}}"#;
+        assert!(maybe_codex_turn_complete(line));
+        assert_eq!(parse_codex_turn_duration_ms(line), None);
+    }
+
+    #[test]
+    fn codex_rollout_cwd_match_and_thread_id_extraction() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("rollout-2025-05-18T10-00-00-abcdef12-3456-7890-abcd-ef1234567890.jsonl");
+        let cwd = if cfg!(windows) { r"C:\repos\myproject" } else { "/repos/myproject" };
+        let first_line = format!(
+            r#"{{"timestamp":"2025-05-18T10:00:00Z","type":"session_meta","payload":{{"id":"thread-uuid-123","cwd":"{}","originator":"codex","cli_version":"1.0","source":"cli"}}}}"#,
+            cwd.replace('\\', "\\\\")
+        );
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "{}", first_line).unwrap();
+        drop(f);
+
+        assert!(codex_rollout_cwd_matches(&path, Path::new(cwd)));
+        assert!(!codex_rollout_cwd_matches(&path, Path::new("/other/path")));
+        assert_eq!(codex_rollout_thread_id(&path), Some("thread-uuid-123".to_string()));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn codex_rollout_cwd_match_normalizes_windows_separators_and_trailing_separator() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("rollout-2025-05-18T10-00-00-abcdef12-3456-7890-abcd-ef1234567890.jsonl");
+        let expected_cwd = r"C:\repos\myproject";
+        let rollout_cwd = format!("{}/", expected_cwd.replace('\\', "/"));
+        let first_line = format!(
+            r#"{{"timestamp":"2025-05-18T10:00:00Z","type":"session_meta","payload":{{"id":"thread-uuid-123","cwd":"{}","originator":"codex","cli_version":"1.0","source":"cli"}}}}"#,
+            rollout_cwd
+        );
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "{}", first_line).unwrap();
+        drop(f);
+
+        assert!(codex_rollout_cwd_matches(&path, Path::new(expected_cwd)));
+    }
+
+    #[test]
+    fn codex_rollout_thread_id_requires_session_meta() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("rollout-2025-05-18T10-00-00-abcdef12-3456-7890-abcd-ef1234567890.jsonl");
+        let first_line = r#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"id":"not-a-thread-id"}}"#;
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "{}", first_line).unwrap();
+        drop(f);
+
+        assert_eq!(codex_rollout_thread_id(&path), None);
+    }
+
+    #[test]
+    fn codex_rollout_thread_id_accepts_thread_id_field() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("rollout-2025-05-18T10-00-00-abcdef12-3456-7890-abcd-ef1234567890.jsonl");
+        let first_line = r#"{"timestamp":"2025-05-18T10:00:00Z","type":"session_meta","payload":{"thread_id":"thread-from-thread-id","cwd":"/tmp"}}"#;
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "{}", first_line).unwrap();
+        drop(f);
+
+        assert_eq!(codex_rollout_thread_id(&path), Some("thread-from-thread-id".to_owned()));
+    }
+
+    #[test]
+    fn newest_codex_rollout_picks_matching_cwd() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions_dir = dir.path().join("sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+
+        let cwd = if cfg!(windows) { r"C:\repos\target" } else { "/repos/target" };
+        let other_cwd = if cfg!(windows) { r"C:\repos\other" } else { "/repos/other" };
+
+        // Create a rollout matching our cwd.
+        let good_path = sessions_dir.join("rollout-2025-05-18T10-00-00-11111111-1111-1111-1111-111111111111.jsonl");
+        let good_line = format!(
+            r#"{{"timestamp":"2025-05-18T10:00:00Z","type":"session_meta","payload":{{"id":"good-thread","cwd":"{}","originator":"codex","cli_version":"1.0","source":"cli"}}}}"#,
+            cwd.replace('\\', "\\\\")
+        );
+        let mut f = std::fs::File::create(&good_path).unwrap();
+        writeln!(f, "{}", good_line).unwrap();
+        drop(f);
+
+        // Create a rollout with a different cwd.
+        let bad_path = sessions_dir.join("rollout-2025-05-18T10-00-01-22222222-2222-2222-2222-222222222222.jsonl");
+        let bad_line = format!(
+            r#"{{"timestamp":"2025-05-18T10:00:01Z","type":"session_meta","payload":{{"id":"bad-thread","cwd":"{}","originator":"codex","cli_version":"1.0","source":"cli"}}}}"#,
+            other_cwd.replace('\\', "\\\\")
+        );
+        let mut f = std::fs::File::create(&bad_path).unwrap();
+        writeln!(f, "{}", bad_line).unwrap();
+        drop(f);
+
+        let after = SystemTime::now() - Duration::from_secs(60);
+        let result = newest_codex_rollout(&sessions_dir, Path::new(cwd), after);
+        assert_eq!(result, Some(good_path));
+    }
+
+    /// Engine integration: the codex parser drives the generic watcher through a discovery miss (no rollout exists yet), then binds the freshly
+    /// created rollout, fires AI-session discovery with the thread id, and emits a metrics snapshot. Exercises the codex-only engine branches
+    /// (non-relocate bind-once-with-backoff, discovery miss, bind-on-appear, thread-id discovery from the filename/meta) that the parser unit tests
+    /// don't cover — this is the regression guard that the metrics-parser refactor didn't break codex end-to-end.
+    #[test]
+    fn codex_watcher_discovers_rollout_and_emits_snapshot() {
+        use std::io::Write;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::{mpsc, Arc};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let codex_home = dir.path().to_path_buf();
+        let sessions_dir = codex_home.join("sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+
+        let cwd = if cfg!(windows) { r"C:\repos\codex-proj" } else { "/repos/codex-proj" };
+
+        let session_id = SessionId::new();
+        let running = Arc::new(AtomicBool::new(true));
+        let running_for_thread = Arc::clone(&running);
+        let (tx, rx) = mpsc::channel::<SessionMetricsEvent>();
+        let (disc_tx, disc_rx) = mpsc::channel::<(SessionId, String)>();
+        let metrics_cb: crate::session_metrics::MetricsCb = Arc::new(move |ev| {
+            let _ = tx.send(ev);
+        });
+        let discover_cb: crate::session_metrics::AiSessionDiscoveryCb = Arc::new(move |sid, id| {
+            let _ = disc_tx.send((sid, id));
+        });
+        let codex_home_for_thread = codex_home.clone();
+        let cwd_for_thread = cwd.to_owned();
+        let handle = std::thread::spawn(move || {
+            let parser = Box::new(CodexMetricsParser::new(&codex_home_for_thread, Path::new(&cwd_for_thread)));
+            crate::session_metrics::run_metrics_watcher(
+                session_id,
+                parser,
+                SystemTime::now() - Duration::from_secs(60),
+                metrics_cb,
+                Arc::new(|_, _| {}),
+                discover_cb,
+                running_for_thread,
+            );
+        });
+
+        // The first poll(s) find no matching rollout (discovery miss). Then create one: `session_meta` (cwd match + thread id) followed by a
+        // `token_count` event the parser should ingest into a snapshot.
+        let rollout = sessions_dir.join("rollout-2025-05-18T10-00-00-33333333-3333-3333-3333-333333333333.jsonl");
+        let session_meta = format!(
+            r#"{{"timestamp":"2025-05-18T10:00:00Z","type":"session_meta","payload":{{"id":"codex-thread-xyz","cwd":"{}","originator":"codex","cli_version":"1.0","source":"cli"}}}}"#,
+            cwd.replace('\\', "\\\\")
+        );
+        let token_count = r#"{"timestamp":"2025-05-18T10:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1500,"output_tokens":800,"total_tokens":2600},"last_token_usage":{"input_tokens":500,"output_tokens":300,"total_tokens":950},"model_context_window":128000}}}"#;
+        let mut f = std::fs::File::create(&rollout).unwrap();
+        writeln!(f, "{}", session_meta).unwrap();
+        writeln!(f, "{}", token_count).unwrap();
+        drop(f);
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(12);
+        let snap = loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            match rx.recv_timeout(remaining) {
+                Ok(s) if s.context_tokens_used == Some(950) => break s,
+                Ok(_) => continue,
+                Err(_) => panic!("timed out waiting for codex snapshot (context_tokens_used never reached 950)"),
+            }
+        };
+        assert_eq!(snap.context_tokens_used, Some(950));
+        assert_eq!(snap.context_tokens_limit, Some(128_000));
+        assert_eq!(snap.input_tokens, Some(1500));
+        assert_eq!(snap.output_tokens, Some(800));
+
+        // The engine must surface the rollout thread id so restore-on-launch can `codex resume <id>`.
+        let (disc_sid, disc_id) = disc_rx.recv_timeout(Duration::from_secs(2)).expect("discovery callback fired");
+        assert_eq!(disc_sid, session_id);
+        assert_eq!(disc_id, "codex-thread-xyz");
+
+        running.store(false, Ordering::SeqCst);
+        handle.join().expect("watcher thread joined");
+    }
+}

--- a/src-tauri/src/plugins/ai/codex/mod.rs
+++ b/src-tauri/src/plugins/ai/codex/mod.rs
@@ -5,14 +5,16 @@
 //! Resume syntax differs from Claude/Copilot: `codex resume <session_id>` (a
 //! subcommand, not a `--resume` flag).
 //!
-//! The metrics watcher implementation lives in
-//! [`crate::session_metrics`] (`run_codex_watcher`); that module documents the
-//! rollout-file layout and the event types it consumes.
+//! The metrics watcher implementation is driven by the generic engine in
+//! [`crate::session_metrics`]; the rollout-file layout and the event types it
+//! consumes are documented in [`metrics`].
 
 use crate::plugins::ai::AiPlugin;
 use crate::plugins::Plugin;
 use crate::types::SessionId;
 use crate::types::Tool;
+
+pub mod metrics;
 
 /// Stable singleton instance for dispatch sites that need a `'static`
 /// [`AiPlugin`] reference without allocating.
@@ -47,14 +49,16 @@ impl AiPlugin for CodexPlugin {
         crate::plugins::ai::SpawnPrep::default()
     }
 
-    fn metrics_watcher_kind(&self, _session_id: SessionId, cwd: &std::path::Path) -> Option<crate::plugins::ai::MetricsWatcherKind> {
+    fn metrics_parser(
+        &self,
+        _session_id: SessionId,
+        cwd: &std::path::Path,
+        _spawn_instant: std::time::SystemTime,
+    ) -> Option<Box<dyn crate::session_metrics::MetricsParser>> {
         let codex_home = std::env::var_os("CODEX_HOME")
             .map(std::path::PathBuf::from)
             .or_else(|| crate::session_metrics::home_dir().map(|home| home.join(".codex")))?;
-        Some(crate::plugins::ai::MetricsWatcherKind::Codex {
-            codex_home,
-            cwd: cwd.to_path_buf(),
-        })
+        Some(Box::new(metrics::CodexMetricsParser::new(&codex_home, cwd)))
     }
 
     fn starts_activity_events_watcher(&self) -> bool {

--- a/src-tauri/src/plugins/ai/copilot/metrics.rs
+++ b/src-tauri/src/plugins/ai/copilot/metrics.rs
@@ -1,0 +1,693 @@
+//! Copilot metrics parsing (OTel file-exporter JSONL).
+//!
+//! GitHub Copilot CLI does **not** write token usage to its own session-state JSONL (`~/.copilot/session-state/<sid>/events.jsonl`). It does,
+//! however, support OpenTelemetry export. We use the **file exporter** — enabled and configured via the env vars in [`super::CopilotPlugin::env`]
+//! (injected by `pty_pool::spawn_internal`) — to redirect spans to a deterministic per-session file `<session_temp_dir>/otel.jsonl`.
+//!
+//! The generic engine in [`crate::session_metrics`] tails that file through a [`CopilotMetricsParser`], which extracts:
+//!
+//! * **Cumulative input/output token totals** from `chat <model>` span `attributes."gen_ai.usage.{input,output}_tokens"`. Each span is one LLM
+//!   round-trip; we sum them.
+//! * **Model name** from `attributes."gen_ai.response.model"` (fallback `"gen_ai.request.model"`).
+//! * **Context-window state** from the inline event `github.copilot.session.usage_info`'s attributes: `github.copilot.token_limit` (the model's
+//!   authoritative window) and `github.copilot.current_tokens` (the conversational context size at the moment that span was emitted — *not* the same
+//!   as `gen_ai.usage.input_tokens`, which also includes cache-creation writes; we use `current_tokens` as the "context % used" numerator to match
+//!   the user-visible Copilot status line).
+//!
+//! Two critical parsing rules:
+//!
+//! 1. **Filter to leaf `chat` spans only.** Copilot's `invoke_agent` parent span aggregates the *same* `gen_ai.usage.*` numbers as its child `chat`
+//!    span(s). Counting both would double the totals. We require the semconv attribute `gen_ai.operation.name == "chat"` and ignore everything else
+//!    (including `type: "metric"` lines, which are redundant with span attributes). The op attribute is the source of truth — `name` varies (`"chat"`
+//!    vs `"chat <model>"` across Copilot versions) and a previous `name.starts_with("chat ")` filter silently dropped bare-name spans, breaking
+//!    `aiSessionId` tracking after `/clear` or `/resume` and zeroing token totals for affected sessions.
+//! 2. **Spans only emit at span CLOSE.** OTel's batch span processor flushes after the span ends, not while it's open. Use the existing PTY-stream
+//!    activity scanner for "is the agent currently working" — OTel cannot answer that question.
+//!
+//! `OTEL_BSP_SCHEDULE_DELAY=1000` (set in [`super::CopilotPlugin::env`]) tightens the SDK's batch flush from its 5s default to ~1Hz so token totals
+//! appear in the sidebar within a couple seconds of each agent turn.
+
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use serde::Deserialize;
+
+use crate::session_metrics::{context_used_pct, now_unix_seconds, LocatedFile, MetricsParser, TurnCb};
+use crate::types::{SessionId, SessionMetricsEvent};
+
+/// Running state accumulated by the Copilot parser across all ingested `chat <model>` spans for one session.
+#[derive(Debug, Default)]
+pub(crate) struct CopilotState {
+    /// Cumulative input tokens (sum of `gen_ai.usage.input_tokens` across every leaf chat span). Includes cache-creation writes.
+    sum_input: u64,
+    /// Cumulative output tokens (sum of `gen_ai.usage.output_tokens`).
+    sum_output: u64,
+    /// Most recent model name observed (`gen_ai.response.model`, fallback `gen_ai.request.model`).
+    last_model: Option<String>,
+    /// Most recent value of `github.copilot.token_limit` from the inline `github.copilot.session.usage_info` event. Authoritative context window for
+    /// the model that turn used.
+    token_limit: Option<u64>,
+    /// Most recent value of `github.copilot.current_tokens` — the size of the conversational context the agent had in front of it at the moment of
+    /// the span. Drives the sidebar's "context % used".
+    current_tokens: Option<u64>,
+    /// Copilot's conversation/session id (`gen_ai.conversation.id`), matching the directory name under `~/.copilot/session-state/<id>/` and
+    /// accepted by `copilot --session-id <id>` (copilot-cli >= 1.0.51). Captured for AI-session discovery; not part of the metrics snapshot.
+    pub(crate) conversation_id: Option<String>,
+    /// True once at least one chat span has been ingested.
+    seen: bool,
+}
+
+impl CopilotState {
+    pub(crate) fn has_any(&self) -> bool {
+        self.seen
+    }
+
+    pub(crate) fn snapshot(&self, session_id: SessionId) -> SessionMetricsEvent {
+        let used = self.current_tokens;
+        let pct = context_used_pct(used, self.token_limit);
+        SessionMetricsEvent {
+            session_id,
+            model: self.last_model.clone(),
+            context_used_pct: pct,
+            context_tokens_used: used,
+            context_tokens_limit: self.token_limit,
+            input_tokens: Some(self.sum_input),
+            output_tokens: Some(self.sum_output),
+            observed_at: now_unix_seconds(),
+        }
+    }
+}
+
+/// Ingest a single OTel JSONL line into `state`. Silently ignores anything that isn't a leaf `chat` span (metric lines, `invoke_agent` parents, other
+/// span kinds, malformed JSON). Never panics.
+///
+/// The `invoke_agent` filter is critical: that span carries the *same* `gen_ai.usage.*` numbers as its child `chat` span(s), so counting both would
+/// double the totals. We filter on the semconv attribute `gen_ai.operation.name == "chat"` — `name` is unreliable across Copilot versions (sometimes
+/// `"chat"`, sometimes `"chat <model>"`) and the previous `name.starts_with("chat ")` filter silently dropped bare-name spans, breaking `aiSessionId`
+/// tracking after `/clear` or `/resume` and zeroing token totals for affected sessions.
+pub(crate) fn ingest_otel_line(line: &[u8], state: &mut CopilotState) {
+    #[derive(Deserialize)]
+    struct Outer {
+        #[serde(default)]
+        r#type: String,
+        #[serde(default)]
+        attributes: Option<serde_json::Value>,
+        #[serde(default)]
+        events: Option<Vec<OtelEvent>>,
+    }
+    #[derive(Deserialize)]
+    struct OtelEvent {
+        #[serde(default)]
+        name: String,
+        #[serde(default)]
+        attributes: Option<serde_json::Value>,
+    }
+
+    let Ok(outer) = serde_json::from_slice::<Outer>(line) else {
+        return;
+    };
+    if outer.r#type != "span" {
+        return;
+    }
+    // Filter on the semconv operation attribute, NOT on `name`. See the doc comment above for why `name` is unreliable across Copilot versions.
+    let attrs = outer.attributes.as_ref();
+    let op = attrs.and_then(|a| a.get("gen_ai.operation.name")).and_then(|v| v.as_str());
+    if op != Some("chat") {
+        return;
+    }
+
+    let input = attrs
+        .and_then(|a| a.get("gen_ai.usage.input_tokens"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let output = attrs
+        .and_then(|a| a.get("gen_ai.usage.output_tokens"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    state.sum_input = state.sum_input.saturating_add(input);
+    state.sum_output = state.sum_output.saturating_add(output);
+
+    if let Some(model) = attrs
+        .and_then(|a| a.get("gen_ai.response.model"))
+        .and_then(|v| v.as_str())
+        .or_else(|| attrs.and_then(|a| a.get("gen_ai.request.model")).and_then(|v| v.as_str()))
+    {
+        state.last_model = Some(model.to_owned());
+    }
+
+    if let Some(conv) = attrs.and_then(|a| a.get("gen_ai.conversation.id")).and_then(|v| v.as_str()) {
+        if !conv.is_empty() {
+            state.conversation_id = Some(conv.to_owned());
+        }
+    }
+
+    if let Some(events) = outer.events.as_ref() {
+        for ev in events {
+            if ev.name != "github.copilot.session.usage_info" {
+                continue;
+            }
+            let ev_attrs = ev.attributes.as_ref();
+            if let Some(v) = ev_attrs.and_then(|a| a.get("github.copilot.token_limit")).and_then(|v| v.as_u64()) {
+                state.token_limit = Some(v);
+            }
+            if let Some(v) = ev_attrs.and_then(|a| a.get("github.copilot.current_tokens")).and_then(|v| v.as_u64()) {
+                state.current_tokens = Some(v);
+            }
+        }
+    }
+
+    state.seen = true;
+}
+
+/// Extract the wall-clock duration of an `invoke_agent` span (one full agent turn) in milliseconds. Returns `None` for any other line — chat spans,
+/// metric lines, malformed JSON — so the caller can call this on every JSONL line it tails.
+///
+/// We deliberately key on `invoke_agent` (not `chat`): one agent turn can involve multiple `chat` round-trips, but exactly one `invoke_agent`. This
+/// matches the user's intuition of "the agent finished" — the icon flips to *awaiting* on the outer span close, not on each LLM hop.
+pub(crate) fn parse_invoke_agent_duration_ms(line: &[u8]) -> Option<u64> {
+    #[derive(Deserialize)]
+    struct Outer {
+        #[serde(default)]
+        r#type: String,
+        #[serde(default)]
+        name: String,
+        #[serde(default, rename = "startTime")]
+        start_time: Option<[u64; 2]>,
+        #[serde(default, rename = "endTime")]
+        end_time: Option<[u64; 2]>,
+    }
+    let outer: Outer = serde_json::from_slice(line).ok()?;
+    if outer.r#type != "span" || outer.name != "invoke_agent" {
+        return None;
+    }
+    let start = outer.start_time?;
+    let end = outer.end_time?;
+    // OTel times are `[seconds, nanos]`. Compute `end - start` in ns, saturating at 0 (some test/edge writers can produce slightly out-of- order
+    // timestamps).
+    let start_ns = start[0].saturating_mul(1_000_000_000).saturating_add(start[1]);
+    let end_ns = end[0].saturating_mul(1_000_000_000).saturating_add(end[1]);
+    Some(end_ns.saturating_sub(start_ns) / 1_000_000)
+}
+
+/// Cheap byte-level prefilter used to skip a full JSON parse on the majority of OTel lines (metrics, logs, chat spans). Tolerates either
+/// `"name":"invoke_agent"` or `"name": "invoke_agent"` spacing — real emitters use the compact form, but the OTel SDK is allowed to insert a space
+/// and we'd rather over-accept here and let [`parse_invoke_agent_duration_ms`] reject than miss a legitimate turn-end.
+fn maybe_invoke_agent_span(line: &[u8]) -> bool {
+    fn contains(hay: &[u8], needle: &[u8]) -> bool {
+        hay.len() >= needle.len() && hay.windows(needle.len()).any(|w| w == needle)
+    }
+    contains(line, b"\"invoke_agent\"")
+}
+
+/// Copilot OTel metrics parser. The OTel file path is fixed per session (`COPILOT_OTEL_FILE_EXPORTER_PATH`), so there is nothing to discover — the
+/// engine binds it on the first poll and tails it for the session's lifetime.
+pub struct CopilotMetricsParser {
+    otel_path: PathBuf,
+    state: CopilotState,
+}
+
+impl CopilotMetricsParser {
+    #[must_use]
+    pub fn new(otel_path: PathBuf) -> Self {
+        Self {
+            otel_path,
+            state: CopilotState::default(),
+        }
+    }
+}
+
+impl MetricsParser for CopilotMetricsParser {
+    fn relocate_each_poll(&self) -> bool {
+        false
+    }
+
+    fn rebind_on_disappear(&self) -> bool {
+        // The per-session OTel file is created at spawn prep and never moves. A transient stat failure must not drop accumulated totals.
+        false
+    }
+
+    fn locate(&mut self, _spawn_instant: SystemTime) -> Option<LocatedFile> {
+        // Fixed path; the conversation id is discovered from parsed content, not the filename.
+        Some(LocatedFile {
+            path: self.otel_path.clone(),
+            ai_session_id: None,
+        })
+    }
+
+    fn reset(&mut self) {
+        self.state = CopilotState::default();
+    }
+
+    fn ingest_line(&mut self, line: &[u8], session_id: SessionId, emit_turn: &TurnCb) {
+        ingest_otel_line(line, &mut self.state);
+        // Cheap byte-level pre-filter — we don't want to re-parse every JSONL line as JSON just to discover it isn't an `invoke_agent` span. Real
+        // Copilot OTel logs are dominated by metric/log lines, so this saves a full serde_json::from_slice on the hot path.
+        if maybe_invoke_agent_span(line) {
+            if let Some(d) = parse_invoke_agent_duration_ms(line) {
+                emit_turn(session_id, Some(d));
+            }
+        }
+    }
+
+    fn content_ai_session_id(&self) -> Option<&str> {
+        // Surface the Copilot conversation id as soon as we see it. The OTel file is per-Arborist-session, so this is unambiguous even when multiple
+        // Copilot sessions run concurrently — unlike a directory-scan of `~/.copilot/session-state/`.
+        self.state.conversation_id.as_deref()
+    }
+
+    fn snapshot(&self, session_id: SessionId) -> Option<SessionMetricsEvent> {
+        if !self.state.has_any() {
+            return None;
+        }
+        Some(self.state.snapshot(session_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    /// Real probe data captured from `copilot -p` with the OTel file exporter enabled. Two spans (chat + invoke_agent parent) plus metric lines. Used
+    /// as the canonical fixture for the parser tests.
+    const COPILOT_OTEL_FIXTURE: &[u8] = include_bytes!("../../../../tests/fixtures/copilot_otel_sample.jsonl");
+
+    fn fixture_lines() -> Vec<&'static [u8]> {
+        COPILOT_OTEL_FIXTURE.split(|&b| b == b'\n').filter(|l| !l.is_empty()).collect()
+    }
+
+    #[test]
+    fn ingest_otel_chat_span_extracts_totals_and_context() {
+        // Find the leaf chat span line.
+        let chat_line = fixture_lines()
+            .into_iter()
+            .find(|l| std::str::from_utf8(l).unwrap_or("").contains(r#""name":"chat "#))
+            .expect("chat span in fixture");
+        let mut state = CopilotState::default();
+        ingest_otel_line(chat_line, &mut state);
+        assert!(state.has_any());
+        assert_eq!(state.sum_input, 39_497);
+        assert_eq!(state.sum_output, 24);
+        assert_eq!(state.last_model.as_deref(), Some("claude-opus-4.7"));
+        assert_eq!(state.token_limit, Some(168_000));
+        assert_eq!(state.current_tokens, Some(29_461));
+    }
+
+    #[test]
+    fn ingest_otel_chat_span_extracts_conversation_id() {
+        // The chat span carries `gen_ai.conversation.id` — that's the Copilot session id we feed back into `--session-id` (copilot-cli >= 1.0.51).
+        let chat_line = fixture_lines()
+            .into_iter()
+            .find(|l| std::str::from_utf8(l).unwrap_or("").contains(r#""name":"chat "#))
+            .expect("chat span in fixture");
+        let mut state = CopilotState::default();
+        ingest_otel_line(chat_line, &mut state);
+        assert!(state.conversation_id.is_some(), "chat span must populate conversation_id",);
+        let id = state.conversation_id.as_deref().expect("present");
+        assert!(!id.is_empty(), "conversation id must be non-empty");
+    }
+
+    #[test]
+    fn ingest_otel_chat_span_bare_name_is_accepted() {
+        // Copilot CLI emits chat spans with two `name` formats — the older `"chat <model>"` and the newer bare `"chat"`. The op attribute
+        // (`gen_ai.operation.name`) is identical in both. A previous `name.starts_with("chat ")` filter silently dropped bare-name spans, breaking
+        // aiSessionId tracking after /clear or /resume and zeroing token totals for affected sessions. This test pins the new op-based filter to the
+        // bare-name shape.
+        let line = br#"{"type":"span","name":"chat","attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"claude-opus-4.7-high","gen_ai.conversation.id":"abc-123","gen_ai.usage.input_tokens":50,"gen_ai.usage.output_tokens":5}}"#;
+        let mut state = CopilotState::default();
+        ingest_otel_line(line, &mut state);
+        assert!(state.has_any(), "bare-name chat span must be accepted");
+        assert_eq!(state.sum_input, 50);
+        assert_eq!(state.sum_output, 5);
+        assert_eq!(state.last_model.as_deref(), Some("claude-opus-4.7-high"));
+        assert_eq!(state.conversation_id.as_deref(), Some("abc-123"));
+    }
+
+    #[test]
+    fn ingest_otel_invoke_agent_with_chat_name_prefix_is_rejected() {
+        // Belt-and-suspenders: invoke_agent carries the same usage numbers as its chat children. If a future Copilot version named the parent
+        // something like "chat agent invocation" while keeping op=invoke_agent, a name-prefix filter would double-count. The op-based filter prevents
+        // that regardless of the name string.
+        let line = br#"{"type":"span","name":"chat agent invocation","attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.usage.input_tokens":999,"gen_ai.usage.output_tokens":99}}"#;
+        let mut state = CopilotState::default();
+        ingest_otel_line(line, &mut state);
+        assert!(!state.has_any(), "invoke_agent op must be ignored regardless of name",);
+    }
+
+    #[test]
+    fn ingest_otel_unknown_op_is_rejected() {
+        // Defense in depth for any future op kind we haven't yet characterized — only `chat` is known to carry leaf usage totals we want to sum.
+        let line = br#"{"type":"span","name":"chat_completion","attributes":{"gen_ai.operation.name":"chat_completion","gen_ai.usage.input_tokens":1000,"gen_ai.usage.output_tokens":100}}"#;
+        let mut state = CopilotState::default();
+        ingest_otel_line(line, &mut state);
+        assert!(!state.has_any(), "non-chat op must be ignored");
+    }
+
+    #[test]
+    fn ingest_otel_span_without_op_attribute_is_rejected() {
+        // The semconv attribute is the source of truth. A span missing it (e.g. malformed exporter output) must not be counted even if `name` happens
+        // to start with "chat".
+        let line = br#"{"type":"span","name":"chat foo","attributes":{"gen_ai.usage.input_tokens":10,"gen_ai.usage.output_tokens":1}}"#;
+        let mut state = CopilotState::default();
+        ingest_otel_line(line, &mut state);
+        assert!(!state.has_any(), "missing gen_ai.operation.name must be treated as unknown",);
+    }
+
+    #[test]
+    fn ingest_otel_invoke_agent_is_ignored() {
+        // The invoke_agent span carries the same gen_ai.usage.* numbers as its child chat span. If we counted both we'd double-count.
+        let parent_line = fixture_lines()
+            .into_iter()
+            .find(|l| std::str::from_utf8(l).unwrap_or("").contains(r#""name":"invoke_agent""#))
+            .expect("invoke_agent span in fixture");
+        let mut state = CopilotState::default();
+        ingest_otel_line(parent_line, &mut state);
+        assert!(!state.has_any(), "invoke_agent must not advance state");
+        assert_eq!(state.sum_input, 0);
+        assert_eq!(state.sum_output, 0);
+    }
+
+    #[test]
+    fn ingest_otel_metric_lines_are_ignored() {
+        let metric_line = fixture_lines()
+            .into_iter()
+            .find(|l| std::str::from_utf8(l).unwrap_or("").contains(r#""type":"metric""#))
+            .expect("metric line in fixture");
+        let mut state = CopilotState::default();
+        ingest_otel_line(metric_line, &mut state);
+        assert!(!state.has_any(), "metric lines must not advance state");
+    }
+
+    #[test]
+    fn ingest_otel_full_fixture_no_double_counting() {
+        // Replay the entire fixture (two chat spans + invoke_agent + metric lines). Both chat spans should contribute their tokens; the invoke_agent
+        // must NOT (it carries duplicates of the first chat span's totals). This is the regression assertion for the subagent / aggregate-parent
+        // shape AND for accepting both the `chat <model>` and bare `chat` name formats.
+        let mut state = CopilotState::default();
+        for line in fixture_lines() {
+            ingest_otel_line(line, &mut state);
+        }
+        assert_eq!(state.sum_input, 39_497 + 12_345, "both chat spans counted");
+        assert_eq!(state.sum_output, 24 + 67);
+        // The bare-name span comes last in the fixture, so its `current_tokens` / `token_limit` win the latest-wins race.
+        assert_eq!(state.token_limit, Some(170_000));
+        assert_eq!(state.current_tokens, Some(42_000));
+        assert_eq!(state.last_model.as_deref(), Some("claude-opus-4.7-high"));
+    }
+
+    #[test]
+    fn ingest_otel_malformed_json_is_ignored() {
+        let mut state = CopilotState::default();
+        ingest_otel_line(b"not json", &mut state);
+        ingest_otel_line(b"{}", &mut state);
+        ingest_otel_line(b"{\"type\":\"span\"}", &mut state); // no name
+        assert!(!state.has_any());
+    }
+
+    #[test]
+    fn ingest_otel_two_chat_spans_sum_and_latest_wins() {
+        let chat1 = br#"{"type":"span","name":"chat model-a","attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"model-a","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":10},"events":[{"name":"github.copilot.session.usage_info","attributes":{"github.copilot.token_limit":1000,"github.copilot.current_tokens":500}}]}"#;
+        let chat2 = br#"{"type":"span","name":"chat model-b","attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"model-b","gen_ai.usage.input_tokens":200,"gen_ai.usage.output_tokens":20},"events":[{"name":"github.copilot.session.usage_info","attributes":{"github.copilot.token_limit":2000,"github.copilot.current_tokens":700}}]}"#;
+        let mut state = CopilotState::default();
+        ingest_otel_line(chat1, &mut state);
+        ingest_otel_line(chat2, &mut state);
+        // Sums.
+        assert_eq!(state.sum_input, 300);
+        assert_eq!(state.sum_output, 30);
+        // Latest wins for model + context state.
+        assert_eq!(state.last_model.as_deref(), Some("model-b"));
+        assert_eq!(state.token_limit, Some(2000));
+        assert_eq!(state.current_tokens, Some(700));
+    }
+
+    #[test]
+    fn ingest_otel_chat_span_without_usage_info_event() {
+        // Totals should still update; context fields stay at their last observed values (None here).
+        let line = br#"{"type":"span","name":"chat foo","attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"foo","gen_ai.usage.input_tokens":7,"gen_ai.usage.output_tokens":3}}"#;
+        let mut state = CopilotState::default();
+        ingest_otel_line(line, &mut state);
+        assert_eq!(state.sum_input, 7);
+        assert_eq!(state.sum_output, 3);
+        assert!(state.token_limit.is_none());
+        assert!(state.current_tokens.is_none());
+    }
+
+    #[test]
+    fn ingest_otel_falls_back_to_request_model() {
+        let line = br#"{"type":"span","name":"chat fallback","attributes":{"gen_ai.operation.name":"chat","gen_ai.request.model":"req-only","gen_ai.usage.input_tokens":1,"gen_ai.usage.output_tokens":2}}"#;
+        let mut state = CopilotState::default();
+        ingest_otel_line(line, &mut state);
+        assert_eq!(state.last_model.as_deref(), Some("req-only"));
+    }
+
+    #[test]
+    fn copilot_state_snapshot_computes_pct_from_current_tokens() {
+        // Critical: pct uses the LATEST current_tokens / token_limit, NOT sum_input. Confirms the "context_tokens_used != input_tokens" invariant
+        // from the design. The fixture's bare-name span is the last chat span, so its 42_000 / 170_000 win the latest-wins race for context
+        // numerator/denominator. Cumulative totals remain the SUM across both spans.
+        let mut state = CopilotState::default();
+        for line in fixture_lines() {
+            ingest_otel_line(line, &mut state);
+        }
+        let snap = state.snapshot(SessionId::new());
+        assert_eq!(snap.context_tokens_used, Some(42_000));
+        assert_eq!(snap.context_tokens_limit, Some(170_000));
+        // 42000 * 100 / 170000 = 24
+        assert_eq!(snap.context_used_pct, Some(24));
+        // Cumulative totals are independent of the context numerator.
+        assert_eq!(snap.input_tokens, Some(39_497 + 12_345));
+        assert_eq!(snap.output_tokens, Some(24 + 67));
+    }
+
+    #[test]
+    fn copilot_state_snapshot_omits_pct_without_limit() {
+        let line = br#"{"type":"span","name":"chat foo","attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"foo","gen_ai.usage.input_tokens":1,"gen_ai.usage.output_tokens":1}}"#;
+        let mut state = CopilotState::default();
+        ingest_otel_line(line, &mut state);
+        let snap = state.snapshot(SessionId::new());
+        assert!(snap.context_used_pct.is_none());
+        assert!(snap.context_tokens_used.is_none());
+        assert!(snap.context_tokens_limit.is_none());
+    }
+
+    #[test]
+    fn parse_invoke_agent_duration_extracts_ms() {
+        // Real fixture: invoke_agent span starts at [1777474197, 905_000_000] and ends at [1777474200, 749_237_700]. Difference is 2_844_237_700 ns ≈
+        // 2844 ms.
+        let line = fixture_lines()
+            .into_iter()
+            .find(|l| {
+                let needle = b"invoke_agent";
+                l.starts_with(br#"{"type":"span","traceId"#) && l.windows(needle.len()).any(|w| w == needle)
+            })
+            .expect("invoke_agent span in fixture");
+        let ms = parse_invoke_agent_duration_ms(line).expect("duration parsed");
+        assert!((2_840..=2_850).contains(&ms), "duration_ms ~= 2844, got {ms}",);
+    }
+
+    #[test]
+    fn parse_invoke_agent_duration_ignores_chat_span() {
+        // chat <model> spans are excluded — they are LLM round-trips, not turn boundaries.
+        let line = fixture_lines()
+            .into_iter()
+            .find(|l| {
+                let needle: &[u8] = br#""name":"chat "#;
+                l.starts_with(br#"{"type":"span","#) && l.windows(needle.len()).any(|w| w == needle)
+            })
+            .expect("chat span in fixture");
+        assert!(parse_invoke_agent_duration_ms(line).is_none());
+    }
+
+    #[test]
+    fn parse_invoke_agent_duration_ignores_metric_lines() {
+        let line = b"{\"type\":\"metric\",\"name\":\"gen_ai.client.token.usage\"}";
+        assert!(parse_invoke_agent_duration_ms(line).is_none());
+    }
+
+    #[test]
+    fn parse_invoke_agent_duration_handles_missing_times() {
+        let line = br#"{"type":"span","name":"invoke_agent"}"#;
+        assert!(parse_invoke_agent_duration_ms(line).is_none());
+    }
+
+    #[test]
+    fn parse_invoke_agent_duration_saturates_for_inverted_times() {
+        // Defensive: out-of-order timestamps must yield 0, not panic.
+        let line = br#"{"type":"span","name":"invoke_agent","startTime":[10,0],"endTime":[5,0]}"#;
+        assert_eq!(parse_invoke_agent_duration_ms(line), Some(0));
+    }
+
+    #[test]
+    fn maybe_invoke_agent_span_skips_unrelated_lines() {
+        // The cheap prefilter must reject anything that doesn't even mention "invoke_agent" — that's the whole point of avoiding a
+        // serde_json::from_slice on the hot path.
+        assert!(!maybe_invoke_agent_span(b""));
+        assert!(!maybe_invoke_agent_span(b"{\"type\":\"metric\"}"));
+        assert!(!maybe_invoke_agent_span(br#"{"type":"span","name":"chat claude-opus"}"#));
+    }
+
+    #[test]
+    fn maybe_invoke_agent_span_admits_real_invoke_agent_lines() {
+        let line = br#"{"type":"span","name":"invoke_agent","startTime":[1,0],"endTime":[2,0]}"#;
+        assert!(maybe_invoke_agent_span(line));
+    }
+
+    /// Run a Copilot watcher against an evolving JSONL file in a tempdir. Drives state transitions by appending to the file and waiting for the
+    /// callback to fire — no virtual time, but the test only sleeps long enough to clear at most a couple of poll intervals.
+    #[test]
+    fn copilot_watcher_emits_on_new_chat_span() {
+        use std::sync::mpsc;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("otel.jsonl");
+        // Pre-create empty so the watcher's first poll sees a valid file.
+        std::fs::write(&path, b"").unwrap();
+
+        let session_id = SessionId::new();
+        let running = Arc::new(AtomicBool::new(true));
+        let running_for_thread = Arc::clone(&running);
+        let (tx, rx) = mpsc::channel::<SessionMetricsEvent>();
+        let cb: crate::session_metrics::MetricsCb = Arc::new(move |ev| {
+            // Channel may be closed if the test already finished; ignore send errors so the watcher thread can shut down cleanly.
+            let _ = tx.send(ev);
+        });
+        let path_for_thread = path.clone();
+        let handle = std::thread::spawn(move || {
+            let parser = Box::new(CopilotMetricsParser::new(path_for_thread));
+            crate::session_metrics::run_metrics_watcher(
+                session_id,
+                parser,
+                SystemTime::now(),
+                cb,
+                Arc::new(|_, _| {}),
+                Arc::new(|_, _| {}),
+                running_for_thread,
+            );
+        });
+
+        // Append the fixture (two chat spans + invoke_agent + metrics). On Linux, `std::fs::write` is not atomic so the watcher can catch a partial
+        // write (only the first span). Drain snapshots until we see the cumulative totals from both spans.
+        std::fs::write(&path, COPILOT_OTEL_FIXTURE).unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(8);
+        let snap = loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            let s = match rx.recv_timeout(remaining) {
+                Ok(s) => s,
+                Err(_) => panic!("timed out waiting for cumulative snapshot (context_tokens_used never reached 42_000)"),
+            };
+            if s.context_tokens_used == Some(42_000) {
+                break s;
+            }
+        };
+        assert_eq!(snap.context_tokens_used, Some(42_000));
+        assert_eq!(snap.context_tokens_limit, Some(170_000));
+        assert_eq!(snap.input_tokens, Some(39_497 + 12_345));
+        assert_eq!(snap.output_tokens, Some(24 + 67));
+        assert_eq!(snap.model.as_deref(), Some("claude-opus-4.7-high"));
+
+        // Shut the watcher down.
+        running.store(false, Ordering::SeqCst);
+        handle.join().expect("watcher thread joined");
+    }
+
+    #[test]
+    fn copilot_watcher_emits_turn_end_for_invoke_agent_span() {
+        use std::sync::mpsc;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("otel.jsonl");
+        std::fs::write(&path, b"").unwrap();
+
+        let session_id = SessionId::new();
+        let running = Arc::new(AtomicBool::new(true));
+        let running_for_thread = Arc::clone(&running);
+        let (tx, rx) = mpsc::channel::<(SessionId, Option<u64>)>();
+        let metrics_cb: crate::session_metrics::MetricsCb = Arc::new(|_| {});
+        let turn_cb: TurnCb = Arc::new(move |sid, dur| {
+            let _ = tx.send((sid, dur));
+        });
+        let path_for_thread = path.clone();
+        let handle = std::thread::spawn(move || {
+            let parser = Box::new(CopilotMetricsParser::new(path_for_thread));
+            crate::session_metrics::run_metrics_watcher(
+                session_id,
+                parser,
+                SystemTime::now(),
+                metrics_cb,
+                turn_cb,
+                Arc::new(|_, _| {}),
+                running_for_thread,
+            );
+        });
+
+        // The full fixture contains exactly one invoke_agent span.
+        std::fs::write(&path, COPILOT_OTEL_FIXTURE).unwrap();
+        let (sid, dur) = rx.recv_timeout(Duration::from_secs(8)).expect("watcher emitted turn-end");
+        assert_eq!(sid, session_id);
+        let dur = dur.expect("invoke_agent carries a duration");
+        assert!((2_840..=2_850).contains(&dur), "expected ~2844ms duration, got {dur}",);
+
+        running.store(false, Ordering::SeqCst);
+        handle.join().expect("watcher thread joined");
+    }
+
+    #[test]
+    fn copilot_watcher_handles_truncate_and_resets_totals() {
+        use std::sync::mpsc;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("otel.jsonl");
+        std::fs::write(&path, b"").unwrap();
+
+        let session_id = SessionId::new();
+        let running = Arc::new(AtomicBool::new(true));
+        let running_for_thread = Arc::clone(&running);
+        let (tx, rx) = mpsc::channel::<SessionMetricsEvent>();
+        let cb: crate::session_metrics::MetricsCb = Arc::new(move |ev| {
+            let _ = tx.send(ev);
+        });
+        let path_for_thread = path.clone();
+        let handle = std::thread::spawn(move || {
+            let parser = Box::new(CopilotMetricsParser::new(path_for_thread));
+            crate::session_metrics::run_metrics_watcher(
+                session_id,
+                parser,
+                SystemTime::now(),
+                cb,
+                Arc::new(|_, _| {}),
+                Arc::new(|_, _| {}),
+                running_for_thread,
+            );
+        });
+
+        // 1) Initial usage from the full fixture.
+        std::fs::write(&path, COPILOT_OTEL_FIXTURE).unwrap();
+        let _first = rx.recv_timeout(Duration::from_secs(8)).expect("first snapshot");
+
+        // 2) Truncate to a fresh, smaller chat span. Watcher must reset.
+        let smaller = br#"{"type":"span","name":"chat tiny","attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"tiny","gen_ai.usage.input_tokens":42,"gen_ai.usage.output_tokens":1},"events":[{"name":"github.copilot.session.usage_info","attributes":{"github.copilot.token_limit":1000,"github.copilot.current_tokens":50}}]}
+"#;
+        std::fs::write(&path, smaller).unwrap();
+
+        // Drain until we get the post-truncate snapshot. The first message received after the truncate should reflect the smaller numbers (not the
+        // cumulative pre-truncate values).
+        let deadline = std::time::Instant::now() + Duration::from_secs(8);
+        let snap = loop {
+            assert!(std::time::Instant::now() < deadline, "timed out");
+            let s = rx.recv_timeout(Duration::from_secs(8)).expect("post-truncate snapshot");
+            if s.input_tokens == Some(42) {
+                break s;
+            }
+        };
+        assert_eq!(snap.input_tokens, Some(42));
+        assert_eq!(snap.output_tokens, Some(1));
+        assert_eq!(snap.context_tokens_used, Some(50));
+        assert_eq!(snap.context_tokens_limit, Some(1000));
+        assert_eq!(snap.model.as_deref(), Some("tiny"));
+
+        running.store(false, Ordering::SeqCst);
+        handle.join().expect("watcher thread joined");
+    }
+}

--- a/src-tauri/src/plugins/ai/copilot/mod.rs
+++ b/src-tauri/src/plugins/ai/copilot/mod.rs
@@ -9,6 +9,8 @@ use crate::plugins::Plugin;
 use crate::types::SessionId;
 use crate::types::Tool;
 
+pub mod metrics;
+
 /// Stable singleton instance for dispatch sites that need a `'static`
 /// [`AiPlugin`] reference without allocating.
 pub static PLUGIN: CopilotPlugin = CopilotPlugin;
@@ -50,10 +52,15 @@ impl AiPlugin for CopilotPlugin {
         }
     }
 
-    fn metrics_watcher_kind(&self, session_id: SessionId, _cwd: &std::path::Path) -> Option<crate::plugins::ai::MetricsWatcherKind> {
-        Some(crate::plugins::ai::MetricsWatcherKind::Copilot {
-            otel_path: crate::compose::copilot_otel_path(&session_id),
-        })
+    fn metrics_parser(
+        &self,
+        session_id: SessionId,
+        _cwd: &std::path::Path,
+        _spawn_instant: std::time::SystemTime,
+    ) -> Option<Box<dyn crate::session_metrics::MetricsParser>> {
+        Some(Box::new(metrics::CopilotMetricsParser::new(crate::compose::copilot_otel_path(
+            &session_id,
+        ))))
     }
 
     fn starts_activity_events_watcher(&self) -> bool {

--- a/src-tauri/src/plugins/ai/mod.rs
+++ b/src-tauri/src/plugins/ai/mod.rs
@@ -35,8 +35,15 @@ pub trait AiPlugin: Plugin {
     /// Spawn-prep side effects run right before PTY spawn.
     fn spawn_prep(&self, session_id: &SessionId) -> SpawnPrep;
 
-    /// Resolve which metrics watcher implementation to run.
-    fn metrics_watcher_kind(&self, session_id: SessionId, cwd: &Path) -> Option<MetricsWatcherKind>;
+    /// Build the per-session metrics parser for this tool, or `None` when no watcher can run (e.g. the home dir could not be resolved). The returned
+    /// parser owns all wire-format knowledge; the generic engine in [`crate::session_metrics`] drives it. `spawn_instant` lets file-discovery filter
+    /// stale transcripts/rollouts by mtime.
+    fn metrics_parser(
+        &self,
+        session_id: SessionId,
+        cwd: &Path,
+        spawn_instant: std::time::SystemTime,
+    ) -> Option<Box<dyn crate::session_metrics::MetricsParser>>;
 
     /// Whether this tool should also arm the activity-events watcher (the events.jsonl tailer for Copilot, or the hook-events.jsonl tailer for
     /// Claude). When `true`, the host calls [`Self::activity_events_kind`] to discover which tailer flavour to spawn.
@@ -91,14 +98,6 @@ pub enum RestartAiSessionPolicy {
     Preserve,
     /// Clear persisted id before restart and rediscover later.
     Clear,
-}
-
-/// Which metrics watcher implementation to run for a tool.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MetricsWatcherKind {
-    Claude { home: PathBuf, cwd: PathBuf },
-    Copilot { otel_path: PathBuf },
-    Codex { codex_home: PathBuf, cwd: PathBuf },
 }
 
 /// Which activity-events tailer flavour to spawn for a tool, with its resolved on-disk path.
@@ -207,10 +206,15 @@ pub fn spawn_prep(tool: Tool, session_id: &SessionId) -> SpawnPrep {
     plugin_for_tool(tool).spawn_prep(session_id)
 }
 
-/// Resolve which metrics watcher implementation to run for `tool`.
+/// Build the per-session metrics parser for `tool`, or `None` if no watcher can run.
 #[must_use]
-pub fn metrics_watcher_kind(tool: Tool, session_id: SessionId, cwd: &Path) -> Option<MetricsWatcherKind> {
-    plugin_for_tool(tool).metrics_watcher_kind(session_id, cwd)
+pub fn metrics_parser(
+    tool: Tool,
+    session_id: SessionId,
+    cwd: &Path,
+    spawn_instant: std::time::SystemTime,
+) -> Option<Box<dyn crate::session_metrics::MetricsParser>> {
+    plugin_for_tool(tool).metrics_parser(session_id, cwd, spawn_instant)
 }
 
 /// Whether the activity-events watcher should be armed for this tool.

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -224,7 +224,12 @@ mod tests {
         fn spawn_prep(&self, _session_id: &crate::types::SessionId) -> ai::SpawnPrep {
             ai::SpawnPrep::default()
         }
-        fn metrics_watcher_kind(&self, _session_id: crate::types::SessionId, _cwd: &std::path::Path) -> Option<ai::MetricsWatcherKind> {
+        fn metrics_parser(
+            &self,
+            _session_id: crate::types::SessionId,
+            _cwd: &std::path::Path,
+            _spawn_instant: std::time::SystemTime,
+        ) -> Option<Box<dyn crate::session_metrics::MetricsParser>> {
             None
         }
         fn starts_activity_events_watcher(&self) -> bool {

--- a/src-tauri/src/session_metrics.rs
+++ b/src-tauri/src/session_metrics.rs
@@ -1,61 +1,15 @@
 //! Per-session token-usage / context-window watcher.
 //!
-//! ## Signal sources (v1)
+//! ## Responsibilities
 //!
-//! ### Claude
+//! This module owns the **generic** parts of the metrics pipeline: thread lifecycle ([`MetricsRegistry`]), polling cadence ([`POLL_INTERVAL`]),
+//! file tailing with truncation/rotation handling ([`tail_lines`]), file-discovery backoff timing, snapshot deduplication, and callback plumbing
+//! (`session://metrics`, `session://activity` turn-end, AI-session discovery).
 //!
-//! Claude Code persists every session as a JSONL transcript at `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`. Each `assistant`-type line
-//! carries a `message.usage` object with `input_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens` and `output_tokens`. The model's
-//! context-window limit can be read from `~/.claude/token_usage.json::actual_limit`, with a fallback table for when that file does not exist yet.
-//!
-//! For each Arborist Claude session we spin up a [`MetricsWatcher`] thread that periodically scans the project directory matching the session's
-//! `cwd`, picks the JSONL file with the most recent mtime that's >= the session's spawn instant, and extracts the latest token totals. On change, it
-//! emits a [`MetricsSnapshot`] through the supplied callback.
-//!
-//! Limitation: two same-tool sessions in the same worktree cannot be disambiguated by cwd + mtime alone — both would observe the most-
-//! recently-written JSONL. See follow-up issue #4 for the hook-driven authoritative version.
-//!
-//! ### Copilot
-//!
-//! GitHub Copilot CLI does **not** write token usage to its own session- state JSONL (`~/.copilot/session-state/<sid>/events.jsonl`). It does,
-//! however, support OpenTelemetry export. We use the **file exporter** — enabled and configured via the env vars in `compose::env_for_tool` (injected
-//! by `pty_pool::spawn_internal`) — to redirect spans to a deterministic per-session file `<session_temp_dir>/otel.jsonl`.
-//!
-//! The watcher tails that file and extracts:
-//!
-//! * **Cumulative input/output token totals** from `chat <model>` span
-//!   `attributes."gen_ai.usage.{input,output}_tokens"`. Each span is one LLM
-//!   round-trip; we sum them.
-//! * **Model name** from `attributes."gen_ai.response.model"` (fallback
-//!   `"gen_ai.request.model"`).
-//! * **Context-window state** from the inline event
-//!   `github.copilot.session.usage_info`'s attributes:
-//!   `github.copilot.token_limit` (the model's authoritative window) and
-//!   `github.copilot.current_tokens` (the conversational context size at the
-//!   moment that span was emitted — *not* the same as
-//!   `gen_ai.usage.input_tokens`, which also includes cache-creation writes; we
-//!   use `current_tokens` as the "context % used" numerator to match the
-//!   user-visible Copilot status line).
-//!
-//! Two critical parsing rules:
-//!
-//! 1. **Filter to leaf `chat` spans only.** Copilot's `invoke_agent` parent
-//!    span aggregates the *same* `gen_ai.usage.*` numbers as its child `chat`
-//!    span(s). Counting both would double the totals. We require the semconv
-//!    attribute `gen_ai.operation.name == "chat"` and ignore everything else
-//!    (including `type: "metric"` lines, which are redundant with span
-//!    attributes). The op attribute is the source of truth — `name` varies
-//!    (`"chat"` vs `"chat <model>"` across Copilot versions) and a previous
-//!    `name.starts_with("chat ")` filter silently dropped bare-name spans,
-//!    breaking `aiSessionId` tracking after `/clear` or `/resume` and zeroing
-//!    token totals for affected sessions.
-//! 2. **Spans only emit at span CLOSE.** OTel's batch span processor flushes
-//!    after the span ends, not while it's open. Use the existing PTY-stream
-//!    activity scanner for "is the agent currently working" — OTel cannot
-//!    answer that question.
-//!
-//! `OTEL_BSP_SCHEDULE_DELAY=1000` (set in `env_for_tool`) tightens the SDK's batch flush from its 5s default to ~1Hz so token totals appear in the
-//! sidebar within a couple seconds of each agent turn.
+//! All **format-specific** knowledge — where each tool writes its metrics, how to read a session id out of the file, how to parse a line, and how to
+//! build a snapshot — lives behind the [`MetricsParser`] trait, implemented per tool in the plugin modules
+//! (`plugins::ai::{claude,copilot,codex}::metrics`). The generic engine [`run_metrics_watcher`] drives one parser; adding a new AI tool means
+//! dropping in a plugin + parser, not editing this file.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -64,15 +18,15 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use serde::Deserialize;
-
 use crate::pty_pool::ActivityCb;
 use crate::types::{SessionId, SessionMetricsEvent, Tool};
 
 /// Polling cadence for the watcher. Trade-off: smaller is more responsive, larger is fewer syscalls.
 pub const POLL_INTERVAL: Duration = Duration::from_millis(2000);
-const CODEX_DISCOVERY_SCAN_MIN_INTERVAL: Duration = POLL_INTERVAL;
-const CODEX_DISCOVERY_SCAN_MAX_INTERVAL: Duration = Duration::from_secs(30);
+/// Minimum interval between file-discovery scans while a watcher is unbound (Codex's shared sessions tree, Copilot's first-poll bind).
+const DISCOVERY_SCAN_MIN_INTERVAL: Duration = POLL_INTERVAL;
+/// Maximum backoff interval between file-discovery scans while a watcher remains unbound.
+const DISCOVERY_SCAN_MAX_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Callback the watcher invokes for each new (changed) snapshot. Production wires this into `app.emit("session://metrics", payload)`; tests pass a
 /// channel sender.
@@ -144,30 +98,16 @@ impl MetricsRegistry {
         // Stop any existing watcher first so the per-tool worker starts from a clean slate (used by session restart).
         self.stop(&session_id);
 
-        let Some(watcher_kind) = crate::plugins::ai::metrics_watcher_kind(tool, session_id, &cwd) else {
-            tracing::debug!(session_id = %session_id, tool = ?tool, "AI metrics watcher not started; no watcher kind available");
+        let Some(parser) = crate::plugins::ai::metrics_parser(tool, session_id, &cwd, spawn_instant) else {
+            tracing::debug!(session_id = %session_id, tool = ?tool, "AI metrics watcher not started; no parser available");
             return false;
         };
 
         let running = Arc::new(AtomicBool::new(true));
         let running_for_thread = Arc::clone(&running);
-        let join = match watcher_kind {
-            crate::plugins::ai::MetricsWatcherKind::Claude { home, cwd } => {
-                thread::Builder::new().name(format!("arborist-metrics-{}", session_id)).spawn(move || {
-                    run_claude_watcher(session_id, home, cwd, spawn_instant, emit, emit_turn, discover, running_for_thread);
-                })
-            }
-            crate::plugins::ai::MetricsWatcherKind::Copilot { otel_path } => {
-                thread::Builder::new().name(format!("arborist-metrics-{}", session_id)).spawn(move || {
-                    run_copilot_watcher(session_id, otel_path, emit, emit_turn, discover, running_for_thread);
-                })
-            }
-            crate::plugins::ai::MetricsWatcherKind::Codex { codex_home, cwd } => {
-                thread::Builder::new().name(format!("arborist-metrics-{}", session_id)).spawn(move || {
-                    run_codex_watcher(session_id, codex_home, cwd, spawn_instant, emit, emit_turn, discover, running_for_thread);
-                })
-            }
-        };
+        let join = thread::Builder::new().name(format!("arborist-metrics-{}", session_id)).spawn(move || {
+            run_metrics_watcher(session_id, parser, spawn_instant, emit, emit_turn, discover, running_for_thread);
+        });
         match join {
             Ok(handle) => {
                 // For tools that arm an activity-events tailer (Copilot today, Claude when the hook helper was wired in at compose time), dispatch
@@ -319,80 +259,155 @@ impl MetricsRegistry {
 // --------------------------------------------------------------------------- Per-session worker
 // ---------------------------------------------------------------------------
 
+/// A metrics-bearing file located by a [`MetricsParser`], plus any AI-session id derivable from its name/path.
+pub struct LocatedFile {
+    /// Path to the file the engine should tail.
+    pub path: PathBuf,
+    /// AI-session id derived from the file's *location* (Claude's JSONL stem, Codex's rollout thread id). `None` when the id is only readable from
+    /// file content (Copilot reads its conversation id from parsed spans — see [`MetricsParser::content_ai_session_id`]).
+    pub ai_session_id: Option<String>,
+}
+
+/// Per-tool wire-format strategy driven by the generic [`run_metrics_watcher`] engine.
+///
+/// Implementors own everything format-specific: where the tool writes metrics ([`locate`](MetricsParser::locate)), how to parse a line
+/// ([`ingest_line`](MetricsParser::ingest_line)), and how to build a snapshot ([`snapshot`](MetricsParser::snapshot)). The engine owns the generic
+/// machinery: thread lifecycle, polling cadence, file tailing with truncation handling, discovery backoff, and snapshot dedup. Implementations live
+/// in the plugin metrics modules (`plugins::ai::{claude,copilot,codex}::metrics`).
+pub trait MetricsParser: Send {
+    /// When `true`, the engine re-runs [`locate`](MetricsParser::locate) every poll and rebinds whenever the freshest file changes (Claude: a
+    /// `/clear` starts a new transcript). When `false`, the engine binds once and only rediscovers after the bound file disappears.
+    fn relocate_each_poll(&self) -> bool;
+
+    /// When `true`, a stat failure on the bound file unbinds it so the next poll rediscovers (Codex: rollout files can be rotated/renamed). When
+    /// `false`, a transient stat failure is ignored and accumulated state is preserved (Copilot: the per-session OTel file never moves).
+    fn rebind_on_disappear(&self) -> bool;
+
+    /// Locate the file to tail. `spawn_instant` lets discovery ignore stale files predating this session. Returns `None` when nothing matches yet.
+    fn locate(&mut self, spawn_instant: SystemTime) -> Option<LocatedFile>;
+
+    /// Reset accumulated parser state (on rebind, truncation, or rotation).
+    fn reset(&mut self);
+
+    /// Parse one tailed line, accumulating state and optionally emitting a turn-end via `emit_turn`.
+    fn ingest_line(&mut self, line: &[u8], session_id: SessionId, emit_turn: &TurnCb);
+
+    /// AI-session id derivable from already-parsed file *content* (Copilot's conversation id). Defaults to `None` for tools whose id comes from the
+    /// file location instead (see [`LocatedFile::ai_session_id`]).
+    fn content_ai_session_id(&self) -> Option<&str> {
+        None
+    }
+
+    /// Build the current metrics snapshot, or `None` when no usable data has accumulated yet.
+    fn snapshot(&self, session_id: SessionId) -> Option<SessionMetricsEvent>;
+}
+
+/// Generic metrics-watcher engine. Drives one [`MetricsParser`] for the lifetime of `running`: discovers/binds the tool's metrics file, tails it
+/// (handling truncation/rotation), feeds each new line to the parser, surfaces AI-session ids, and emits deduplicated snapshots.
 #[allow(clippy::too_many_arguments)]
-fn run_claude_watcher(
+pub(crate) fn run_metrics_watcher(
     session_id: SessionId,
-    home: PathBuf,
-    cwd: PathBuf,
+    mut parser: Box<dyn MetricsParser>,
     spawn_instant: SystemTime,
     emit: MetricsCb,
-    // Kept in the signature for parity with `run_copilot_watcher` (and so the symmetric `MetricsRegistry::start` dispatch can pass the same
-    // `TurnCb` to both watchers) — but the Claude watcher no longer emits turn-end events. See the inline comment on the `tail_lines` loop body
-    // for the full rationale; in short, hook-events are the authoritative source for Claude turn boundaries now.
-    _emit_turn: TurnCb,
+    emit_turn: TurnCb,
     discover: AiSessionDiscoveryCb,
     running: Arc<AtomicBool>,
 ) {
-    let project_dir = home.join(".claude").join("projects").join(encode_cwd(&cwd));
-    let token_usage_path = home.join(".claude").join("token_usage.json");
+    let relocate_each_poll = parser.relocate_each_poll();
+    let rebind_on_disappear = parser.rebind_on_disappear();
 
     let mut last_emitted: Option<SessionMetricsEvent> = None;
     let mut tracked_path: Option<PathBuf> = None;
     let mut tracked_len: u64 = 0;
-    let mut totals = TurnTotals::default();
-    let mut last_model: Option<String> = None;
+    let mut last_announced_content: Option<String> = None;
+    let mut discovery_due = Instant::now();
+    let mut discovery_interval = DISCOVERY_SCAN_MIN_INTERVAL;
 
     while running.load(Ordering::SeqCst) {
-        // Discover/refresh the JSONL we're tracking. The freshest file whose mtime is >= our spawn instant wins.
-        let candidate = newest_jsonl_after(&project_dir, spawn_instant);
-        if let Some(c) = candidate {
-            // If we switched files (e.g. the user typed `/clear` and Claude started a new session) reset the read cursor and totals.
-            if tracked_path.as_ref() != Some(&c) {
-                tracked_path = Some(c.clone());
-                tracked_len = 0;
-                totals = TurnTotals::default();
-                last_model = None;
-                // The tracked file's stem is Claude's session id (the directory layout is `<encoded-cwd>/<sessionId>.jsonl`). Fire the AI-session
-                // discovery callback so the next app-restart restore can `--resume <id>`.
-                if let Some(stem) = c.file_stem().and_then(|s| s.to_str()) {
-                    discover(session_id, stem.to_owned());
+        // ---- Discovery / (re)binding ----
+        let tail_path: Option<PathBuf> = if relocate_each_poll {
+            // Relocate every poll: the freshest matching file wins. Switching files resets the cursor and parser state but deliberately NOT
+            // `last_emitted` — a Claude `/clear` starts a new transcript yet continues the same Arborist session's metrics stream.
+            if let Some(loc) = parser.locate(spawn_instant) {
+                if tracked_path.as_ref() != Some(&loc.path) {
+                    tracked_path = Some(loc.path.clone());
+                    tracked_len = 0;
+                    parser.reset();
+                    if let Some(id) = loc.ai_session_id {
+                        discover(session_id, id);
+                    }
+                }
+                tracked_path.clone()
+            } else {
+                None
+            }
+        } else {
+            // Bind once; only rediscover while unbound, with backoff between misses. Codex shares one `~/.codex/sessions/` tree across projects, so a
+            // cold scan is O(N) over rollout history — the backoff keeps idle sessions cheap.
+            if tracked_path.is_none() && Instant::now() >= discovery_due {
+                if let Some(loc) = parser.locate(spawn_instant) {
+                    tracked_path = Some(loc.path);
+                    tracked_len = 0;
+                    parser.reset();
+                    if let Some(id) = loc.ai_session_id {
+                        discover(session_id, id);
+                    }
+                    discovery_interval = DISCOVERY_SCAN_MIN_INTERVAL;
+                } else {
+                    discovery_interval = next_discovery_interval(discovery_interval, DISCOVERY_SCAN_MAX_INTERVAL);
+                    discovery_due = Instant::now().checked_add(discovery_interval).unwrap_or_else(Instant::now);
                 }
             }
+            tracked_path.clone()
+        };
 
-            if let Ok(meta) = std::fs::metadata(&c) {
-                let len = meta.len();
-                // Defensive: handle truncation/rotation. Same shape as the Copilot watcher.
-                if len < tracked_len {
+        // ---- Tail the bound file ----
+        if let Some(path) = tail_path {
+            match std::fs::metadata(&path) {
+                Ok(meta) => {
+                    let len = meta.len();
+                    // Defensive: handle truncation/rotation. Reset and reread from the start.
+                    if len < tracked_len {
+                        tracked_len = 0;
+                        parser.reset();
+                        last_emitted = None;
+                        last_announced_content = None;
+                    }
+                    if len > tracked_len {
+                        let emit_turn_ref = &emit_turn;
+                        tracked_len = tail_lines(&path, tracked_len, len, |line| {
+                            parser.ingest_line(line, session_id, emit_turn_ref);
+                        });
+                    }
+                }
+                Err(_) if rebind_on_disappear => {
+                    // File disappeared (deletion, rename) — drop tracking so the next tick rediscovers.
+                    tracked_path = None;
                     tracked_len = 0;
-                    totals = TurnTotals::default();
-                    last_model = None;
+                    parser.reset();
                     last_emitted = None;
+                    last_announced_content = None;
+                    discovery_interval = DISCOVERY_SCAN_MIN_INTERVAL;
+                    discovery_due = Instant::now();
                 }
-                if len > tracked_len {
-                    tracked_len = tail_lines(&c, tracked_len, len, |line| {
-                        if let Some((usage, model)) = extract_assistant_usage(line) {
-                            totals.add(&usage);
-                            if let Some(m) = model {
-                                last_model = Some(m);
-                            }
-                            // Intentionally do NOT emit a TurnEnd here. Claude's transcript writes one `assistant` line per round-trip with the
-                            // model — so a single user turn that goes user → assistant(tool_use) → user(tool_result) → assistant(tool_use) →
-                            // user(tool_result) → assistant(end_turn) produces three assistant lines. The original code (pre-hook-integration)
-                            // emitted TurnEnd on each, which would clear `inTurn` and promote the sidebar to `awaiting` between tool calls —
-                            // exactly the "thinking → zzz while reading file" symptom users see. Authoritative turn boundaries now come from the
-                            // Claude hook-events tailer ([`crate::claude_hook_events`]) via `UserPromptSubmit` (turnStart) and `Stop` (turnEnd).
-                            // For sessions where hooks aren't active (sidecar missing, partial install) we lose the `awaiting` promotion entirely;
-                            // PTY-byte heuristics still drive `working` / `idle` so the sidebar remains informative, just without the explicit
-                            // "agent finished" cue.
-                        }
-                    });
-                }
+                // Transient stat failure with no rebind: keep tracking and accumulated state (the file is expected to reappear).
+                Err(_) => {}
             }
         }
 
-        if totals.has_any() {
-            let limit = resolve_limit(&token_usage_path, last_model.as_deref());
-            let snapshot = build_snapshot(session_id, &totals, last_model.clone(), limit);
+        // ---- Content-derived AI-session id discovery (e.g. Copilot conversation id) ----
+        // The parser may only learn its session id after parsing file content. Fire only on change to keep the per-poll work cheap.
+        if let Some(content_id) = parser.content_ai_session_id() {
+            if last_announced_content.as_deref() != Some(content_id) {
+                let owned = content_id.to_owned();
+                discover(session_id, owned.clone());
+                last_announced_content = Some(owned);
+            }
+        }
+
+        // ---- Snapshot + dedup ----
+        if let Some(snapshot) = parser.snapshot(session_id) {
             // Compare the data payload only — observed_at advances every poll and would otherwise defeat dedup, causing a redundant emission ~every
             // POLL_INTERVAL even when nothing changed.
             if !last_emitted.as_ref().is_some_and(|prev| prev.same_payload_as(&snapshot)) {
@@ -405,68 +420,9 @@ fn run_claude_watcher(
     }
 }
 
-// --------------------------------------------------------------------------- Copilot worker
-// ---------------------------------------------------------------------------
-
-fn run_copilot_watcher(
-    session_id: SessionId,
-    otel_path: PathBuf,
-    emit: MetricsCb,
-    emit_turn: TurnCb,
-    discover: AiSessionDiscoveryCb,
-    running: Arc<AtomicBool>,
-) {
-    let mut state = CopilotState::default();
-    let mut cursor: u64 = 0;
-    let mut last_emitted: Option<SessionMetricsEvent> = None;
-    let mut last_announced_conversation: Option<String> = None;
-
-    while running.load(Ordering::SeqCst) {
-        if let Ok(meta) = std::fs::metadata(&otel_path) {
-            let len = meta.len();
-            // Truncated or rotated under us: reset and reread from start. Spawn-time prep removes a stale otel.jsonl, but a hostile rotation mid-run
-            // shouldn't make us read garbage offsets.
-            if len < cursor {
-                cursor = 0;
-                state = CopilotState::default();
-                last_emitted = None;
-                last_announced_conversation = None;
-            }
-            if len > cursor {
-                cursor = tail_lines(&otel_path, cursor, len, |line| {
-                    ingest_otel_line(line, &mut state);
-                    // Cheap byte-level pre-filter — we don't want to re-parse every JSONL line as JSON just to discover it isn't an `invoke_agent`
-                    // span. Real Copilot OTel logs are dominated by metric/log lines, so this saves a full serde_json::from_slice on the hot path.
-                    if maybe_invoke_agent_span(line) {
-                        if let Some(d) = parse_invoke_agent_duration_ms(line) {
-                            emit_turn(session_id, Some(d));
-                        }
-                    }
-                });
-            }
-        }
-
-        // Surface the Copilot conversation id as soon as we see it. The OTel file is per-Arborist-session (controlled by `env_for_tool` via
-        // `COPILOT_OTEL_FILE_EXPORTER_PATH`), so this is unambiguous even when multiple Copilot sessions run concurrently — unlike a directory-scan
-        // of `~/.copilot/session-state/`. Fire only on change to keep the per-poll work cheap.
-        if let Some(conv) = state.conversation_id.as_ref() {
-            if last_announced_conversation.as_ref() != Some(conv) {
-                discover(session_id, conv.clone());
-                last_announced_conversation = Some(conv.clone());
-            }
-        }
-
-        if state.has_any() {
-            let snapshot = state.snapshot(session_id);
-            // Same dedup fix as the Claude watcher: observed_at must not be part of the comparison.
-            if !last_emitted.as_ref().is_some_and(|prev| prev.same_payload_as(&snapshot)) {
-                emit(snapshot.clone());
-                last_emitted = Some(snapshot);
-            }
-        }
-
-        thread::sleep(POLL_INTERVAL);
-    }
+/// Doubling backoff for file-discovery scans, capped at `max`.
+fn next_discovery_interval(current: Duration, max: Duration) -> Duration {
+    current.saturating_mul(2).min(max)
 }
 
 // --------------------------------------------------------------------------- Path helpers
@@ -501,31 +457,6 @@ pub(crate) fn home_dir() -> Option<PathBuf> {
         }
     }
     None
-}
-
-fn newest_jsonl_after(dir: &Path, after: SystemTime) -> Option<PathBuf> {
-    let entries = std::fs::read_dir(dir).ok()?;
-    let mut best: Option<(SystemTime, PathBuf)> = None;
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
-            continue;
-        }
-        let Ok(meta) = entry.metadata() else { continue };
-        let Ok(mtime) = meta.modified() else { continue };
-        // Allow a small clock-skew slack window (5s) so the very first line — which can land before our spawn_instant due to mtime resolution / clock
-        // differences — is still picked up.
-        let slack = Duration::from_secs(5);
-        let cutoff = after.checked_sub(slack).unwrap_or(after);
-        if mtime < cutoff {
-            continue;
-        }
-        match &best {
-            Some((bt, _)) if *bt >= mtime => {}
-            _ => best = Some((mtime, path)),
-        }
-    }
-    best.map(|(_, p)| p)
 }
 
 /// Defensive cap on a single watcher read. A runaway exporter (e.g. a Copilot bug or a Claude session that grew enormous between polls) must not be
@@ -626,723 +557,26 @@ fn find_next_newline(path: &Path, start: u64, end: u64) -> Option<u64> {
     None
 }
 
-// --------------------------------------------------------------------------- JSONL parsing
+// --------------------------------------------------------------------------- Time helper
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Default, Deserialize, Clone, Copy)]
-pub(crate) struct UsageBlock {
-    #[serde(default)]
-    input_tokens: u64,
-    #[serde(default)]
-    output_tokens: u64,
-    #[serde(default)]
-    cache_creation_input_tokens: u64,
-    #[serde(default)]
-    cache_read_input_tokens: u64,
-}
-
-#[derive(Debug, Default)]
-struct TurnTotals {
-    /// Most recent observed turn — these reset to the values from the latest assistant line (each line is the cumulative state of that turn, not a
-    /// delta).
-    last_input: u64,
-    last_output: u64,
-    last_cache_creation: u64,
-    last_cache_read: u64,
-    /// Cumulative input/output across all observed assistant lines (sum of per-turn values). Useful for "session totals".
-    sum_input: u64,
-    sum_output: u64,
-    /// Set true once we've ingested at least one usage block.
-    seen: bool,
-}
-
-impl TurnTotals {
-    fn add(&mut self, u: &UsageBlock) {
-        self.sum_input = self.sum_input.saturating_add(u.input_tokens);
-        self.sum_output = self.sum_output.saturating_add(u.output_tokens);
-        self.last_input = u.input_tokens;
-        self.last_output = u.output_tokens;
-        self.last_cache_creation = u.cache_creation_input_tokens;
-        self.last_cache_read = u.cache_read_input_tokens;
-        self.seen = true;
-    }
-
-    fn has_any(&self) -> bool {
-        self.seen
-    }
-
-    fn context_tokens_used(&self) -> u64 {
-        self.last_input
-            .saturating_add(self.last_cache_creation)
-            .saturating_add(self.last_cache_read)
-            .saturating_add(self.last_output)
-    }
-}
-
-/// Try to parse a single JSONL line and return its `(usage, model)` if it is an `assistant` event with a `message.usage` block. Returns `None` for
-/// any other line (system, user, sub-event, malformed, etc.). Never panics.
-pub(crate) fn extract_assistant_usage(line: &[u8]) -> Option<(UsageBlock, Option<String>)> {
-    #[derive(Deserialize)]
-    struct Outer {
-        #[serde(default)]
-        r#type: String,
-        #[serde(default)]
-        message: Option<Message>,
-    }
-    #[derive(Deserialize)]
-    struct Message {
-        #[serde(default)]
-        model: Option<String>,
-        #[serde(default)]
-        usage: Option<UsageBlock>,
-    }
-    let outer: Outer = serde_json::from_slice(line).ok()?;
-    if outer.r#type != "assistant" {
-        return None;
-    }
-    let msg = outer.message?;
-    let usage = msg.usage?;
-    Some((usage, msg.model))
-}
-
-// --------------------------------------------------------------------------- Context-limit lookup
-// ---------------------------------------------------------------------------
-
-#[derive(Deserialize)]
-struct TokenUsageFile {
-    #[serde(default)]
-    actual_limit: Option<u64>,
-    #[serde(default)]
-    expected_limit: Option<u64>,
-}
-
-/// Resolve the model's context-window limit. Tries `~/.claude/token_usage.json` first, then falls back to a small built-in table for known Anthropic
-/// models. Returns `None` when neither source recognises the model.
-pub(crate) fn resolve_limit(token_usage_path: &Path, model: Option<&str>) -> Option<u64> {
-    if let Ok(bytes) = std::fs::read(token_usage_path) {
-        if let Ok(file) = serde_json::from_slice::<TokenUsageFile>(&bytes) {
-            if let Some(v) = file.actual_limit.or(file.expected_limit) {
-                if v > 0 {
-                    return Some(v);
-                }
-            }
-        }
-    }
-    model.and_then(fallback_limit_for_model)
-}
-
-/// Fallback table for known model families. Keys match the substring form because Claude reports e.g. `"claude-sonnet-4-6"` while Anthropic also uses
-/// `"claude-3-5-sonnet"`-style names.
-fn fallback_limit_for_model(model: &str) -> Option<u64> {
-    let m = model.to_ascii_lowercase();
-    if m.contains("opus") || m.contains("sonnet") || m.contains("haiku") {
-        // All current Anthropic models default to 200k context.
-        return Some(200_000);
-    }
-    None
-}
-
-// --------------------------------------------------------------------------- Snapshot construction
-// ---------------------------------------------------------------------------
-
-fn build_snapshot(session_id: SessionId, totals: &TurnTotals, model: Option<String>, limit: Option<u64>) -> SessionMetricsEvent {
-    let used = totals.context_tokens_used();
-    let pct = limit.and_then(|lim| used.saturating_mul(100).checked_div(lim).map(|raw| raw.min(100) as u8));
-    SessionMetricsEvent {
-        session_id,
-        model,
-        context_used_pct: pct,
-        context_tokens_used: Some(used),
-        context_tokens_limit: limit,
-        input_tokens: Some(totals.sum_input),
-        output_tokens: Some(totals.sum_output),
-        observed_at: now_unix_seconds(),
-    }
-}
-
-fn now_unix_seconds() -> u64 {
+pub(crate) fn now_unix_seconds() -> u64 {
     SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0)
 }
 
-// --------------------------------------------------------------------------- Copilot OTel parser
-// ---------------------------------------------------------------------------
-
-/// Running state accumulated by the Copilot watcher across all ingested `chat <model>` spans for one session.
-#[derive(Debug, Default)]
-pub(crate) struct CopilotState {
-    /// Cumulative input tokens (sum of `gen_ai.usage.input_tokens` across every leaf chat span). Includes cache-creation writes.
-    sum_input: u64,
-    /// Cumulative output tokens (sum of `gen_ai.usage.output_tokens`).
-    sum_output: u64,
-    /// Most recent model name observed (`gen_ai.response.model`, fallback `gen_ai.request.model`).
-    last_model: Option<String>,
-    /// Most recent value of `github.copilot.token_limit` from the inline `github.copilot.session.usage_info` event. Authoritative context window for
-    /// the model that turn used.
-    token_limit: Option<u64>,
-    /// Most recent value of `github.copilot.current_tokens` — the size of the conversational context the agent had in front of it at the moment of
-    /// the span. Drives the sidebar's "context % used".
-    current_tokens: Option<u64>,
-    /// Copilot's conversation/session id (`gen_ai.conversation.id`), matching the directory name under `~/.copilot/session-state/<id>/` and
-    /// accepted by `copilot --session-id <id>` (copilot-cli >= 1.0.51). Captured for AI-session discovery; not part of the metrics snapshot.
-    pub(crate) conversation_id: Option<String>,
-    /// True once at least one chat span has been ingested.
-    seen: bool,
-}
-
-impl CopilotState {
-    pub(crate) fn has_any(&self) -> bool {
-        self.seen
+/// Compute "percent of context window used", clamped to 100. Returns `None` when either value is unknown or the limit is zero. Uses `u128` so absurd
+/// token counts can't overflow the intermediate multiply. Shared by every tool's snapshot builder — this is generic arithmetic, not wire-format
+/// knowledge, so it belongs in the engine rather than being re-derived per plugin.
+pub(crate) fn context_used_pct(used: Option<u64>, limit: Option<u64>) -> Option<u8> {
+    match (used, limit) {
+        (Some(u), Some(lim)) if lim > 0 => Some(((u as u128 * 100 / lim as u128).min(100)) as u8),
+        _ => None,
     }
-
-    pub(crate) fn snapshot(&self, session_id: SessionId) -> SessionMetricsEvent {
-        let used = self.current_tokens;
-        let pct = match (used, self.token_limit) {
-            (Some(u), Some(lim)) if lim > 0 => Some(u.saturating_mul(100).checked_div(lim).map(|raw| raw.min(100) as u8).unwrap_or(0)),
-            _ => None,
-        };
-        SessionMetricsEvent {
-            session_id,
-            model: self.last_model.clone(),
-            context_used_pct: pct,
-            context_tokens_used: used,
-            context_tokens_limit: self.token_limit,
-            input_tokens: Some(self.sum_input),
-            output_tokens: Some(self.sum_output),
-            observed_at: now_unix_seconds(),
-        }
-    }
-}
-
-/// Ingest a single OTel JSONL line into `state`. Silently ignores anything that isn't a leaf `chat` span (metric lines, `invoke_agent` parents, other
-/// span kinds, malformed JSON). Never panics.
-///
-/// The `invoke_agent` filter is critical: that span carries the *same* `gen_ai.usage.*` numbers as its child `chat` span(s), so counting both would
-/// double the totals. We filter on the semconv attribute `gen_ai.operation.name == "chat"` — `name` is unreliable across Copilot versions (sometimes
-/// `"chat"`, sometimes `"chat <model>"`) and the previous `name.starts_with("chat ")` filter silently dropped bare-name spans, breaking `aiSessionId`
-/// tracking after `/clear` or `/resume` and zeroing token totals for affected sessions.
-pub(crate) fn ingest_otel_line(line: &[u8], state: &mut CopilotState) {
-    #[derive(Deserialize)]
-    struct Outer {
-        #[serde(default)]
-        r#type: String,
-        #[serde(default)]
-        attributes: Option<serde_json::Value>,
-        #[serde(default)]
-        events: Option<Vec<OtelEvent>>,
-    }
-    #[derive(Deserialize)]
-    struct OtelEvent {
-        #[serde(default)]
-        name: String,
-        #[serde(default)]
-        attributes: Option<serde_json::Value>,
-    }
-
-    let Ok(outer) = serde_json::from_slice::<Outer>(line) else {
-        return;
-    };
-    if outer.r#type != "span" {
-        return;
-    }
-    // Filter on the semconv operation attribute, NOT on `name`. See the doc comment above for why `name` is unreliable across Copilot versions.
-    let attrs = outer.attributes.as_ref();
-    let op = attrs.and_then(|a| a.get("gen_ai.operation.name")).and_then(|v| v.as_str());
-    if op != Some("chat") {
-        return;
-    }
-
-    let input = attrs
-        .and_then(|a| a.get("gen_ai.usage.input_tokens"))
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0);
-    let output = attrs
-        .and_then(|a| a.get("gen_ai.usage.output_tokens"))
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0);
-    state.sum_input = state.sum_input.saturating_add(input);
-    state.sum_output = state.sum_output.saturating_add(output);
-
-    if let Some(model) = attrs
-        .and_then(|a| a.get("gen_ai.response.model"))
-        .and_then(|v| v.as_str())
-        .or_else(|| attrs.and_then(|a| a.get("gen_ai.request.model")).and_then(|v| v.as_str()))
-    {
-        state.last_model = Some(model.to_owned());
-    }
-
-    if let Some(conv) = attrs.and_then(|a| a.get("gen_ai.conversation.id")).and_then(|v| v.as_str()) {
-        if !conv.is_empty() {
-            state.conversation_id = Some(conv.to_owned());
-        }
-    }
-
-    if let Some(events) = outer.events.as_ref() {
-        for ev in events {
-            if ev.name != "github.copilot.session.usage_info" {
-                continue;
-            }
-            let ev_attrs = ev.attributes.as_ref();
-            if let Some(v) = ev_attrs.and_then(|a| a.get("github.copilot.token_limit")).and_then(|v| v.as_u64()) {
-                state.token_limit = Some(v);
-            }
-            if let Some(v) = ev_attrs.and_then(|a| a.get("github.copilot.current_tokens")).and_then(|v| v.as_u64()) {
-                state.current_tokens = Some(v);
-            }
-        }
-    }
-
-    state.seen = true;
-}
-
-/// Extract the wall-clock duration of an `invoke_agent` span (one full agent turn) in milliseconds. Returns `None` for any other line — chat spans,
-/// metric lines, malformed JSON — so the caller can call this on every JSONL line it tails.
-///
-/// We deliberately key on `invoke_agent` (not `chat`): one agent turn can involve multiple `chat` round-trips, but exactly one `invoke_agent`. This
-/// matches the user's intuition of "the agent finished" — the icon flips to *awaiting* on the outer span close, not on each LLM hop.
-pub(crate) fn parse_invoke_agent_duration_ms(line: &[u8]) -> Option<u64> {
-    #[derive(Deserialize)]
-    struct Outer {
-        #[serde(default)]
-        r#type: String,
-        #[serde(default)]
-        name: String,
-        #[serde(default, rename = "startTime")]
-        start_time: Option<[u64; 2]>,
-        #[serde(default, rename = "endTime")]
-        end_time: Option<[u64; 2]>,
-    }
-    let outer: Outer = serde_json::from_slice(line).ok()?;
-    if outer.r#type != "span" || outer.name != "invoke_agent" {
-        return None;
-    }
-    let start = outer.start_time?;
-    let end = outer.end_time?;
-    // OTel times are `[seconds, nanos]`. Compute `end - start` in ns, saturating at 0 (some test/edge writers can produce slightly out-of- order
-    // timestamps).
-    let start_ns = start[0].saturating_mul(1_000_000_000).saturating_add(start[1]);
-    let end_ns = end[0].saturating_mul(1_000_000_000).saturating_add(end[1]);
-    Some(end_ns.saturating_sub(start_ns) / 1_000_000)
-}
-
-/// Cheap byte-level prefilter used to skip a full JSON parse on the majority of OTel lines (metrics, logs, chat spans). Tolerates either
-/// `"name":"invoke_agent"` or `"name": "invoke_agent"` spacing — real emitters use the compact form, but the OTel SDK is allowed to insert a space
-/// and we'd rather over-accept here and let
-/// [`parse_invoke_agent_duration_ms`] reject than miss a legitimate
-/// turn-end.
-fn maybe_invoke_agent_span(line: &[u8]) -> bool {
-    fn contains(hay: &[u8], needle: &[u8]) -> bool {
-        hay.len() >= needle.len() && hay.windows(needle.len()).any(|w| w == needle)
-    }
-    contains(line, b"\"invoke_agent\"")
-}
-
-// --------------------------------------------------------------------------- Codex rollout worker
-// ---------------------------------------------------------------------------
-//
-// Codex persists every session as a JSONL "rollout" file under `<CODEX_HOME>/sessions/` (default `~/.codex/sessions/`), optionally nested in
-// `YYYY/MM/DD/` date subdirectories. Filenames follow `rollout-<TIMESTAMP>-<UUID>.jsonl`. The first line is a `session_meta` envelope carrying the
-// thread id and `cwd`; subsequent lines are `event_msg` / `turn_context` envelopes. The watcher discovers the file by matching `cwd` and spawn
-// instant, fires the AI-session discovery callback with the thread id, then tails `token_count` (cumulative usage) and `turn_complete` (turn
-// duration) events. `RolloutItem` is adjacently tagged (`{"type":...,"payload":...}`) but the inner `EventMsg` is internally tagged, so token
-// fields live at `payload.info.*`, not `payload.payload.info.*`. Only token usage and model name are surfaced to the sidebar — feature parity
-// with the Claude and Copilot watchers.
-
-/// Outer envelope for every rollout JSONL line: `{"timestamp": "...", "type": "...", "payload": {...}}`. Inner-payload shape varies by `type` and is
-/// inspected as `serde_json::Value` to avoid a deserialize match per variant.
-#[derive(Deserialize)]
-struct CodexRolloutLine {
-    #[serde(default)]
-    r#type: String,
-    #[serde(default)]
-    payload: Option<serde_json::Value>,
-}
-
-/// Normalize a path into comparable components for cross-platform matching. On Windows, slashes are unified and each component is lowercased so
-/// `C:\Repos\X` and `c:/repos/x/` normalize to the same `Vec<String>`. On Unix, components are preserved as-is.
-fn normalize_path_components(path: &Path) -> Vec<String> {
-    path.components()
-        .map(|c| {
-            let raw = c.as_os_str().to_string_lossy();
-            if cfg!(windows) {
-                raw.replace('/', "\\").to_ascii_lowercase()
-            } else {
-                raw.into_owned()
-            }
-        })
-        .collect()
-}
-
-/// Discover the newest rollout JSONL under `sessions_dir` (including date-nested subdirs) whose first-line `SessionMeta.cwd` matches `cwd` and whose
-/// mtime is >= `after`. Returns the full path when found. Called during rollout discovery while no file is bound; `run_codex_watcher` applies a
-/// backoff between misses to avoid re-scanning the entire Codex sessions tree on every poll tick.
-fn newest_codex_rollout(sessions_dir: &Path, cwd: &Path, after: SystemTime) -> Option<PathBuf> {
-    let slack = Duration::from_secs(5);
-    let cutoff = after.checked_sub(slack).unwrap_or(after);
-    let expected_norm = normalize_path_components(cwd);
-    let mut best: Option<(SystemTime, PathBuf)> = None;
-
-    // Helper to check a single directory for rollout files.
-    fn scan_dir(dir: &Path, expected_norm: &[String], cutoff: SystemTime, best: &mut Option<(SystemTime, PathBuf)>) {
-        let Ok(entries) = std::fs::read_dir(dir) else { return };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
-                continue;
-            }
-            let fname = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            if !fname.starts_with("rollout-") {
-                continue;
-            }
-            let Ok(meta) = entry.metadata() else { continue };
-            let Ok(mtime) = meta.modified() else { continue };
-            if mtime < cutoff {
-                continue;
-            }
-            // Check if the cwd matches by reading the first line (SessionMeta).
-            if !codex_rollout_cwd_matches_norm(&path, expected_norm) {
-                continue;
-            }
-            match best {
-                Some((bt, _)) if *bt >= mtime => {}
-                _ => *best = Some((mtime, path)),
-            }
-        }
-    }
-
-    // Scan top-level `sessions/` directory.
-    scan_dir(sessions_dir, &expected_norm, cutoff, &mut best);
-
-    // Also scan three-level nested subdirs (Codex commonly uses YYYY/MM/DD).
-    if let Ok(years) = std::fs::read_dir(sessions_dir) {
-        for year_entry in years.flatten() {
-            let year_path = year_entry.path();
-            if !year_path.is_dir() {
-                continue;
-            }
-            if let Ok(months) = std::fs::read_dir(&year_path) {
-                for month_entry in months.flatten() {
-                    let month_path = month_entry.path();
-                    if !month_path.is_dir() {
-                        continue;
-                    }
-                    if let Ok(days) = std::fs::read_dir(&month_path) {
-                        for day_entry in days.flatten() {
-                            let day_path = day_entry.path();
-                            if day_path.is_dir() {
-                                scan_dir(&day_path, &expected_norm, cutoff, &mut best);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    best.map(|(_, p)| p)
-}
-
-/// Read a rollout file's first line and decode it as a `session_meta` `CodexRolloutLine`. Returns the payload (a JSON object) when the line is
-/// well-formed and the type matches; `None` otherwise. Shared by `codex_rollout_cwd_matches_norm` and `codex_rollout_thread_id`.
-fn read_codex_session_meta(path: &Path) -> Option<serde_json::Value> {
-    use std::io::{BufRead, BufReader};
-    let f = std::fs::File::open(path).ok()?;
-    let mut reader = BufReader::new(f);
-    let mut first_line = String::new();
-    reader.read_line(&mut first_line).ok()?;
-    if first_line.is_empty() {
-        return None;
-    }
-    let line: CodexRolloutLine = serde_json::from_str(&first_line).ok()?;
-    if line.r#type != "session_meta" {
-        return None;
-    }
-    line.payload
-}
-
-/// Check whether a rollout file's `SessionMeta.cwd` matches the (already-normalized) expected cwd.
-fn codex_rollout_cwd_matches_norm(path: &Path, expected_norm: &[String]) -> bool {
-    let Some(payload) = read_codex_session_meta(path) else { return false };
-    let Some(cwd_str) = payload.get("cwd").and_then(|v| v.as_str()) else {
-        return false;
-    };
-    normalize_path_components(Path::new(cwd_str)) == expected_norm
-}
-
-/// Test-only wrapper around [`codex_rollout_cwd_matches_norm`] that normalizes `expected_cwd` per call. Kept for the unit tests that don't want to
-/// pre-normalize.
-#[cfg(test)]
-fn codex_rollout_cwd_matches(path: &Path, expected_cwd: &Path) -> bool {
-    codex_rollout_cwd_matches_norm(path, &normalize_path_components(expected_cwd))
-}
-
-/// Extract the thread_id from the first line of a Codex rollout file.
-fn codex_rollout_thread_id(path: &Path) -> Option<String> {
-    let payload = read_codex_session_meta(path)?;
-    payload
-        .get("thread_id")
-        .or_else(|| payload.get("id"))
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_owned())
-}
-
-/// Codex rollout watcher state accumulated from `TokenCount` and `TurnContext` events.
-#[derive(Debug, Default)]
-struct CodexState {
-    /// Cumulative input tokens (from total_token_usage.input_tokens).
-    sum_input: u64,
-    /// Cumulative output tokens (from total_token_usage.output_tokens).
-    sum_output: u64,
-    /// Model context window limit (from model_context_window or TurnStarted).
-    context_window: Option<u64>,
-    /// Current tokens occupying the context window — sourced from `last_token_usage.total_tokens` (the most recent turn),
-    /// NOT the cumulative session counter `total_token_usage`. This mirrors Codex's own status card, which drives the
-    /// context gauge from `last_token_usage`; using the cumulative total would pin the gauge at 100% after enough turns.
-    context_tokens_used: Option<u64>,
-    /// Most recent model name (from TurnContext).
-    last_model: Option<String>,
-    /// True once at least one TokenCount event has been ingested.
-    seen: bool,
-}
-
-impl CodexState {
-    fn has_any(&self) -> bool {
-        self.seen
-    }
-
-    fn snapshot(&self, session_id: SessionId) -> SessionMetricsEvent {
-        let used = self.context_tokens_used;
-        let pct = match (used, self.context_window) {
-            (Some(u), Some(lim)) if lim > 0 => Some(((u as u128 * 100 / lim as u128).min(100)) as u8),
-            _ => None,
-        };
-        SessionMetricsEvent {
-            session_id,
-            model: self.last_model.clone(),
-            context_used_pct: pct,
-            context_tokens_used: used,
-            context_tokens_limit: self.context_window,
-            input_tokens: Some(self.sum_input),
-            output_tokens: Some(self.sum_output),
-            observed_at: now_unix_seconds(),
-        }
-    }
-}
-
-/// Extract token-count fields from a `token_count` event's `info` object. Returns a tuple of
-/// `(input, output, context_tokens, model_context_window)`, each `Some` when present and well-typed. Missing info returns
-/// an all-`None` tuple early.
-///
-/// Codex's `EventMsg` is *internally* tagged, so `TokenCountEvent`'s fields are inlined directly under the rollout
-/// line's `payload` (i.e. `payload.info`). We still accept the legacy `payload.payload.info` shape defensively in case
-/// an older CLI build emitted an extra wrapper.
-///
-/// `input`/`output` come from `total_token_usage` (Codex's cumulative session counters), while `context_tokens` — the
-/// value that drives the context-window gauge — comes from `last_token_usage.total_tokens` (the live occupancy of the
-/// window), falling back to the cumulative total only if `last_token_usage` is absent.
-fn extract_codex_token_count(payload: &serde_json::Value) -> (Option<u64>, Option<u64>, Option<u64>, Option<u64>) {
-    let Some(info) = payload.get("info").or_else(|| payload.get("payload").and_then(|p| p.get("info"))) else {
-        return (None, None, None, None);
-    };
-    let total = info.get("total_token_usage");
-    let input = total.and_then(|t| t.get("input_tokens")).and_then(|v| v.as_u64());
-    let output = total.and_then(|t| t.get("output_tokens")).and_then(|v| v.as_u64());
-    let context_tokens = info
-        .get("last_token_usage")
-        .and_then(|t| t.get("total_tokens"))
-        .and_then(|v| v.as_u64())
-        .or_else(|| total.and_then(|t| t.get("total_tokens")).and_then(|v| v.as_u64()));
-    let mcw = info.get("model_context_window").and_then(|v| v.as_u64()).filter(|&v| v > 0);
-    (input, output, context_tokens, mcw)
-}
-
-/// Ingest a single Codex rollout JSONL line. Extracts token usage from `EventMsg::TokenCount` and model from `TurnContext`.
-fn ingest_codex_rollout_line(line: &[u8], state: &mut CodexState) {
-    // Lines in the rollout are `{"timestamp":"...","type":"<variant>","payload":{...}}`.
-    // We care about:
-    // - type = "event_msg" with payload.type = "token_count" → token usage
-    // - type = "turn_context" → model name
-    //
-    // Codex's `RolloutItem` is adjacently tagged (`tag = "type", content = "payload"`) while the inner `EventMsg` is
-    // internally tagged (`tag = "type"`, no content), and both use `rename_all = "snake_case"`. So the real event tag is
-    // `token_count` / `task_started`, not the PascalCase `TokenCount` / `TurnStarted`. We accept both spellings so a
-    // format change in either direction doesn't silently zero out the sidebar.
-    let Ok(outer) = serde_json::from_slice::<CodexRolloutLine>(line) else {
-        return;
-    };
-
-    match outer.r#type.as_str() {
-        "event_msg" => {
-            let Some(payload) = outer.payload else { return };
-            // EventMsg is tagged: {"type":"token_count", ...inlined TokenCountEvent fields}
-            let Some(event_type) = payload.get("type").and_then(|v| v.as_str()) else {
-                return;
-            };
-            match event_type {
-                "token_count" | "TokenCount" => {
-                    let (input, output, total, mcw) = extract_codex_token_count(&payload);
-                    if let Some(v) = input {
-                        state.sum_input = v;
-                    }
-                    if let Some(v) = output {
-                        state.sum_output = v;
-                    }
-                    if let Some(v) = total {
-                        state.context_tokens_used = Some(v);
-                    }
-                    if let Some(v) = mcw {
-                        state.context_window = Some(v);
-                    }
-                    state.seen = true;
-                }
-                "task_started" | "turn_started" | "TurnStarted" => {
-                    // `TurnStartedEvent.model_context_window` is inlined under `payload` (internally-tagged EventMsg); the
-                    // legacy `payload.payload.model_context_window` shape is accepted defensively.
-                    if let Some(mcw) = payload
-                        .get("model_context_window")
-                        .or_else(|| payload.get("payload").and_then(|p| p.get("model_context_window")))
-                        .and_then(|v| v.as_u64())
-                        .filter(|&v| v > 0)
-                    {
-                        state.context_window = Some(mcw);
-                    }
-                }
-                _ => {}
-            }
-        }
-        "turn_context" => {
-            let Some(payload) = outer.payload else { return };
-            if let Some(model) = payload.get("model").and_then(|v| v.as_str()) {
-                if !model.is_empty() {
-                    state.last_model = Some(model.to_owned());
-                }
-            }
-        }
-        _ => {}
-    }
-}
-
-/// Cheap byte-level prefilter to detect a `TurnComplete` event in a Codex rollout line. Avoids full JSON parse on the majority of lines.
-fn maybe_codex_turn_complete(line: &[u8]) -> bool {
-    fn contains(hay: &[u8], needle: &[u8]) -> bool {
-        hay.len() >= needle.len() && hay.windows(needle.len()).any(|w| w == needle)
-    }
-    contains(line, b"\"TurnComplete\"") || contains(line, b"\"task_complete\"") || contains(line, b"\"turn_complete\"")
-}
-
-/// Parse a Codex turn-complete event.
-///
-/// Returns:
-/// - `Some(Some(duration_ms))` for a real turn-complete event with duration
-/// - `Some(None)` for a real turn-complete event without duration
-/// - `None` when the line is not a turn-complete event (or cannot be parsed)
-fn parse_codex_turn_duration_ms(line: &[u8]) -> Option<Option<u64>> {
-    let outer: CodexRolloutLine = serde_json::from_slice(line).ok()?;
-    if outer.r#type != "event_msg" {
-        return None;
-    }
-    let payload = outer.payload?;
-    let event_type = payload.get("type").and_then(|v| v.as_str())?;
-    if event_type != "TurnComplete" && event_type != "task_complete" && event_type != "turn_complete" {
-        return None;
-    }
-    let duration_ms = payload
-        .get("duration_ms")
-        .or_else(|| payload.get("payload").and_then(|inner| inner.get("duration_ms")))
-        .and_then(|v| v.as_u64());
-    Some(duration_ms)
-}
-
-#[allow(clippy::too_many_arguments)]
-fn run_codex_watcher(
-    session_id: SessionId,
-    codex_home: PathBuf,
-    cwd: PathBuf,
-    spawn_instant: SystemTime,
-    emit: MetricsCb,
-    emit_turn: TurnCb,
-    discover: AiSessionDiscoveryCb,
-    running: Arc<AtomicBool>,
-) {
-    let sessions_dir = codex_home.join("sessions");
-
-    let mut last_emitted: Option<SessionMetricsEvent> = None;
-    let mut tracked_path: Option<PathBuf> = None;
-    let mut tracked_len: u64 = 0;
-    let mut state = CodexState::default();
-    let mut discovery_due = Instant::now();
-    let mut discovery_interval = CODEX_DISCOVERY_SCAN_MIN_INTERVAL;
-
-    while running.load(Ordering::SeqCst) {
-        // Discovery runs only while no rollout file is bound and uses a backoff between misses. Codex shares one `~/.codex/sessions/` tree across
-        // projects and nests files in dated subdirs, so a cold scan is O(N) over rollout history.
-        if tracked_path.is_none() && Instant::now() >= discovery_due {
-            if let Some(c) = newest_codex_rollout(&sessions_dir, &cwd, spawn_instant) {
-                if let Some(thread_id) = codex_rollout_thread_id(&c) {
-                    discover(session_id, thread_id);
-                }
-                tracked_path = Some(c);
-                tracked_len = 0;
-                state = CodexState::default();
-                discovery_interval = CODEX_DISCOVERY_SCAN_MIN_INTERVAL;
-            } else {
-                discovery_interval = codex_next_discovery_interval(discovery_interval, CODEX_DISCOVERY_SCAN_MAX_INTERVAL);
-                discovery_due = Instant::now().checked_add(discovery_interval).unwrap_or_else(Instant::now);
-            }
-        }
-
-        if let Some(path) = tracked_path.as_ref() {
-            match std::fs::metadata(path) {
-                Ok(meta) => {
-                    let len = meta.len();
-                    // Defensive: handle truncation/rotation. Same shape as the Claude and Copilot watchers.
-                    if len < tracked_len {
-                        tracked_len = 0;
-                        state = CodexState::default();
-                        last_emitted = None;
-                    }
-                    if len > tracked_len {
-                        tracked_len = tail_lines(path, tracked_len, len, |line| {
-                            ingest_codex_rollout_line(line, &mut state);
-                            if maybe_codex_turn_complete(line) {
-                                if let Some(duration) = parse_codex_turn_duration_ms(line) {
-                                    emit_turn(session_id, duration);
-                                }
-                            }
-                        });
-                    }
-                }
-                Err(_) => {
-                    // File disappeared (deletion, rename) — drop tracking so the next tick rediscovers.
-                    tracked_path = None;
-                    tracked_len = 0;
-                    state = CodexState::default();
-                    last_emitted = None;
-                    discovery_interval = CODEX_DISCOVERY_SCAN_MIN_INTERVAL;
-                    discovery_due = Instant::now();
-                }
-            }
-        }
-
-        if state.has_any() {
-            let snapshot = state.snapshot(session_id);
-            if !last_emitted.as_ref().is_some_and(|prev| prev.same_payload_as(&snapshot)) {
-                emit(snapshot.clone());
-                last_emitted = Some(snapshot);
-            }
-        }
-
-        thread::sleep(POLL_INTERVAL);
-    }
-}
-
-fn codex_next_discovery_interval(current: Duration, max: Duration) -> Duration {
-    current.saturating_mul(2).min(max)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
 
     #[test]
     fn encode_cwd_replaces_separators_and_drive_colon() {
@@ -1383,155 +617,6 @@ mod tests {
     }
 
     #[test]
-    fn extract_assistant_usage_happy_path() {
-        let line = br#"{"type":"assistant","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":12,"output_tokens":34,"cache_creation_input_tokens":56,"cache_read_input_tokens":78}}}"#;
-        let (u, m) = extract_assistant_usage(line).expect("parsed");
-        assert_eq!(u.input_tokens, 12);
-        assert_eq!(u.output_tokens, 34);
-        assert_eq!(u.cache_creation_input_tokens, 56);
-        assert_eq!(u.cache_read_input_tokens, 78);
-        assert_eq!(m.as_deref(), Some("claude-sonnet-4-6"));
-    }
-
-    #[test]
-    fn extract_assistant_usage_returns_none_for_user_lines() {
-        let line = br#"{"type":"user","message":{"role":"user","content":"hi"}}"#;
-        assert!(extract_assistant_usage(line).is_none());
-    }
-
-    #[test]
-    fn extract_assistant_usage_returns_none_for_system_lines() {
-        let line = br#"{"type":"system","subtype":"turn_duration","durationMs":42}"#;
-        assert!(extract_assistant_usage(line).is_none());
-    }
-
-    #[test]
-    fn extract_assistant_usage_tolerates_missing_optional_fields() {
-        // No cache fields present — should default to 0.
-        let line = br#"{"type":"assistant","message":{"usage":{"input_tokens":1,"output_tokens":2}}}"#;
-        let (u, m) = extract_assistant_usage(line).expect("parsed");
-        assert_eq!(u.input_tokens, 1);
-        assert_eq!(u.output_tokens, 2);
-        assert_eq!(u.cache_creation_input_tokens, 0);
-        assert_eq!(u.cache_read_input_tokens, 0);
-        assert!(m.is_none());
-    }
-
-    #[test]
-    fn extract_assistant_usage_returns_none_for_garbage() {
-        assert!(extract_assistant_usage(b"not json").is_none());
-        assert!(extract_assistant_usage(b"{}").is_none());
-    }
-
-    #[test]
-    fn turn_totals_track_last_and_sum() {
-        let mut t = TurnTotals::default();
-        t.add(&UsageBlock {
-            input_tokens: 10,
-            output_tokens: 5,
-            cache_creation_input_tokens: 100,
-            cache_read_input_tokens: 200,
-        });
-        t.add(&UsageBlock {
-            input_tokens: 20,
-            output_tokens: 7,
-            cache_creation_input_tokens: 0,
-            cache_read_input_tokens: 500,
-        });
-        // Last = the second turn.
-        assert_eq!(t.last_input, 20);
-        assert_eq!(t.last_output, 7);
-        assert_eq!(t.last_cache_read, 500);
-        assert_eq!(t.last_cache_creation, 0);
-        // Sums accumulate input+output (cache fields aren't summed — they're per-turn state).
-        assert_eq!(t.sum_input, 30);
-        assert_eq!(t.sum_output, 12);
-        // Context tokens used = sum of the LAST turn's four fields.
-        assert_eq!(t.context_tokens_used(), 20 + 500 + 7);
-        assert!(t.has_any());
-    }
-
-    #[test]
-    fn fallback_limit_known_models() {
-        assert_eq!(fallback_limit_for_model("claude-sonnet-4-6"), Some(200_000));
-        assert_eq!(fallback_limit_for_model("claude-opus-4-7"), Some(200_000));
-        assert_eq!(fallback_limit_for_model("claude-haiku-4-5"), Some(200_000));
-        assert_eq!(fallback_limit_for_model("gpt-4"), None);
-    }
-
-    #[test]
-    fn resolve_limit_prefers_token_usage_file() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let p = dir.path().join("token_usage.json");
-        let mut f = std::fs::File::create(&p).unwrap();
-        f.write_all(br#"{"actual_limit":128000,"expected_limit":200000}"#).unwrap();
-        assert_eq!(resolve_limit(&p, Some("claude-opus-4-7")), Some(128_000));
-    }
-
-    #[test]
-    fn resolve_limit_falls_back_when_file_missing() {
-        let p = std::path::Path::new("/nonexistent/arborist-test/token_usage.json");
-        assert_eq!(resolve_limit(p, Some("claude-sonnet-4-6")), Some(200_000));
-        assert_eq!(resolve_limit(p, Some("unknown-model")), None);
-        assert_eq!(resolve_limit(p, None), None);
-    }
-
-    #[test]
-    fn resolve_limit_ignores_zero_in_file() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let p = dir.path().join("token_usage.json");
-        let mut f = std::fs::File::create(&p).unwrap();
-        f.write_all(br#"{"actual_limit":0}"#).unwrap();
-        // Falls through to fallback table.
-        assert_eq!(resolve_limit(&p, Some("claude-sonnet-4-6")), Some(200_000));
-    }
-
-    #[test]
-    fn build_snapshot_computes_pct_when_limit_known() {
-        let mut totals = TurnTotals::default();
-        totals.add(&UsageBlock {
-            input_tokens: 50_000,
-            output_tokens: 0,
-            cache_creation_input_tokens: 0,
-            cache_read_input_tokens: 0,
-        });
-        let snap = build_snapshot(SessionId::new(), &totals, Some("claude-sonnet-4-6".into()), Some(200_000));
-        assert_eq!(snap.context_used_pct, Some(25));
-        assert_eq!(snap.context_tokens_used, Some(50_000));
-        assert_eq!(snap.context_tokens_limit, Some(200_000));
-        assert_eq!(snap.input_tokens, Some(50_000));
-        assert_eq!(snap.output_tokens, Some(0));
-    }
-
-    #[test]
-    fn build_snapshot_caps_pct_at_100() {
-        let mut totals = TurnTotals::default();
-        totals.add(&UsageBlock {
-            input_tokens: 999_999,
-            output_tokens: 0,
-            cache_creation_input_tokens: 0,
-            cache_read_input_tokens: 0,
-        });
-        let snap = build_snapshot(SessionId::new(), &totals, None, Some(200_000));
-        assert_eq!(snap.context_used_pct, Some(100));
-    }
-
-    #[test]
-    fn build_snapshot_omits_pct_when_limit_unknown() {
-        let mut totals = TurnTotals::default();
-        totals.add(&UsageBlock {
-            input_tokens: 100,
-            output_tokens: 0,
-            cache_creation_input_tokens: 0,
-            cache_read_input_tokens: 0,
-        });
-        let snap = build_snapshot(SessionId::new(), &totals, None, None);
-        assert!(snap.context_used_pct.is_none());
-        assert_eq!(snap.context_tokens_used, Some(100));
-        assert!(snap.context_tokens_limit.is_none());
-    }
-
-    #[test]
     fn registry_start_spawns_watcher_for_copilot() {
         let reg = MetricsRegistry::new();
         let id = SessionId::new();
@@ -1560,438 +645,6 @@ mod tests {
         let reg = MetricsRegistry::new();
         // Should not panic on unknown session id.
         reg.stop(&SessionId::new());
-    }
-
-    #[test]
-    fn newest_jsonl_after_picks_freshest_eligible_file() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let a = dir.path().join("aaa.jsonl");
-        let b = dir.path().join("bbb.jsonl");
-        let c = dir.path().join("not-a-transcript.txt");
-        std::fs::write(&a, b"x").unwrap();
-        std::thread::sleep(Duration::from_millis(20));
-        std::fs::write(&b, b"y").unwrap();
-        std::fs::write(&c, b"z").unwrap();
-
-        // After=epoch-far-past => both eligible; b is newer => picked.
-        let picked = newest_jsonl_after(dir.path(), UNIX_EPOCH).expect("some");
-        assert_eq!(picked, b);
-
-        // After=now+1day => nothing eligible.
-        let future = SystemTime::now() + Duration::from_secs(86_400);
-        assert!(newest_jsonl_after(dir.path(), future).is_none());
-    }
-
-    // -- Copilot OTel parser ---------------------------------------------
-
-    /// Real probe data captured from `copilot -p` with the OTel file exporter enabled. Two spans (chat + invoke_agent parent) plus metric lines. Used
-    /// as the canonical fixture for the parser tests.
-    const COPILOT_OTEL_FIXTURE: &[u8] = include_bytes!("../tests/fixtures/copilot_otel_sample.jsonl");
-
-    fn fixture_lines() -> Vec<&'static [u8]> {
-        COPILOT_OTEL_FIXTURE.split(|&b| b == b'\n').filter(|l| !l.is_empty()).collect()
-    }
-
-    #[test]
-    fn ingest_otel_chat_span_extracts_totals_and_context() {
-        // Find the leaf chat span line.
-        let chat_line = fixture_lines()
-            .into_iter()
-            .find(|l| std::str::from_utf8(l).unwrap_or("").contains(r#""name":"chat "#))
-            .expect("chat span in fixture");
-        let mut state = CopilotState::default();
-        ingest_otel_line(chat_line, &mut state);
-        assert!(state.has_any());
-        assert_eq!(state.sum_input, 39_497);
-        assert_eq!(state.sum_output, 24);
-        assert_eq!(state.last_model.as_deref(), Some("claude-opus-4.7"));
-        assert_eq!(state.token_limit, Some(168_000));
-        assert_eq!(state.current_tokens, Some(29_461));
-    }
-
-    #[test]
-    fn ingest_otel_chat_span_extracts_conversation_id() {
-        // The chat span carries `gen_ai.conversation.id` — that's the Copilot session id we feed back into `--session-id` (copilot-cli >= 1.0.51).
-        let chat_line = fixture_lines()
-            .into_iter()
-            .find(|l| std::str::from_utf8(l).unwrap_or("").contains(r#""name":"chat "#))
-            .expect("chat span in fixture");
-        let mut state = CopilotState::default();
-        ingest_otel_line(chat_line, &mut state);
-        assert!(state.conversation_id.is_some(), "chat span must populate conversation_id",);
-        let id = state.conversation_id.as_deref().expect("present");
-        assert!(!id.is_empty(), "conversation id must be non-empty");
-    }
-
-    #[test]
-    fn ingest_otel_chat_span_bare_name_is_accepted() {
-        // Copilot CLI emits chat spans with two `name` formats — the older `"chat <model>"` and the newer bare `"chat"`. The op attribute
-        // (`gen_ai.operation.name`) is identical in both. A previous `name.starts_with("chat ")` filter silently dropped bare-name spans, breaking
-        // aiSessionId tracking after /clear or /resume and zeroing token totals for affected sessions. This test pins the new op-based filter to the
-        // bare-name shape.
-        let line = br#"{"type":"span","name":"chat","attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"claude-opus-4.7-high","gen_ai.conversation.id":"abc-123","gen_ai.usage.input_tokens":50,"gen_ai.usage.output_tokens":5}}"#;
-        let mut state = CopilotState::default();
-        ingest_otel_line(line, &mut state);
-        assert!(state.has_any(), "bare-name chat span must be accepted");
-        assert_eq!(state.sum_input, 50);
-        assert_eq!(state.sum_output, 5);
-        assert_eq!(state.last_model.as_deref(), Some("claude-opus-4.7-high"));
-        assert_eq!(state.conversation_id.as_deref(), Some("abc-123"));
-    }
-
-    #[test]
-    fn ingest_otel_invoke_agent_with_chat_name_prefix_is_rejected() {
-        // Belt-and-suspenders: invoke_agent carries the same usage numbers as its chat children. If a future Copilot version named the parent
-        // something like "chat agent invocation" while keeping op=invoke_agent, a name-prefix filter would double-count. The op-based filter prevents
-        // that regardless of the name string.
-        let line = br#"{"type":"span","name":"chat agent invocation","attributes":{"gen_ai.operation.name":"invoke_agent","gen_ai.usage.input_tokens":999,"gen_ai.usage.output_tokens":99}}"#;
-        let mut state = CopilotState::default();
-        ingest_otel_line(line, &mut state);
-        assert!(!state.has_any(), "invoke_agent op must be ignored regardless of name",);
-    }
-
-    #[test]
-    fn ingest_otel_unknown_op_is_rejected() {
-        // Defense in depth for any future op kind we haven't yet characterized — only `chat` is known to carry leaf usage totals we want to sum.
-        let line = br#"{"type":"span","name":"chat_completion","attributes":{"gen_ai.operation.name":"chat_completion","gen_ai.usage.input_tokens":1000,"gen_ai.usage.output_tokens":100}}"#;
-        let mut state = CopilotState::default();
-        ingest_otel_line(line, &mut state);
-        assert!(!state.has_any(), "non-chat op must be ignored");
-    }
-
-    #[test]
-    fn ingest_otel_span_without_op_attribute_is_rejected() {
-        // The semconv attribute is the source of truth. A span missing it (e.g. malformed exporter output) must not be counted even if `name` happens
-        // to start with "chat".
-        let line = br#"{"type":"span","name":"chat foo","attributes":{"gen_ai.usage.input_tokens":10,"gen_ai.usage.output_tokens":1}}"#;
-        let mut state = CopilotState::default();
-        ingest_otel_line(line, &mut state);
-        assert!(!state.has_any(), "missing gen_ai.operation.name must be treated as unknown",);
-    }
-
-    #[test]
-    fn ingest_otel_invoke_agent_is_ignored() {
-        // The invoke_agent span carries the same gen_ai.usage.* numbers as its child chat span. If we counted both we'd double-count.
-        let parent_line = fixture_lines()
-            .into_iter()
-            .find(|l| std::str::from_utf8(l).unwrap_or("").contains(r#""name":"invoke_agent""#))
-            .expect("invoke_agent span in fixture");
-        let mut state = CopilotState::default();
-        ingest_otel_line(parent_line, &mut state);
-        assert!(!state.has_any(), "invoke_agent must not advance state");
-        assert_eq!(state.sum_input, 0);
-        assert_eq!(state.sum_output, 0);
-    }
-
-    #[test]
-    fn ingest_otel_metric_lines_are_ignored() {
-        let metric_line = fixture_lines()
-            .into_iter()
-            .find(|l| std::str::from_utf8(l).unwrap_or("").contains(r#""type":"metric""#))
-            .expect("metric line in fixture");
-        let mut state = CopilotState::default();
-        ingest_otel_line(metric_line, &mut state);
-        assert!(!state.has_any(), "metric lines must not advance state");
-    }
-
-    #[test]
-    fn ingest_otel_full_fixture_no_double_counting() {
-        // Replay the entire fixture (two chat spans + invoke_agent + metric lines). Both chat spans should contribute their tokens; the invoke_agent
-        // must NOT (it carries duplicates of the first chat span's totals). This is the regression assertion for the subagent / aggregate-parent
-        // shape AND for accepting both the `chat <model>` and bare `chat` name formats.
-        let mut state = CopilotState::default();
-        for line in fixture_lines() {
-            ingest_otel_line(line, &mut state);
-        }
-        assert_eq!(state.sum_input, 39_497 + 12_345, "both chat spans counted");
-        assert_eq!(state.sum_output, 24 + 67);
-        // The bare-name span comes last in the fixture, so its `current_tokens` / `token_limit` win the latest-wins race.
-        assert_eq!(state.token_limit, Some(170_000));
-        assert_eq!(state.current_tokens, Some(42_000));
-        assert_eq!(state.last_model.as_deref(), Some("claude-opus-4.7-high"));
-    }
-
-    #[test]
-    fn ingest_otel_malformed_json_is_ignored() {
-        let mut state = CopilotState::default();
-        ingest_otel_line(b"not json", &mut state);
-        ingest_otel_line(b"{}", &mut state);
-        ingest_otel_line(b"{\"type\":\"span\"}", &mut state); // no name
-        assert!(!state.has_any());
-    }
-
-    #[test]
-    fn ingest_otel_two_chat_spans_sum_and_latest_wins() {
-        let chat1 = br#"{"type":"span","name":"chat model-a","attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"model-a","gen_ai.usage.input_tokens":100,"gen_ai.usage.output_tokens":10},"events":[{"name":"github.copilot.session.usage_info","attributes":{"github.copilot.token_limit":1000,"github.copilot.current_tokens":500}}]}"#;
-        let chat2 = br#"{"type":"span","name":"chat model-b","attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"model-b","gen_ai.usage.input_tokens":200,"gen_ai.usage.output_tokens":20},"events":[{"name":"github.copilot.session.usage_info","attributes":{"github.copilot.token_limit":2000,"github.copilot.current_tokens":700}}]}"#;
-        let mut state = CopilotState::default();
-        ingest_otel_line(chat1, &mut state);
-        ingest_otel_line(chat2, &mut state);
-        // Sums.
-        assert_eq!(state.sum_input, 300);
-        assert_eq!(state.sum_output, 30);
-        // Latest wins for model + context state.
-        assert_eq!(state.last_model.as_deref(), Some("model-b"));
-        assert_eq!(state.token_limit, Some(2000));
-        assert_eq!(state.current_tokens, Some(700));
-    }
-
-    #[test]
-    fn ingest_otel_chat_span_without_usage_info_event() {
-        // Totals should still update; context fields stay at their last observed values (None here).
-        let line = br#"{"type":"span","name":"chat foo","attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"foo","gen_ai.usage.input_tokens":7,"gen_ai.usage.output_tokens":3}}"#;
-        let mut state = CopilotState::default();
-        ingest_otel_line(line, &mut state);
-        assert_eq!(state.sum_input, 7);
-        assert_eq!(state.sum_output, 3);
-        assert!(state.token_limit.is_none());
-        assert!(state.current_tokens.is_none());
-    }
-
-    #[test]
-    fn ingest_otel_falls_back_to_request_model() {
-        let line = br#"{"type":"span","name":"chat fallback","attributes":{"gen_ai.operation.name":"chat","gen_ai.request.model":"req-only","gen_ai.usage.input_tokens":1,"gen_ai.usage.output_tokens":2}}"#;
-        let mut state = CopilotState::default();
-        ingest_otel_line(line, &mut state);
-        assert_eq!(state.last_model.as_deref(), Some("req-only"));
-    }
-
-    #[test]
-    fn copilot_state_snapshot_computes_pct_from_current_tokens() {
-        // Critical: pct uses the LATEST current_tokens / token_limit, NOT sum_input. Confirms the "context_tokens_used != input_tokens" invariant
-        // from the design. The fixture's bare-name span is the last chat span, so its 42_000 / 170_000 win the latest-wins race for context
-        // numerator/denominator. Cumulative totals remain the SUM across both spans.
-        let mut state = CopilotState::default();
-        for line in fixture_lines() {
-            ingest_otel_line(line, &mut state);
-        }
-        let snap = state.snapshot(SessionId::new());
-        assert_eq!(snap.context_tokens_used, Some(42_000));
-        assert_eq!(snap.context_tokens_limit, Some(170_000));
-        // 42000 * 100 / 170000 = 24
-        assert_eq!(snap.context_used_pct, Some(24));
-        // Cumulative totals are independent of the context numerator.
-        assert_eq!(snap.input_tokens, Some(39_497 + 12_345));
-        assert_eq!(snap.output_tokens, Some(24 + 67));
-    }
-
-    #[test]
-    fn copilot_state_snapshot_omits_pct_without_limit() {
-        let line = br#"{"type":"span","name":"chat foo","attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"foo","gen_ai.usage.input_tokens":1,"gen_ai.usage.output_tokens":1}}"#;
-        let mut state = CopilotState::default();
-        ingest_otel_line(line, &mut state);
-        let snap = state.snapshot(SessionId::new());
-        assert!(snap.context_used_pct.is_none());
-        assert!(snap.context_tokens_used.is_none());
-        assert!(snap.context_tokens_limit.is_none());
-    }
-
-    #[test]
-    fn parse_invoke_agent_duration_extracts_ms() {
-        // Real fixture: invoke_agent span starts at [1777474197, 905_000_000] and ends at [1777474200, 749_237_700]. Difference is 2_844_237_700 ns ≈
-        // 2844 ms.
-        let line = fixture_lines()
-            .into_iter()
-            .find(|l| {
-                let needle = b"invoke_agent";
-                l.starts_with(br#"{"type":"span","traceId"#) && l.windows(needle.len()).any(|w| w == needle)
-            })
-            .expect("invoke_agent span in fixture");
-        let ms = parse_invoke_agent_duration_ms(line).expect("duration parsed");
-        assert!((2_840..=2_850).contains(&ms), "duration_ms ~= 2844, got {ms}",);
-    }
-
-    #[test]
-    fn parse_invoke_agent_duration_ignores_chat_span() {
-        // chat <model> spans are excluded — they are LLM round-trips, not turn boundaries.
-        let line = fixture_lines()
-            .into_iter()
-            .find(|l| {
-                let needle: &[u8] = br#""name":"chat "#;
-                l.starts_with(br#"{"type":"span","#) && l.windows(needle.len()).any(|w| w == needle)
-            })
-            .expect("chat span in fixture");
-        assert!(parse_invoke_agent_duration_ms(line).is_none());
-    }
-
-    #[test]
-    fn parse_invoke_agent_duration_ignores_metric_lines() {
-        let line = b"{\"type\":\"metric\",\"name\":\"gen_ai.client.token.usage\"}";
-        assert!(parse_invoke_agent_duration_ms(line).is_none());
-    }
-
-    #[test]
-    fn parse_invoke_agent_duration_handles_missing_times() {
-        let line = br#"{"type":"span","name":"invoke_agent"}"#;
-        assert!(parse_invoke_agent_duration_ms(line).is_none());
-    }
-
-    #[test]
-    fn parse_invoke_agent_duration_saturates_for_inverted_times() {
-        // Defensive: out-of-order timestamps must yield 0, not panic.
-        let line = br#"{"type":"span","name":"invoke_agent","startTime":[10,0],"endTime":[5,0]}"#;
-        assert_eq!(parse_invoke_agent_duration_ms(line), Some(0));
-    }
-
-    #[test]
-    fn maybe_invoke_agent_span_skips_unrelated_lines() {
-        // The cheap prefilter must reject anything that doesn't even mention "invoke_agent" — that's the whole point of avoiding a
-        // serde_json::from_slice on the hot path.
-        assert!(!maybe_invoke_agent_span(b""));
-        assert!(!maybe_invoke_agent_span(b"{\"type\":\"metric\"}"));
-        assert!(!maybe_invoke_agent_span(br#"{"type":"span","name":"chat claude-opus"}"#));
-    }
-
-    #[test]
-    fn maybe_invoke_agent_span_admits_real_invoke_agent_lines() {
-        let line = br#"{"type":"span","name":"invoke_agent","startTime":[1,0],"endTime":[2,0]}"#;
-        assert!(maybe_invoke_agent_span(line));
-    }
-
-    // -- Copilot watcher integration -------------------------------------
-
-    /// Run a Copilot watcher against an evolving JSONL file in a tempdir. Drives state transitions by appending to the file and waiting for the
-    /// callback to fire — no virtual time, but the test only sleeps long enough to clear at most a couple of poll intervals.
-    #[test]
-    fn copilot_watcher_emits_on_new_chat_span() {
-        use std::sync::mpsc;
-
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("otel.jsonl");
-        // Pre-create empty so the watcher's first poll sees a valid file.
-        std::fs::write(&path, b"").unwrap();
-
-        let session_id = SessionId::new();
-        let running = Arc::new(AtomicBool::new(true));
-        let running_for_thread = Arc::clone(&running);
-        let (tx, rx) = mpsc::channel::<SessionMetricsEvent>();
-        let cb: MetricsCb = Arc::new(move |ev| {
-            // Channel may be closed if the test already finished; ignore send errors so the watcher thread can shut down cleanly.
-            let _ = tx.send(ev);
-        });
-        let path_for_thread = path.clone();
-        let handle = std::thread::spawn(move || {
-            run_copilot_watcher(
-                session_id,
-                path_for_thread,
-                cb,
-                Arc::new(|_, _| {}),
-                Arc::new(|_, _| {}),
-                running_for_thread,
-            );
-        });
-
-        // Append the fixture (two chat spans + invoke_agent + metrics). On Linux, `std::fs::write` is not atomic so the watcher can catch a partial
-        // write (only the first span). Drain snapshots until we see the cumulative totals from both spans.
-        std::fs::write(&path, COPILOT_OTEL_FIXTURE).unwrap();
-        let deadline = std::time::Instant::now() + Duration::from_secs(8);
-        let snap = loop {
-            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-            let s = match rx.recv_timeout(remaining) {
-                Ok(s) => s,
-                Err(_) => panic!("timed out waiting for cumulative snapshot (context_tokens_used never reached 42_000)"),
-            };
-            if s.context_tokens_used == Some(42_000) {
-                break s;
-            }
-        };
-        assert_eq!(snap.context_tokens_used, Some(42_000));
-        assert_eq!(snap.context_tokens_limit, Some(170_000));
-        assert_eq!(snap.input_tokens, Some(39_497 + 12_345));
-        assert_eq!(snap.output_tokens, Some(24 + 67));
-        assert_eq!(snap.model.as_deref(), Some("claude-opus-4.7-high"));
-
-        // Shut the watcher down.
-        running.store(false, Ordering::SeqCst);
-        handle.join().expect("watcher thread joined");
-    }
-
-    #[test]
-    fn copilot_watcher_emits_turn_end_for_invoke_agent_span() {
-        use std::sync::mpsc;
-
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("otel.jsonl");
-        std::fs::write(&path, b"").unwrap();
-
-        let session_id = SessionId::new();
-        let running = Arc::new(AtomicBool::new(true));
-        let running_for_thread = Arc::clone(&running);
-        let (tx, rx) = mpsc::channel::<(SessionId, Option<u64>)>();
-        let metrics_cb: MetricsCb = Arc::new(|_| {});
-        let turn_cb: TurnCb = Arc::new(move |sid, dur| {
-            let _ = tx.send((sid, dur));
-        });
-        let path_for_thread = path.clone();
-        let handle = std::thread::spawn(move || {
-            run_copilot_watcher(session_id, path_for_thread, metrics_cb, turn_cb, Arc::new(|_, _| {}), running_for_thread);
-        });
-
-        // The full fixture contains exactly one invoke_agent span.
-        std::fs::write(&path, COPILOT_OTEL_FIXTURE).unwrap();
-        let (sid, dur) = rx.recv_timeout(Duration::from_secs(8)).expect("watcher emitted turn-end");
-        assert_eq!(sid, session_id);
-        let dur = dur.expect("invoke_agent carries a duration");
-        assert!((2_840..=2_850).contains(&dur), "expected ~2844ms duration, got {dur}",);
-
-        running.store(false, Ordering::SeqCst);
-        handle.join().expect("watcher thread joined");
-    }
-
-    #[test]
-    fn copilot_watcher_handles_truncate_and_resets_totals() {
-        use std::sync::mpsc;
-
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("otel.jsonl");
-        std::fs::write(&path, b"").unwrap();
-
-        let session_id = SessionId::new();
-        let running = Arc::new(AtomicBool::new(true));
-        let running_for_thread = Arc::clone(&running);
-        let (tx, rx) = mpsc::channel::<SessionMetricsEvent>();
-        let cb: MetricsCb = Arc::new(move |ev| {
-            let _ = tx.send(ev);
-        });
-        let path_for_thread = path.clone();
-        let handle = std::thread::spawn(move || {
-            run_copilot_watcher(
-                session_id,
-                path_for_thread,
-                cb,
-                Arc::new(|_, _| {}),
-                Arc::new(|_, _| {}),
-                running_for_thread,
-            );
-        });
-
-        // 1) Initial usage from the full fixture.
-        std::fs::write(&path, COPILOT_OTEL_FIXTURE).unwrap();
-        let _first = rx.recv_timeout(Duration::from_secs(8)).expect("first snapshot");
-
-        // 2) Truncate to a fresh, smaller chat span. Watcher must reset.
-        let smaller = br#"{"type":"span","name":"chat tiny","attributes":{"gen_ai.operation.name":"chat","gen_ai.response.model":"tiny","gen_ai.usage.input_tokens":42,"gen_ai.usage.output_tokens":1},"events":[{"name":"github.copilot.session.usage_info","attributes":{"github.copilot.token_limit":1000,"github.copilot.current_tokens":50}}]}
-"#;
-        std::fs::write(&path, smaller).unwrap();
-
-        // Drain until we get the post-truncate snapshot. The first message received after the truncate should reflect the smaller numbers (not the
-        // cumulative pre-truncate values).
-        let deadline = std::time::Instant::now() + Duration::from_secs(8);
-        let snap = loop {
-            assert!(std::time::Instant::now() < deadline, "timed out");
-            let s = rx.recv_timeout(Duration::from_secs(8)).expect("post-truncate snapshot");
-            if s.input_tokens == Some(42) {
-                break s;
-            }
-        };
-        assert_eq!(snap.input_tokens, Some(42));
-        assert_eq!(snap.output_tokens, Some(1));
-        assert_eq!(snap.context_tokens_used, Some(50));
-        assert_eq!(snap.context_tokens_limit, Some(1000));
-        assert_eq!(snap.model.as_deref(), Some("tiny"));
-
-        running.store(false, Ordering::SeqCst);
-        handle.join().expect("watcher thread joined");
     }
 
     // ----- read_range cap (defensive against runaway exporter) -------------
@@ -2109,86 +762,6 @@ mod tests {
         assert_eq!(new_cursor, 12);
     }
 
-    // ----- Claude watcher partial-line protection --------------------------
-
-    /// Regression for the gap noted in PR review: a half-written trailing JSON line at EOF must NOT be silently dropped. The watcher must only
-    /// advance its cursor up to the last complete `\n`, so the rest of the line is re-read after the writer finishes it.
-    #[test]
-    fn claude_watcher_does_not_drop_partial_trailing_line() {
-        use std::io::Write;
-        use std::sync::mpsc;
-
-        // Set up a fake $HOME so the watcher's project_dir resolves into our tempdir. encode_cwd of the cwd we pass becomes the dir name.
-        let home = tempfile::tempdir().expect("home");
-        let cwd_dir = tempfile::tempdir().expect("cwd");
-        let cwd = cwd_dir.path().to_path_buf();
-        let project_dir = home.path().join(".claude").join("projects").join(encode_cwd(&cwd));
-        std::fs::create_dir_all(&project_dir).unwrap();
-        let jsonl = project_dir.join("session.jsonl");
-        std::fs::write(&jsonl, b"").unwrap();
-
-        let session_id = SessionId::new();
-        let running = Arc::new(AtomicBool::new(true));
-        let running_for_thread = Arc::clone(&running);
-        let (tx, rx) = mpsc::channel::<SessionMetricsEvent>();
-        let cb: MetricsCb = Arc::new(move |ev| {
-            let _ = tx.send(ev);
-        });
-        let home_for_thread = home.path().to_path_buf();
-        let cwd_for_thread = cwd.clone();
-        let spawn_instant = SystemTime::now() - Duration::from_secs(60);
-        let handle = std::thread::spawn(move || {
-            run_claude_watcher(
-                session_id,
-                home_for_thread,
-                cwd_for_thread,
-                spawn_instant,
-                cb,
-                Arc::new(|_, _| {}),
-                Arc::new(|_, _| {}),
-                running_for_thread,
-            );
-        });
-
-        // 1) Write one complete line + a partial second line (no newline).
-        let complete = br#"{"type":"assistant","message":{"model":"claude-opus-4.7","usage":{"input_tokens":10,"output_tokens":2}}}"#;
-        let partial = br#"{"type":"assistant","message":{"model":"claude-opus-4.7","usage":{"input_tokens":99"#;
-        {
-            let mut f = std::fs::OpenOptions::new().append(true).open(&jsonl).unwrap();
-            f.write_all(complete).unwrap();
-            f.write_all(b"\n").unwrap();
-            f.write_all(partial).unwrap();
-        }
-
-        // First emission must reflect ONLY the complete line.
-        let first = rx.recv_timeout(Duration::from_secs(8)).expect("first snapshot");
-        assert_eq!(first.input_tokens, Some(10));
-        assert_eq!(first.output_tokens, Some(2));
-
-        // 2) Finish the partial line. The cursor must have stayed at the end of the
-        //    first line, so the now-complete second line gets parsed in full and added
-        //    to the totals.
-        {
-            let mut f = std::fs::OpenOptions::new().append(true).open(&jsonl).unwrap();
-            f.write_all(b",\"output_tokens\":7}}}\n").unwrap();
-        }
-
-        // Drain until totals jump to 10+99 = 109 in.
-        let deadline = std::time::Instant::now() + Duration::from_secs(8);
-        let snap = loop {
-            assert!(std::time::Instant::now() < deadline, "timed out");
-            let s = rx.recv_timeout(Duration::from_secs(8)).expect("post-completion snapshot");
-            if s.input_tokens == Some(109) {
-                break s;
-            }
-        };
-        assert_eq!(snap.input_tokens, Some(109), "partial line was re-read");
-        assert_eq!(snap.output_tokens, Some(9));
-
-        running.store(false, Ordering::SeqCst);
-        handle.join().expect("watcher thread joined");
-    }
-
     // ----- dedup regression -------------------------------------------------
 
     /// Bug regression: `observed_at` must not be compared as part of the dedup check. Two snapshots with the same data but different timestamps must
@@ -2266,245 +839,27 @@ mod tests {
         );
     }
 
-    // ----- Codex rollout watcher utilities ---------------------------------
-
     #[test]
-    fn ingest_codex_token_count_event() {
-        // Real Codex format: `RolloutItem` is adjacently tagged (`payload`), `EventMsg` is internally tagged
-        // (`token_count`), so `info` is inlined directly under `payload` — there is no second `payload` wrapper.
-        // Context occupancy is the LAST turn's total (950), while input/output are the cumulative session totals.
-        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1500,"cached_input_tokens":200,"output_tokens":800,"reasoning_output_tokens":100,"total_tokens":2600},"last_token_usage":{"input_tokens":500,"cached_input_tokens":100,"output_tokens":300,"reasoning_output_tokens":50,"total_tokens":950},"model_context_window":128000},"rate_limits":null}}"#;
-        let mut state = CodexState::default();
-        ingest_codex_rollout_line(line, &mut state);
-        assert!(state.seen);
-        assert_eq!(state.sum_input, 1500);
-        assert_eq!(state.sum_output, 800);
-        assert_eq!(state.context_tokens_used, Some(950));
-        assert_eq!(state.context_window, Some(128000));
+    fn next_discovery_interval_doubles_until_cap() {
+        let next = next_discovery_interval(DISCOVERY_SCAN_MIN_INTERVAL, DISCOVERY_SCAN_MAX_INTERVAL);
+        assert_eq!(next, DISCOVERY_SCAN_MIN_INTERVAL.saturating_mul(2));
+
+        let capped = next_discovery_interval(DISCOVERY_SCAN_MAX_INTERVAL, DISCOVERY_SCAN_MAX_INTERVAL);
+        assert_eq!(capped, DISCOVERY_SCAN_MAX_INTERVAL);
     }
 
     #[test]
-    fn ingest_codex_token_count_event_legacy_double_payload() {
-        // Defensive: an older/alternative shape with PascalCase tag and a nested `payload.payload.info` wrapper.
-        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"TokenCount","payload":{"info":{"total_token_usage":{"input_tokens":1500,"cached_input_tokens":200,"output_tokens":800,"reasoning_output_tokens":100,"total_tokens":2600},"last_token_usage":{"input_tokens":500,"cached_input_tokens":100,"output_tokens":300,"reasoning_output_tokens":50,"total_tokens":950},"model_context_window":128000}}}}"#;
-        let mut state = CodexState::default();
-        ingest_codex_rollout_line(line, &mut state);
-        assert!(state.seen);
-        assert_eq!(state.sum_input, 1500);
-        assert_eq!(state.sum_output, 800);
-        assert_eq!(state.context_tokens_used, Some(950));
-        assert_eq!(state.context_window, Some(128000));
-    }
-
-    #[test]
-    fn ingest_codex_context_occupancy_tracks_last_turn_not_cumulative() {
-        // Across turns, `total_token_usage` accumulates without bound while `last_token_usage` reflects the live window.
-        // The context gauge must follow the latter, so it can never get pinned at 100% once the session exceeds the window.
-        let window = 100_000u64;
-        let turn1 = br#"{"timestamp":"t1","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":60000,"output_tokens":20000,"total_tokens":80000},"last_token_usage":{"input_tokens":60000,"output_tokens":20000,"total_tokens":80000},"model_context_window":100000}}}"#;
-        // After a /compact the cumulative session total (190000) exceeds the window, but only 30000 tokens occupy it.
-        let turn2 = br#"{"timestamp":"t2","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":140000,"output_tokens":50000,"total_tokens":190000},"last_token_usage":{"input_tokens":25000,"output_tokens":5000,"total_tokens":30000},"model_context_window":100000}}}"#;
-        let mut state = CodexState::default();
-        ingest_codex_rollout_line(turn1, &mut state);
-        ingest_codex_rollout_line(turn2, &mut state);
-        assert_eq!(state.context_tokens_used, Some(30_000));
-        assert_eq!(state.context_window, Some(window));
-        let snap = state.snapshot(SessionId::new());
-        assert_eq!(snap.context_used_pct, Some(30));
-        // Cumulative session totals still surface for the input/output displays.
-        assert_eq!(snap.input_tokens, Some(140_000));
-        assert_eq!(snap.output_tokens, Some(50_000));
-    }
-
-    #[test]
-    fn ingest_codex_turn_context_extracts_model() {
-        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"turn_context","payload":{"model":"o3-mini","cwd":"/tmp","approval_policy":"OnRequest","sandbox_policy":{"type":"workspace-write"},"summary":"auto"}}"#;
-        let mut state = CodexState::default();
-        ingest_codex_rollout_line(line, &mut state);
-        assert_eq!(state.last_model.as_deref(), Some("o3-mini"));
-    }
-
-    #[test]
-    fn ingest_codex_turn_started_extracts_context_window() {
-        // Real Codex format: `task_started` tag, `model_context_window` inlined under `payload`.
-        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"task_started","turn_id":"abc","model_context_window":200000}}"#;
-        let mut state = CodexState::default();
-        ingest_codex_rollout_line(line, &mut state);
-        assert_eq!(state.context_window, Some(200000));
-    }
-
-    #[test]
-    fn ingest_codex_turn_started_extracts_context_window_legacy() {
-        // Defensive: PascalCase tag with a nested `payload.payload.model_context_window`.
-        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"TurnStarted","payload":{"turn_id":"abc","model_context_window":200000}}}"#;
-        let mut state = CodexState::default();
-        ingest_codex_rollout_line(line, &mut state);
-        assert_eq!(state.context_window, Some(200000));
-    }
-
-    #[test]
-    fn codex_state_snapshot_computes_pct() {
-        let state = CodexState {
-            sum_input: 1000,
-            sum_output: 500,
-            context_window: Some(100_000),
-            context_tokens_used: Some(50_000),
-            last_model: Some("o3".into()),
-            seen: true,
-        };
-        let snap = state.snapshot(SessionId::new());
-        assert_eq!(snap.context_used_pct, Some(50));
-        assert_eq!(snap.model.as_deref(), Some("o3"));
-        assert_eq!(snap.input_tokens, Some(1000));
-        assert_eq!(snap.output_tokens, Some(500));
-    }
-
-    #[test]
-    fn codex_state_snapshot_pct_handles_large_values_without_overflow() {
-        let state = CodexState {
-            sum_input: 1000,
-            sum_output: 500,
-            context_window: Some(10_000_000_000_000_000_000),
-            context_tokens_used: Some(5_000_000_000_000_000_000),
-            last_model: Some("o3".into()),
-            seen: true,
-        };
-        let snap = state.snapshot(SessionId::new());
-        assert_eq!(snap.context_used_pct, Some(50));
-    }
-
-    #[test]
-    fn parse_codex_turn_complete_duration() {
-        // Real Codex format: `turn_complete` tag, `duration_ms` inlined under `payload`.
-        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"turn_complete","turn_id":"t1","duration_ms":4200}}"#;
-        assert_eq!(parse_codex_turn_duration_ms(line), Some(Some(4200)));
-    }
-
-    #[test]
-    fn parse_codex_turn_complete_duration_legacy_double_payload() {
-        // Defensive: PascalCase tag with a nested `payload.payload.duration_ms`.
-        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"TurnComplete","payload":{"turn_id":"t1","last_agent_message":"done","duration_ms":4200}}}"#;
-        assert_eq!(parse_codex_turn_duration_ms(line), Some(Some(4200)));
-    }
-
-    #[test]
-    fn parse_codex_turn_complete_no_duration() {
-        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"turn_complete","turn_id":"t1"}}"#;
-        assert_eq!(parse_codex_turn_duration_ms(line), Some(None));
-    }
-
-    #[test]
-    fn parse_codex_turn_complete_ignores_non_turn_complete_event_with_keyword() {
-        let line = br#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"type":"token_count","note":"TurnComplete"}}"#;
-        assert!(maybe_codex_turn_complete(line));
-        assert_eq!(parse_codex_turn_duration_ms(line), None);
-    }
-
-    #[test]
-    fn codex_rollout_cwd_match_and_thread_id_extraction() {
-        use std::io::Write;
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("rollout-2025-05-18T10-00-00-abcdef12-3456-7890-abcd-ef1234567890.jsonl");
-        let cwd = if cfg!(windows) { r"C:\repos\myproject" } else { "/repos/myproject" };
-        let first_line = format!(
-            r#"{{"timestamp":"2025-05-18T10:00:00Z","type":"session_meta","payload":{{"id":"thread-uuid-123","cwd":"{}","originator":"codex","cli_version":"1.0","source":"cli"}}}}"#,
-            cwd.replace('\\', "\\\\")
+    fn context_used_pct_handles_unknowns_clamp_and_overflow() {
+        assert_eq!(context_used_pct(None, Some(100)), None);
+        assert_eq!(context_used_pct(Some(50), None), None);
+        assert_eq!(context_used_pct(Some(50), Some(0)), None);
+        assert_eq!(context_used_pct(Some(50), Some(200)), Some(25));
+        // Used exceeds the window (e.g. post-overflow Codex cumulative) — must clamp, not wrap.
+        assert_eq!(context_used_pct(Some(500), Some(200)), Some(100));
+        // u128 intermediate must not overflow on absurd inputs.
+        assert_eq!(
+            context_used_pct(Some(5_000_000_000_000_000_000), Some(10_000_000_000_000_000_000)),
+            Some(50)
         );
-        let mut f = std::fs::File::create(&path).unwrap();
-        writeln!(f, "{}", first_line).unwrap();
-        drop(f);
-
-        assert!(codex_rollout_cwd_matches(&path, Path::new(cwd)));
-        assert!(!codex_rollout_cwd_matches(&path, Path::new("/other/path")));
-        assert_eq!(codex_rollout_thread_id(&path), Some("thread-uuid-123".to_string()));
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn codex_rollout_cwd_match_normalizes_windows_separators_and_trailing_separator() {
-        use std::io::Write;
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("rollout-2025-05-18T10-00-00-abcdef12-3456-7890-abcd-ef1234567890.jsonl");
-        let expected_cwd = r"C:\repos\myproject";
-        let rollout_cwd = format!("{}/", expected_cwd.replace('\\', "/"));
-        let first_line = format!(
-            r#"{{"timestamp":"2025-05-18T10:00:00Z","type":"session_meta","payload":{{"id":"thread-uuid-123","cwd":"{}","originator":"codex","cli_version":"1.0","source":"cli"}}}}"#,
-            rollout_cwd
-        );
-        let mut f = std::fs::File::create(&path).unwrap();
-        writeln!(f, "{}", first_line).unwrap();
-        drop(f);
-
-        assert!(codex_rollout_cwd_matches(&path, Path::new(expected_cwd)));
-    }
-
-    #[test]
-    fn codex_rollout_thread_id_requires_session_meta() {
-        use std::io::Write;
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("rollout-2025-05-18T10-00-00-abcdef12-3456-7890-abcd-ef1234567890.jsonl");
-        let first_line = r#"{"timestamp":"2025-05-18T10:00:00Z","type":"event_msg","payload":{"id":"not-a-thread-id"}}"#;
-        let mut f = std::fs::File::create(&path).unwrap();
-        writeln!(f, "{}", first_line).unwrap();
-        drop(f);
-
-        assert_eq!(codex_rollout_thread_id(&path), None);
-    }
-
-    #[test]
-    fn codex_rollout_thread_id_accepts_thread_id_field() {
-        use std::io::Write;
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("rollout-2025-05-18T10-00-00-abcdef12-3456-7890-abcd-ef1234567890.jsonl");
-        let first_line = r#"{"timestamp":"2025-05-18T10:00:00Z","type":"session_meta","payload":{"thread_id":"thread-from-thread-id","cwd":"/tmp"}}"#;
-        let mut f = std::fs::File::create(&path).unwrap();
-        writeln!(f, "{}", first_line).unwrap();
-        drop(f);
-
-        assert_eq!(codex_rollout_thread_id(&path), Some("thread-from-thread-id".to_owned()));
-    }
-
-    #[test]
-    fn newest_codex_rollout_picks_matching_cwd() {
-        use std::io::Write;
-        let dir = tempfile::tempdir().expect("tempdir");
-        let sessions_dir = dir.path().join("sessions");
-        std::fs::create_dir_all(&sessions_dir).unwrap();
-
-        let cwd = if cfg!(windows) { r"C:\repos\target" } else { "/repos/target" };
-        let other_cwd = if cfg!(windows) { r"C:\repos\other" } else { "/repos/other" };
-
-        // Create a rollout matching our cwd.
-        let good_path = sessions_dir.join("rollout-2025-05-18T10-00-00-11111111-1111-1111-1111-111111111111.jsonl");
-        let good_line = format!(
-            r#"{{"timestamp":"2025-05-18T10:00:00Z","type":"session_meta","payload":{{"id":"good-thread","cwd":"{}","originator":"codex","cli_version":"1.0","source":"cli"}}}}"#,
-            cwd.replace('\\', "\\\\")
-        );
-        let mut f = std::fs::File::create(&good_path).unwrap();
-        writeln!(f, "{}", good_line).unwrap();
-        drop(f);
-
-        // Create a rollout with a different cwd.
-        let bad_path = sessions_dir.join("rollout-2025-05-18T10-00-01-22222222-2222-2222-2222-222222222222.jsonl");
-        let bad_line = format!(
-            r#"{{"timestamp":"2025-05-18T10:00:01Z","type":"session_meta","payload":{{"id":"bad-thread","cwd":"{}","originator":"codex","cli_version":"1.0","source":"cli"}}}}"#,
-            other_cwd.replace('\\', "\\\\")
-        );
-        let mut f = std::fs::File::create(&bad_path).unwrap();
-        writeln!(f, "{}", bad_line).unwrap();
-        drop(f);
-
-        let after = SystemTime::now() - Duration::from_secs(60);
-        let result = newest_codex_rollout(&sessions_dir, Path::new(cwd), after);
-        assert_eq!(result, Some(good_path));
-    }
-
-    #[test]
-    fn codex_next_discovery_interval_doubles_until_cap() {
-        let next = codex_next_discovery_interval(CODEX_DISCOVERY_SCAN_MIN_INTERVAL, CODEX_DISCOVERY_SCAN_MAX_INTERVAL);
-        assert_eq!(next, CODEX_DISCOVERY_SCAN_MIN_INTERVAL.saturating_mul(2));
-
-        let capped = codex_next_discovery_interval(CODEX_DISCOVERY_SCAN_MAX_INTERVAL, CODEX_DISCOVERY_SCAN_MAX_INTERVAL);
-        assert_eq!(capped, CODEX_DISCOVERY_SCAN_MAX_INTERVAL);
     }
 }


### PR DESCRIPTION
Implements #242. Encapsulates each AI tool's session-metrics wire-format parsing inside its own plugin module, leaving `session_metrics.rs` as a generic engine.

## What changed
- New `MetricsParser` trait + `LocatedFile` + `run_metrics_watcher` in `session_metrics.rs`, replacing `run_claude_watcher` / `run_copilot_watcher` / `run_codex_watcher` and the `MetricsWatcherKind` enum dispatch.
- `AiPlugin::metrics_watcher_kind` -> `metrics_parser(...) -> Option<Box<dyn MetricsParser>>`.
- Per-tool parsing + tests moved into `plugins/ai/{claude,copilot,codex}/metrics.rs`.
- `session_metrics.rs` keeps only the generic engine: threading, polling cadence, file tailing, truncation/rotation handling, discovery backoff, snapshot dedup, emit plumbing. Shrank ~2511 -> ~835 lines.
- Extracted shared `context_used_pct()` helper (was triplicated across the three snapshot builders; overflow-safe via `u128`).

## Behavior preservation
Strategy flags reproduce each tool's exact original behavior with no change to surfaced metrics:
- Claude: `relocate_each_poll=true` (re-locates newest JSONL each poll; preserves `last_emitted` across `/clear` switch, resets on truncation).
- Copilot: binds fixed otel path once; transient stat errors keep state; conversation id via `content_ai_session_id()`.
- Codex: `rebind_on_disappear=true` with discovery backoff; thread id via `LocatedFile.ai_session_id`.

## Testing
- Per-tool parser/watcher tests moved alongside their parsers.
- Added `codex_watcher_discovers_rollout_and_emits_snapshot` engine integration test (codex previously had only parser units).
- Added `context_used_pct` unit test.
- `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test` (646 lib tests) all green; pre-commit and pre-push hooks passed.
- Line-by-line behavioral-equivalence audit + two code-review passes (correctness + simplification).