### PR TITLE
[macos-backspace] Fix macOS backspace and clipboard in the terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "arborist"
 version = "0.1.14"
 dependencies = [
@@ -66,6 +87,7 @@ dependencies = [
  "sha2 0.11.0",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-store",
  "tempfile",
@@ -241,6 +263,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +406,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +521,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -833,10 +876,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -873,6 +928,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1125,6 +1186,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,6 +1377,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1595,6 +1677,20 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -1913,6 +2009,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1973,6 +2079,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2041,6 +2156,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -2230,6 +2346,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,6 +2408,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "phf"
@@ -2510,6 +2647,18 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -3496,6 +3645,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3723,6 +3887,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -4068,6 +4246,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4377,6 +4566,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4477,6 +4736,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -5041,6 +5306,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5112,6 +5395,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5138,6 +5438,26 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5199,3 +5519,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,7 @@ allow = [
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
   "BSD-3-Clause",
+  "BSL-1.0",
   "Unicode-3.0",
   "Zlib",
   "MPL-2.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.11.0",
+    "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.11.0
         version: 2.11.0
+      '@tauri-apps/plugin-clipboard-manager':
+        specifier: ^2.3.2
+        version: 2.3.2
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.1
         version: 2.7.1
@@ -626,6 +629,9 @@ packages:
     resolution: {integrity: sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
 
   '@tauri-apps/plugin-dialog@2.7.1':
     resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
@@ -2138,6 +2144,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.2
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.2
       '@tauri-apps/cli-win32-x64-msvc': 2.11.2
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-dialog@2.7.1':
     dependencies:

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -84,6 +84,7 @@ tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "registry"] }
 tokio-util = "0.7"
 base64 = "0.22"
+tauri-plugin-clipboard-manager = "2.3"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -6,6 +6,8 @@
   "permissions": [
     "core:event:allow-listen",
     "core:event:allow-unlisten",
+    "clipboard-manager:allow-read-text",
+    "clipboard-manager:allow-write-text",
     "allow-ping",
     "allow-config",
     "allow-shell-command-trust",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -150,6 +150,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .setup(|app| {
             use tauri::Manager;
 

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -123,6 +123,36 @@ function withMacPlatform(fn: () => void): void {
   }
 }
 
+// Render a terminal and attach it to a fresh host — the preamble nearly every interaction test needs. Returns the host plus the just-created mock
+// Terminal so tests can assert against `term.paste`, read its OSC handlers, etc., without repeating the renderHook → makeHost → attach boilerplate.
+function attachTerminal(id = 's1'): { host: HTMLDivElement; term: (typeof mockTerminals)[number] } {
+  const { result } = renderHook(() => useTerminal(id));
+  const host = makeHost();
+  act(() => result.current.attach(host));
+  return { host, term: mockTerminals[mockTerminals.length - 1]! };
+}
+
+// Drive the "modifier+V pastes the clipboard" happy path: mock the system clipboard, dispatch the chord, drain the async read, and assert the text
+// reached `term.paste`. Shared by the Ctrl+V / Cmd+V / non-Latin-layout cases, which differ only in the key chord and the pasted payload.
+async function expectChordPastes(init: KeyboardEventInit, clip: string): Promise<void> {
+  const { host, term } = attachTerminal();
+  clipboardReadText.mockResolvedValue(clip);
+  const prevented = !host.dispatchEvent(keydown(init));
+  expect(prevented).toBe(true);
+  expect(clipboardReadText).toHaveBeenCalled();
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(term.paste).toHaveBeenCalledWith(clip);
+}
+
+// Attach a terminal and return its registered OSC 52 handler (always present — `createEntry` registers it). The OSC 52 tests differ only in payload.
+function attachOsc52Handler(): (data: string) => boolean | Promise<boolean> {
+  const { term } = attachTerminal();
+  const handler = term._oscHandlers.get(52);
+  expect(handler).toBeDefined();
+  return handler!;
+}
+
 let originalResizeObserver: typeof ResizeObserver | undefined;
 
 beforeEach(() => {
@@ -333,33 +363,11 @@ describe('useTerminal', () => {
   });
 
   it('Ctrl+V on host reads the system clipboard and pastes via term.paste', async () => {
-    const { result } = renderHook(() => useTerminal('s1'));
-    const host = makeHost();
-    act(() => result.current.attach(host));
-
-    clipboardReadText.mockResolvedValue('clip-text');
-    const prevented = !host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', ctrlKey: true }));
-
-    expect(prevented).toBe(true);
-    expect(clipboardReadText).toHaveBeenCalled();
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('clip-text');
+    await expectChordPastes({ key: 'v', code: 'KeyV', ctrlKey: true }, 'clip-text');
   });
 
   it('Cmd+V (metaKey) on host pastes via the clipboard plugin', async () => {
-    const { result } = renderHook(() => useTerminal('s1'));
-    const host = makeHost();
-    act(() => result.current.attach(host));
-
-    clipboardReadText.mockResolvedValue('mac-clip');
-    const prevented = !host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', metaKey: true }));
-
-    expect(prevented).toBe(true);
-    expect(clipboardReadText).toHaveBeenCalled();
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('mac-clip');
+    await expectChordPastes({ key: 'v', code: 'KeyV', metaKey: true }, 'mac-clip');
   });
 
   it('Ctrl+Shift+V on host also triggers paste (Linux terminal convention)', () => {
@@ -431,18 +439,7 @@ describe('useTerminal', () => {
   it('Ctrl+V on a non-Latin keyboard layout still triggers paste (matches by code, not key)', async () => {
     // On a Russian QWERTY layout the V position prints `м`, so `event.key` is `'м'` — not `'v'`. We deliberately match on `event.code === 'KeyV'`
     // (physical key) rather than `event.key` so the user's normal paste shortcut works regardless of active keyboard layout.
-    const { result } = renderHook(() => useTerminal('s1'));
-    const host = makeHost();
-    act(() => result.current.attach(host));
-
-    clipboardReadText.mockResolvedValue('layout-clip');
-    const prevented = !host.dispatchEvent(keydown({ key: 'м', code: 'KeyV', ctrlKey: true }));
-
-    expect(prevented).toBe(true);
-    expect(clipboardReadText).toHaveBeenCalled();
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('layout-clip');
+    await expectChordPastes({ key: 'м', code: 'KeyV', ctrlKey: true }, 'layout-clip');
   });
 
   it('Ctrl + non-V key with key:"v" is not intercepted (matches by code, not by produced character)', () => {
@@ -537,24 +534,17 @@ describe('useTerminal', () => {
   });
 
   it('OSC 52 clipboard write from the CLI is forwarded to the system clipboard', async () => {
-    const { result } = renderHook(() => useTerminal('s1'));
-    const host = makeHost();
-    act(() => result.current.attach(host));
-    const handler = mockTerminals[0]!._oscHandlers.get(52);
-    expect(handler).toBeDefined();
+    const handler = attachOsc52Handler();
 
     // OSC 52 payload: "<selection>;<base64>". "hi" → "aGk=".
-    const handled = await handler!('c;aGk=');
+    const handled = await handler('c;aGk=');
 
     expect(handled).toBe(true);
     expect(clipboardWriteText).toHaveBeenCalledWith('hi');
   });
 
   it('OSC 52 decodes multi-byte UTF-8 correctly', async () => {
-    const { result } = renderHook(() => useTerminal('s1'));
-    const host = makeHost();
-    act(() => result.current.attach(host));
-    const handler = mockTerminals[0]!._oscHandlers.get(52)!;
+    const handler = attachOsc52Handler();
 
     // "café — 日本" base64-encoded from its UTF-8 bytes.
     const b64 = Buffer.from('café — 日本', 'utf-8').toString('base64');
@@ -565,10 +555,7 @@ describe('useTerminal', () => {
   });
 
   it('OSC 52 read request ("?") is declined and never leaks the clipboard', async () => {
-    const { result } = renderHook(() => useTerminal('s1'));
-    const host = makeHost();
-    act(() => result.current.attach(host));
-    const handler = mockTerminals[0]!._oscHandlers.get(52)!;
+    const handler = attachOsc52Handler();
 
     const handled = await handler('c;?');
 
@@ -577,10 +564,7 @@ describe('useTerminal', () => {
   });
 
   it('OSC 52 with malformed base64 is declined cleanly', async () => {
-    const { result } = renderHook(() => useTerminal('s1'));
-    const host = makeHost();
-    act(() => result.current.attach(host));
-    const handler = mockTerminals[0]!._oscHandlers.get(52)!;
+    const handler = attachOsc52Handler();
 
     const handled = await handler('c;@@not-base64@@');
 

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -129,7 +129,7 @@ function attachTerminal(id = 's1'): { host: HTMLDivElement; term: (typeof mockTe
   const { result } = renderHook(() => useTerminal(id));
   const host = makeHost();
   act(() => result.current.attach(host));
-  return { host, term: mockTerminals[mockTerminals.length - 1]! };
+  return { host, term: mockTerminals.at(-1)! };
 }
 
 // Drive the "modifier+V pastes the clipboard" happy path: mock the system clipboard, dispatch the chord, drain the async read, and assert the text
@@ -316,7 +316,7 @@ describe('useTerminal', () => {
     expect(sessionInput).not.toHaveBeenCalled();
   });
 
-  it('Backspace on macOS sends DEL (\\x7f) straight to the PTY and prevents default', () => {
+  it(String.raw`Backspace on macOS sends DEL (\x7f) straight to the PTY and prevents default`, () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
 
@@ -328,7 +328,7 @@ describe('useTerminal', () => {
     expect(sessionInput).toHaveBeenCalledWith({ sessionId: 's1', data: '\x7f' });
   });
 
-  it('Option(Alt)+Backspace on macOS sends ESC+DEL (\\x1b\\x7f) for word-delete', () => {
+  it(String.raw`Option(Alt)+Backspace on macOS sends ESC+DEL (\x1b\x7f) for word-delete`, () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
 

--- a/src/hooks/use-terminal.test.tsx
+++ b/src/hooks/use-terminal.test.tsx
@@ -86,7 +86,16 @@ import {
   useSubTerminal,
   useTerminal,
 } from './use-terminal';
-import { onSessionOutput, resetBridgeMocks, sessionInput, sessionResize, subSessionInput, subSessionResize } from '@/lib/tauri-bridge.mock';
+import {
+  clipboardReadText,
+  clipboardWriteText,
+  onSessionOutput,
+  resetBridgeMocks,
+  sessionInput,
+  sessionResize,
+  subSessionInput,
+  subSessionResize,
+} from '@/lib/tauri-bridge.mock';
 import { useSessionStore } from '@/store/session-store';
 
 function makeHost(width = 600, height = 400): HTMLDivElement {
@@ -97,22 +106,21 @@ function makeHost(width = 600, height = 400): HTMLDivElement {
   return el;
 }
 
-// Swap globalThis.navigator for one whose `clipboard` is the provided stub, run `fn`, then restore the original — keeps every clipboard test from
-// re-rolling the same defineProperty/try-finally boilerplate. `clipboard` is passed straight through, so tests can hand in `{ readText }`,
-// `{ writeText }`, `{}`, or `undefined` to exercise the various availability branches.
-async function withNavigatorClipboard(clipboard: unknown, fn: () => void | Promise<void>): Promise<void> {
-  const originalNav = (globalThis as { navigator?: Navigator }).navigator;
-  Object.defineProperty(globalThis, 'navigator', { value: { ...originalNav, clipboard }, configurable: true });
-  try {
-    await fn();
-  } finally {
-    Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
-  }
-}
-
 // Build a bubbling, cancelable keydown event with the supplied init — the `bubbles`/`cancelable` flags are required for host dispatch in every case.
 function keydown(init: KeyboardEventInit): KeyboardEvent {
   return new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init });
+}
+
+// Swap globalThis.navigator for one reporting a macOS `platform`, run `fn`, then restore — used by the Backspace-on-macOS tests. The Backspace
+// workaround only fires when `isMacPlatform()` is true; jsdom's default navigator is not macOS, so non-mac tests need no override.
+function withMacPlatform(fn: () => void): void {
+  const originalNav = (globalThis as { navigator?: Navigator }).navigator;
+  Object.defineProperty(globalThis, 'navigator', { value: { ...originalNav, platform: 'MacIntel' }, configurable: true });
+  try {
+    fn();
+  } finally {
+    Object.defineProperty(globalThis, 'navigator', { value: originalNav, configurable: true });
+  }
 }
 
 let originalResizeObserver: typeof ResizeObserver | undefined;
@@ -278,122 +286,146 @@ describe('useTerminal', () => {
     expect(sessionInput).not.toHaveBeenCalled();
   });
 
-  it('Ctrl+V on host triggers navigator.clipboard.readText and term.paste', async () => {
+  it('Backspace on macOS sends DEL (\\x7f) straight to the PTY and prevents default', () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
-    act(() => result.current.attach(host));
 
-    const readText = vi.fn().mockResolvedValue('clip-text');
-    await withNavigatorClipboard({ readText }, async () => {
-      const prevented = !host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', ctrlKey: true }));
-
-      expect(prevented).toBe(true);
-      expect(readText).toHaveBeenCalled();
-      await Promise.resolve();
-      await Promise.resolve();
-      expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('clip-text');
+    withMacPlatform(() => {
+      act(() => result.current.attach(host));
+      const dispatched = host.dispatchEvent(keydown({ key: 'Backspace' }));
+      expect(dispatched).toBe(false); // preventDefault called
     });
+    expect(sessionInput).toHaveBeenCalledWith({ sessionId: 's1', data: '\x7f' });
   });
 
-  it('Cmd+V (metaKey) on host triggers paste via navigator.clipboard.readText', async () => {
+  it('Option(Alt)+Backspace on macOS sends ESC+DEL (\\x1b\\x7f) for word-delete', () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
-    act(() => result.current.attach(host));
 
-    const readText = vi.fn().mockResolvedValue('mac-clip');
-    await withNavigatorClipboard({ readText }, async () => {
-      const prevented = !host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', metaKey: true }));
-
-      expect(prevented).toBe(true);
-      expect(readText).toHaveBeenCalled();
-      await Promise.resolve();
-      await Promise.resolve();
-      expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('mac-clip');
+    withMacPlatform(() => {
+      act(() => result.current.attach(host));
+      host.dispatchEvent(keydown({ key: 'Backspace', altKey: true }));
     });
+    expect(sessionInput).toHaveBeenCalledWith({ sessionId: 's1', data: '\x1b\x7f' });
   });
 
-  it('Ctrl+Shift+V on host also triggers paste (Linux terminal convention)', async () => {
+  it('Ctrl/Cmd+Backspace on macOS is left to fall through (not intercepted)', () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
-    act(() => result.current.attach(host));
 
-    const readText = vi.fn().mockResolvedValue('linux-clip');
-    await withNavigatorClipboard({ readText }, () => {
-      const prevented = !host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', ctrlKey: true, shiftKey: true }));
-
-      expect(prevented).toBe(true);
-      expect(readText).toHaveBeenCalled();
+    withMacPlatform(() => {
+      act(() => result.current.attach(host));
+      expect(host.dispatchEvent(keydown({ key: 'Backspace', ctrlKey: true }))).toBe(true);
+      expect(host.dispatchEvent(keydown({ key: 'Backspace', metaKey: true }))).toBe(true);
     });
+    expect(sessionInput).not.toHaveBeenCalled();
   });
 
-  it('Ctrl+Alt+V is not intercepted (Alt-modifier passthrough)', async () => {
+  it('Backspace off macOS is left to xterm (no interception, no input sent)', () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
-    const readText = vi.fn();
-    await withNavigatorClipboard({ readText }, () => {
-      const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', ctrlKey: true, altKey: true }));
+    const dispatched = host.dispatchEvent(keydown({ key: 'Backspace' }));
 
-      expect(dispatched).toBe(true);
-      expect(readText).not.toHaveBeenCalled();
-    });
+    expect(dispatched).toBe(true); // not preventDefault'd
+    expect(sessionInput).not.toHaveBeenCalled();
   });
 
-  it('Cmd+Shift+V is not intercepted (passthrough; "paste and match style" on macOS)', async () => {
+  it('Ctrl+V on host reads the system clipboard and pastes via term.paste', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
-    const readText = vi.fn();
-    await withNavigatorClipboard({ readText }, () => {
-      const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', metaKey: true, shiftKey: true }));
+    clipboardReadText.mockResolvedValue('clip-text');
+    const prevented = !host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', ctrlKey: true }));
 
-      expect(dispatched).toBe(true);
-      expect(readText).not.toHaveBeenCalled();
-    });
+    expect(prevented).toBe(true);
+    expect(clipboardReadText).toHaveBeenCalled();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('clip-text');
   });
 
-  it('Cmd+Alt+V is not intercepted (Alt-modifier passthrough on macOS)', async () => {
+  it('Cmd+V (metaKey) on host pastes via the clipboard plugin', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
-    const readText = vi.fn();
-    await withNavigatorClipboard({ readText }, () => {
-      const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', metaKey: true, altKey: true }));
+    clipboardReadText.mockResolvedValue('mac-clip');
+    const prevented = !host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', metaKey: true }));
 
-      expect(dispatched).toBe(true);
-      expect(readText).not.toHaveBeenCalled();
-    });
+    expect(prevented).toBe(true);
+    expect(clipboardReadText).toHaveBeenCalled();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('mac-clip');
   });
 
-  it('Ctrl+Cmd+V is not intercepted (both ctrl and meta together is undefined)', async () => {
+  it('Ctrl+Shift+V on host also triggers paste (Linux terminal convention)', () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
-    const readText = vi.fn();
-    await withNavigatorClipboard({ readText }, () => {
-      const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', ctrlKey: true, metaKey: true }));
+    const prevented = !host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', ctrlKey: true, shiftKey: true }));
 
-      expect(dispatched).toBe(true);
-      expect(readText).not.toHaveBeenCalled();
-    });
+    expect(prevented).toBe(true);
+    expect(clipboardReadText).toHaveBeenCalled();
   });
 
-  it('plain "v" keystroke (no modifier) is not intercepted', async () => {
+  it('Ctrl+Alt+V is not intercepted (Alt-modifier passthrough)', () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
-    const readText = vi.fn();
-    await withNavigatorClipboard({ readText }, () => {
-      const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV' }));
+    const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', ctrlKey: true, altKey: true }));
 
-      expect(dispatched).toBe(true);
-      expect(readText).not.toHaveBeenCalled();
-    });
+    expect(dispatched).toBe(true);
+    expect(clipboardReadText).not.toHaveBeenCalled();
+  });
+
+  it('Cmd+Shift+V is not intercepted (passthrough; "paste and match style" on macOS)', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', metaKey: true, shiftKey: true }));
+
+    expect(dispatched).toBe(true);
+    expect(clipboardReadText).not.toHaveBeenCalled();
+  });
+
+  it('Cmd+Alt+V is not intercepted (Alt-modifier passthrough on macOS)', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', metaKey: true, altKey: true }));
+
+    expect(dispatched).toBe(true);
+    expect(clipboardReadText).not.toHaveBeenCalled();
+  });
+
+  it('Ctrl+Cmd+V is not intercepted (both ctrl and meta together is undefined)', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', ctrlKey: true, metaKey: true }));
+
+    expect(dispatched).toBe(true);
+    expect(clipboardReadText).not.toHaveBeenCalled();
+  });
+
+  it('plain "v" keystroke (no modifier) is not intercepted', () => {
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+
+    const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV' }));
+
+    expect(dispatched).toBe(true);
+    expect(clipboardReadText).not.toHaveBeenCalled();
   });
 
   it('Ctrl+V on a non-Latin keyboard layout still triggers paste (matches by code, not key)', async () => {
@@ -403,19 +435,17 @@ describe('useTerminal', () => {
     const host = makeHost();
     act(() => result.current.attach(host));
 
-    const readText = vi.fn().mockResolvedValue('layout-clip');
-    await withNavigatorClipboard({ readText }, async () => {
-      const prevented = !host.dispatchEvent(keydown({ key: 'м', code: 'KeyV', ctrlKey: true }));
+    clipboardReadText.mockResolvedValue('layout-clip');
+    const prevented = !host.dispatchEvent(keydown({ key: 'м', code: 'KeyV', ctrlKey: true }));
 
-      expect(prevented).toBe(true);
-      expect(readText).toHaveBeenCalled();
-      await Promise.resolve();
-      await Promise.resolve();
-      expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('layout-clip');
-    });
+    expect(prevented).toBe(true);
+    expect(clipboardReadText).toHaveBeenCalled();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('layout-clip');
   });
 
-  it('Ctrl + non-V key with key:"v" is not intercepted (matches by code, not by produced character)', async () => {
+  it('Ctrl + non-V key with key:"v" is not intercepted (matches by code, not by produced character)', () => {
     // Inverse of the layout test: on a Russian layout the key that produces `'v'` is at a different physical position (code `KeyM`, since Cyrillic
     // `в` is on a different key entirely) — but for this test the important property is that `event.key === 'v'` does not imply the user pressed the V
     // shortcut. Anything that isn't `code === 'KeyV'` must pass through unchanged.
@@ -423,13 +453,10 @@ describe('useTerminal', () => {
     const host = makeHost();
     act(() => result.current.attach(host));
 
-    const readText = vi.fn();
-    await withNavigatorClipboard({ readText }, () => {
-      const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyM', ctrlKey: true }));
+    const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyM', ctrlKey: true }));
 
-      expect(dispatched).toBe(true);
-      expect(readText).not.toHaveBeenCalled();
-    });
+    expect(dispatched).toBe(true);
+    expect(clipboardReadText).not.toHaveBeenCalled();
   });
 
   it('Ctrl+V resolved after disposeTerminal does not write to a stale terminal', async () => {
@@ -438,180 +465,127 @@ describe('useTerminal', () => {
     act(() => result.current.attach(host));
     const term = mockTerminals[0]!;
 
-    // Hand-rolled deferred so we can dispatch the keydown, dispose the
-    // session, and only THEN resolve `readText` — exactly the race we're
+    // Hand-rolled deferred so we can dispatch the keydown, dispose the session, and only THEN resolve the clipboard read — exactly the race we're
     // guarding against.
     let resolveReadText!: (text: string) => void;
-    const readText = vi.fn(
+    clipboardReadText.mockImplementation(
       () =>
         new Promise<string>((resolve) => {
           resolveReadText = resolve;
         }),
     );
-    await withNavigatorClipboard({ readText }, async () => {
-      host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', ctrlKey: true }));
-      expect(readText).toHaveBeenCalled();
+    host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', ctrlKey: true }));
+    expect(clipboardReadText).toHaveBeenCalled();
 
-      // Dispose the session BEFORE the clipboard read resolves.
-      act(() => disposeTerminal('s1'));
+    // Dispose the session BEFORE the clipboard read resolves.
+    act(() => disposeTerminal('s1'));
 
-      // Now resolve the pending readText. The guard inside pasteFromClipboard should drop the paste because the registry entry is gone.
-      resolveReadText('stale-paste');
-      await Promise.resolve();
-      await Promise.resolve();
+    // Now resolve the pending read. The guard inside pasteFromClipboard should drop the paste because the registry entry is gone.
+    resolveReadText('stale-paste');
+    await Promise.resolve();
+    await Promise.resolve();
 
-      expect(term.paste).not.toHaveBeenCalled();
-    });
+    expect(term.paste).not.toHaveBeenCalled();
   });
 
-  it('Ctrl+C with a selection copies it to the clipboard and suppresses SIGINT', async () => {
+  it('Ctrl+C with a selection copies it to the clipboard and suppresses SIGINT', () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
     mockTerminals[0]!.getSelection.mockReturnValue('selected text');
 
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    await withNavigatorClipboard({ writeText }, () => {
-      const prevented = !host.dispatchEvent(keydown({ key: 'c', code: 'KeyC', ctrlKey: true }));
+    const prevented = !host.dispatchEvent(keydown({ key: 'c', code: 'KeyC', ctrlKey: true }));
 
-      expect(prevented).toBe(true);
-      expect(writeText).toHaveBeenCalledWith('selected text');
-    });
+    expect(prevented).toBe(true);
+    expect(clipboardWriteText).toHaveBeenCalledWith('selected text');
   });
 
-  it('Ctrl+C with no selection is not intercepted (falls through to SIGINT)', async () => {
+  it('Ctrl+C with no selection is not intercepted (falls through to SIGINT)', () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
     mockTerminals[0]!.getSelection.mockReturnValue('');
 
-    const writeText = vi.fn();
-    await withNavigatorClipboard({ writeText }, () => {
-      const dispatched = host.dispatchEvent(keydown({ key: 'c', code: 'KeyC', ctrlKey: true }));
+    const dispatched = host.dispatchEvent(keydown({ key: 'c', code: 'KeyC', ctrlKey: true }));
 
-      expect(dispatched).toBe(true);
-      expect(writeText).not.toHaveBeenCalled();
-    });
+    expect(dispatched).toBe(true);
+    expect(clipboardWriteText).not.toHaveBeenCalled();
   });
 
-  it('Ctrl+Shift+C copies the selection', async () => {
+  it('Ctrl+Shift+C copies the selection', () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
     mockTerminals[0]!.getSelection.mockReturnValue('shift-copy');
 
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    await withNavigatorClipboard({ writeText }, () => {
-      const prevented = !host.dispatchEvent(keydown({ key: 'C', code: 'KeyC', ctrlKey: true, shiftKey: true }));
+    const prevented = !host.dispatchEvent(keydown({ key: 'C', code: 'KeyC', ctrlKey: true, shiftKey: true }));
 
-      expect(prevented).toBe(true);
-      expect(writeText).toHaveBeenCalledWith('shift-copy');
-    });
+    expect(prevented).toBe(true);
+    expect(clipboardWriteText).toHaveBeenCalledWith('shift-copy');
   });
 
-  it('Cmd+C copies the selection on macOS', async () => {
+  it('Cmd+C copies the selection on macOS', () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
     mockTerminals[0]!.getSelection.mockReturnValue('mac-copy');
 
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    await withNavigatorClipboard({ writeText }, () => {
-      const prevented = !host.dispatchEvent(keydown({ key: 'c', code: 'KeyC', metaKey: true }));
+    const prevented = !host.dispatchEvent(keydown({ key: 'c', code: 'KeyC', metaKey: true }));
 
-      expect(prevented).toBe(true);
-      expect(writeText).toHaveBeenCalledWith('mac-copy');
-    });
-  });
-
-  it('Ctrl+C with a selection but no clipboard write API is not intercepted (preserves SIGINT)', async () => {
-    const { result } = renderHook(() => useTerminal('s1'));
-    const host = makeHost();
-    act(() => result.current.attach(host));
-    mockTerminals[0]!.getSelection.mockReturnValue('selected but no API');
-
-    await withNavigatorClipboard({}, () => {
-      const dispatched = host.dispatchEvent(keydown({ key: 'c', code: 'KeyC', ctrlKey: true }));
-
-      expect(dispatched).toBe(true);
-    });
+    expect(prevented).toBe(true);
+    expect(clipboardWriteText).toHaveBeenCalledWith('mac-copy');
   });
 
   it('OSC 52 clipboard write from the CLI is forwarded to the system clipboard', async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    await withNavigatorClipboard({ writeText }, async () => {
-      const { result } = renderHook(() => useTerminal('s1'));
-      const host = makeHost();
-      act(() => result.current.attach(host));
-      const handler = mockTerminals[0]!._oscHandlers.get(52);
-      expect(handler).toBeDefined();
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+    const handler = mockTerminals[0]!._oscHandlers.get(52);
+    expect(handler).toBeDefined();
 
-      // OSC 52 payload: "<selection>;<base64>". "hi" → "aGk=".
-      const handled = await handler!('c;aGk=');
+    // OSC 52 payload: "<selection>;<base64>". "hi" → "aGk=".
+    const handled = await handler!('c;aGk=');
 
-      expect(handled).toBe(true);
-      expect(writeText).toHaveBeenCalledWith('hi');
-    });
+    expect(handled).toBe(true);
+    expect(clipboardWriteText).toHaveBeenCalledWith('hi');
   });
 
   it('OSC 52 decodes multi-byte UTF-8 correctly', async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    await withNavigatorClipboard({ writeText }, async () => {
-      const { result } = renderHook(() => useTerminal('s1'));
-      const host = makeHost();
-      act(() => result.current.attach(host));
-      const handler = mockTerminals[0]!._oscHandlers.get(52)!;
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+    const handler = mockTerminals[0]!._oscHandlers.get(52)!;
 
-      // "café — 日本" base64-encoded from its UTF-8 bytes.
-      const b64 = Buffer.from('café — 日本', 'utf-8').toString('base64');
-      const handled = await handler(`c;${b64}`);
+    // "café — 日本" base64-encoded from its UTF-8 bytes.
+    const b64 = Buffer.from('café — 日本', 'utf-8').toString('base64');
+    const handled = await handler(`c;${b64}`);
 
-      expect(handled).toBe(true);
-      expect(writeText).toHaveBeenCalledWith('café — 日本');
-    });
+    expect(handled).toBe(true);
+    expect(clipboardWriteText).toHaveBeenCalledWith('café — 日本');
   });
 
   it('OSC 52 read request ("?") is declined and never leaks the clipboard', async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    await withNavigatorClipboard({ writeText }, async () => {
-      const { result } = renderHook(() => useTerminal('s1'));
-      const host = makeHost();
-      act(() => result.current.attach(host));
-      const handler = mockTerminals[0]!._oscHandlers.get(52)!;
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+    const handler = mockTerminals[0]!._oscHandlers.get(52)!;
 
-      const handled = await handler('c;?');
+    const handled = await handler('c;?');
 
-      expect(handled).toBe(false);
-      expect(writeText).not.toHaveBeenCalled();
-    });
+    expect(handled).toBe(false);
+    expect(clipboardWriteText).not.toHaveBeenCalled();
   });
 
   it('OSC 52 with malformed base64 is declined cleanly', async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    await withNavigatorClipboard({ writeText }, async () => {
-      const { result } = renderHook(() => useTerminal('s1'));
-      const host = makeHost();
-      act(() => result.current.attach(host));
-      const handler = mockTerminals[0]!._oscHandlers.get(52)!;
+    const { result } = renderHook(() => useTerminal('s1'));
+    const host = makeHost();
+    act(() => result.current.attach(host));
+    const handler = mockTerminals[0]!._oscHandlers.get(52)!;
 
-      const handled = await handler('c;@@not-base64@@');
+    const handled = await handler('c;@@not-base64@@');
 
-      expect(handled).toBe(false);
-      expect(writeText).not.toHaveBeenCalled();
-    });
-  });
-
-  it('OSC 52 is declined when the clipboard write API is unavailable', async () => {
-    await withNavigatorClipboard({}, async () => {
-      const { result } = renderHook(() => useTerminal('s1'));
-      const host = makeHost();
-      act(() => result.current.attach(host));
-      const handler = mockTerminals[0]!._oscHandlers.get(52)!;
-
-      const handled = await handler('c;aGk=');
-
-      expect(handled).toBe(false);
-    });
+    expect(handled).toBe(false);
+    expect(clipboardWriteText).not.toHaveBeenCalled();
   });
 
   it('Shift+Enter listener is removed on detach', () => {
@@ -704,87 +678,58 @@ describe('useTerminal', () => {
     expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('hello world');
   });
 
-  it('paste falls back to navigator.clipboard.readText when clipboardData is empty', async () => {
+  it('paste falls back to the clipboard plugin when clipboardData is empty', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
-    const readText = vi.fn().mockResolvedValue('from-async-clipboard');
-    await withNavigatorClipboard({ readText }, async () => {
-      const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
-      Object.defineProperty(evt, 'clipboardData', { value: { getData: () => '' } });
-      host.dispatchEvent(evt);
+    clipboardReadText.mockResolvedValue('from-async-clipboard');
+    const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+    Object.defineProperty(evt, 'clipboardData', { value: { getData: () => '' } });
+    host.dispatchEvent(evt);
 
-      expect(readText).toHaveBeenCalled();
-      // Drain the microtask queue so the .then(...) on readText resolves. Two awaits: one for the readText resolution, one for the chained .then.
-      await Promise.resolve();
-      await Promise.resolve();
+    expect(clipboardReadText).toHaveBeenCalled();
+    // Drain the microtask queue so the .then(...) on the read resolves. Two awaits: one for the read resolution, one for the chained .then.
+    await Promise.resolve();
+    await Promise.resolve();
 
-      expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('from-async-clipboard');
-    });
+    expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('from-async-clipboard');
   });
 
-  it('paste with empty clipboard and no async fallback does not call term.paste() and does not preventDefault', async () => {
+  it('paste with empty clipboardData reads the plugin, finds nothing, and pastes nothing (but still preventDefaults)', async () => {
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
-    await withNavigatorClipboard(undefined, () => {
-      const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
-      Object.defineProperty(evt, 'clipboardData', { value: { getData: () => '' } });
-      const dispatched = host.dispatchEvent(evt);
+    clipboardReadText.mockResolvedValue('');
+    const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+    Object.defineProperty(evt, 'clipboardData', { value: { getData: () => '' } });
+    const prevented = !host.dispatchEvent(evt);
 
-      expect(mockTerminals[0]!.paste).not.toHaveBeenCalled();
-      // When we have no paste path, we MUST let the event propagate so xterm or any other listener still has a chance to handle it — otherwise we
-      // just turn paste into a silent no-op (regression).
-      expect(dispatched).toBe(true);
-    });
+    // The plugin clipboard is always available in Tauri, so we own the paste end-to-end and always suppress the default to avoid a double-paste
+    // through xterm's own handler.
+    expect(prevented).toBe(true);
+    expect(clipboardReadText).toHaveBeenCalled();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockTerminals[0]!.paste).not.toHaveBeenCalled();
   });
 
-  it('Ctrl+V keydown does not preventDefault when navigator.clipboard.readText is unavailable', async () => {
+  it('paste with inline clipboardData consumes it without reading the plugin', () => {
+    // Inline payload is the happy path and must always be consumed directly — we own the paste end-to-end here and never round-trip to the plugin.
     const { result } = renderHook(() => useTerminal('s1'));
     const host = makeHost();
     act(() => result.current.attach(host));
 
-    await withNavigatorClipboard(undefined, () => {
-      const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', ctrlKey: true }));
-
-      // Without a clipboard API, we can't paste — so we must not suppress xterm's own keydown handling. A silent no-op is a regression vs. the
-      // previous behavior (xterm sending \x16).
-      expect(dispatched).toBe(true);
-      expect(mockTerminals[0]!.paste).not.toHaveBeenCalled();
+    const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+    Object.defineProperty(evt, 'clipboardData', {
+      value: { getData: () => 'inline-text' },
     });
-  });
+    const prevented = !host.dispatchEvent(evt);
 
-  it('Cmd+V keydown does not preventDefault when navigator.clipboard.readText is unavailable', async () => {
-    const { result } = renderHook(() => useTerminal('s1'));
-    const host = makeHost();
-    act(() => result.current.attach(host));
-
-    await withNavigatorClipboard(undefined, () => {
-      const dispatched = host.dispatchEvent(keydown({ key: 'v', code: 'KeyV', metaKey: true }));
-
-      expect(dispatched).toBe(true);
-      expect(mockTerminals[0]!.paste).not.toHaveBeenCalled();
-    });
-  });
-
-  it('paste with inline clipboardData still preventDefaults even if async clipboard is missing', async () => {
-    // Inline payload is the happy path and must always be consumed — we own the paste end-to-end here.
-    const { result } = renderHook(() => useTerminal('s1'));
-    const host = makeHost();
-    act(() => result.current.attach(host));
-
-    await withNavigatorClipboard(undefined, () => {
-      const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
-      Object.defineProperty(evt, 'clipboardData', {
-        value: { getData: () => 'inline-text' },
-      });
-      const prevented = !host.dispatchEvent(evt);
-
-      expect(prevented).toBe(true);
-      expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('inline-text');
-    });
+    expect(prevented).toBe(true);
+    expect(mockTerminals[0]!.paste).toHaveBeenCalledWith('inline-text');
+    expect(clipboardReadText).not.toHaveBeenCalled();
   });
 
   it('paste runs in capture phase, beating a descendants stopPropagation', () => {

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -40,7 +40,16 @@ import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 
-import { formatError, onSessionOutput, sessionInput, sessionResize, subSessionInput, subSessionResize } from '@/lib/tauri-bridge';
+import {
+  clipboardReadText,
+  clipboardWriteText,
+  formatError,
+  onSessionOutput,
+  sessionInput,
+  sessionResize,
+  subSessionInput,
+  subSessionResize,
+} from '@/lib/tauri-bridge';
 import { useSessionStore } from '@/store/session-store';
 import { useSubSessionStore } from '@/store/sub-session-store';
 import type { SessionId, SubSessionId } from '@/types/arborist';
@@ -340,13 +349,7 @@ function createEntry(id: string, ioKind: IoKind): RegistryEntry {
   // from inside the TUI even though it reports success.
   term.parser.registerOscHandler(52, handleOsc52);
 
-  term.onData((data) => {
-    const sendInput = ioKind === 'session' ? sessionInput({ sessionId: id, data }) : subSessionInput({ id: id as SubSessionId, data });
-    sendInput.catch((err: unknown) => {
-      const message = formatError(err);
-      console.warn(`[use-terminal] ${ioKind} input(${id}) failed: ${message}`);
-    });
-  });
+  term.onData((data) => sendPtyInput(id, ioKind, data));
 
   return {
     term,
@@ -402,47 +405,27 @@ function teardownKeydownListener(entry: RegistryEntry): void {
 }
 
 /**
- * Whether the async clipboard read API is available in this runtime.
- *
- * Used by both Ctrl/Cmd+V interception and the `paste` event listener fallback to decide *up front* whether they have any chance of actually pasting.
- * If this returns `false`, the listeners must NOT cancel the event — letting the event propagate gives xterm (or any other interested handler) a
- * chance to act on it instead of leaving the user with a silent no-op.
- */
-function canReadClipboard(): boolean {
-  return typeof navigator !== 'undefined' && typeof navigator.clipboard?.readText === 'function';
-}
-
-/**
- * Whether the async clipboard write API is available in this runtime. Gates Ctrl/Cmd+C copy interception the same way [`canReadClipboard`] gates
- * paste: if this returns `false` the copy branch must NOT cancel the event, so that plain Ctrl+C still falls through to xterm and sends SIGINT
- * instead of becoming a silent no-op.
- */
-function canWriteClipboard(): boolean {
-  return typeof navigator !== 'undefined' && typeof navigator.clipboard?.writeText === 'function';
-}
-
-/**
- * Copy the terminal's current selection to the system clipboard via `navigator.clipboard.writeText()`. Returns `true` only when there was a
- * non-empty selection AND the write API is available — i.e. when the caller should cancel the originating keystroke. Returning `false` is what
- * keeps Ctrl+C working as interrupt: with no selection (or no clipboard API) the caller leaves the event alone and xterm sends the SIGINT byte
- * (`\x03`) as usual. The write itself is fire-and-forget; failures are logged but never surfaced to the user.
+ * Copy the terminal's current selection to the system clipboard via the Tauri clipboard plugin. Returns `true` only when there was a non-empty
+ * selection — i.e. when the caller should cancel the originating keystroke. Returning `false` is what keeps Ctrl+C working as interrupt: with no
+ * selection the caller leaves the event alone and xterm sends the SIGINT byte (`\x03`) as usual. The write itself is fire-and-forget; failures are
+ * logged but never surfaced to the user.
  */
 function copySelectionToClipboard(entry: RegistryEntry): boolean {
   const selection = entry.term.getSelection();
   if (!selection) return false;
-  if (!canWriteClipboard()) return false;
   writeTextToClipboard(selection);
   return true;
 }
 
 /**
- * Fire-and-forget write to the system clipboard via `navigator.clipboard.writeText()`. Shared by the Ctrl/Cmd+C selection copy and the OSC 52
- * handler. Callers gate on [`canWriteClipboard`] first; failures are logged but never surfaced to the user.
+ * Fire-and-forget write to the system clipboard via the Tauri clipboard plugin (`clipboardWriteText`). Shared by the Ctrl/Cmd+C selection copy and
+ * the OSC 52 handler. Routed through the plugin rather than `navigator.clipboard.writeText` so it behaves identically on macOS WKWebView (where the
+ * browser clipboard API is sandboxed). Failures are logged but never surfaced to the user.
  */
 function writeTextToClipboard(text: string): void {
-  navigator.clipboard.writeText(text).catch((err: unknown) => {
-    const message = err instanceof Error ? err.message : String(err);
-    console.warn(`[use-terminal] clipboard.writeText() failed: ${message}`);
+  clipboardWriteText(text).catch((err: unknown) => {
+    const message = formatError(err);
+    console.warn(`[use-terminal] clipboardWriteText() failed: ${message}`);
   });
 }
 
@@ -470,8 +453,8 @@ function decodeOsc52Payload(b64: string): string | null {
  *
  * `data` is the parser payload after the `52;` identifier, i.e. `"<selection>;<base64-or-?>"`. We ignore the selection target (we always write the
  * system clipboard) and decline read requests (`payload === '?'`) — servicing those would let the remote program exfiltrate the user's clipboard,
- * which we deliberately do not allow. Returns `true` only when we actually wrote, so xterm knows the sequence was consumed; otherwise `false` so
- * xterm falls back to its default (drop) behaviour.
+ * which we deliberately do not allow. Returns `true` once we've accepted the sequence for writing (the plugin write is fire-and-forget), so xterm
+ * knows it was consumed; returns `false` for read requests / malformed payloads so xterm falls back to its default (drop) behaviour.
  */
 function handleOsc52(data: string): boolean {
   const sep = data.indexOf(';');
@@ -479,7 +462,6 @@ function handleOsc52(data: string): boolean {
   const payload = data.slice(sep + 1);
   // `?` is a paste/read request — decline it (never leak the clipboard to the program).
   if (payload === '?' || payload === '') return false;
-  if (!canWriteClipboard()) return false;
   const text = decodeOsc52Payload(payload);
   if (text === null) return false;
   writeTextToClipboard(text);
@@ -487,22 +469,19 @@ function handleOsc52(data: string): boolean {
 }
 
 /**
- * Read text from the system clipboard via `navigator.clipboard.readText()` and forward it to the terminal via `term.paste()`. Used by both the
- * Ctrl/Cmd+V keydown branch (where xterm's keydown handler would otherwise eat the keystroke before any `paste` event fires) and the `paste` event
- * listener fallback (when `clipboardData` is empty, as happens in some WebView2 right-click → Paste flows).
+ * Read text from the system clipboard via the Tauri clipboard plugin (`clipboardReadText`) and forward it to the terminal via `term.paste()`. Used
+ * by both the Ctrl/Cmd+V keydown branch (where xterm's keydown handler would otherwise eat the keystroke before any `paste` event fires) and the
+ * `paste` event listener fallback (when `clipboardData` is empty, as happens in some WebView2 right-click → Paste flows).
  *
- * Callers must gate cancellation of the original event on [`canReadClipboard`] — this function silently no-ops if the API is missing, and
- * unconditionally cancelling the event in that case would block xterm from handling the keystroke / paste itself.
+ * Routed through the plugin rather than `navigator.clipboard.readText()` because the latter is sandboxed in macOS WKWebView and rejects with
+ * `NotAllowedError`, silently breaking terminal paste. An empty clipboard resolves to `''`, which we drop.
  *
- * The async resolution of `readText()` is racy with session disposal: the user could dispatch Ctrl+V and then close the tab before the clipboard
- * read resolves. We re-check the registry by `sessionId` before calling `term.paste(text)` so we don't write into a disposed (or replaced)
- * terminal. Failures are logged but otherwise silent — there's no useful UI recovery and we don't want to spam the user with toasts every time they
- * paste an empty clipboard.
+ * The async resolution is racy with session disposal: the user could dispatch Ctrl+V and then close the tab before the clipboard read resolves. We
+ * re-check the registry by `sessionId` before calling `term.paste(text)` so we don't write into a disposed (or replaced) terminal. Failures are
+ * logged but otherwise silent — there's no useful UI recovery and we don't want to spam the user with toasts every time they paste an empty clipboard.
  */
 function pasteFromClipboard(id: string, entry: RegistryEntry): void {
-  if (!canReadClipboard()) return;
-  navigator.clipboard
-    .readText()
+  clipboardReadText()
     .then((text) => {
       if (!text) return;
       // Guard against a concurrent disposeTerminal(): if the registry entry for this id is gone or has been replaced, drop the paste rather than
@@ -511,13 +490,25 @@ function pasteFromClipboard(id: string, entry: RegistryEntry): void {
       entry.term.paste(text);
     })
     .catch((err: unknown) => {
-      const message = err instanceof Error ? err.message : String(err);
-      console.warn(`[use-terminal] clipboard.readText() failed: ${message}`);
+      const message = formatError(err);
+      console.warn(`[use-terminal] clipboardReadText() failed: ${message}`);
     });
 }
 
 /**
- * Handle the Shift+Enter chord: send ESC + CR (`\x1b\r`) instead of the bare `\r` xterm emits by default. CLIs like Claude Code and GitHub Copilot
+ * Forward a byte sequence to the PTY, routing through the correct bridge command for a parent session vs. a terminal sub-session. Fire-and-forget:
+ * failures are logged but never surfaced, matching xterm's own `onData` path. Shared by `onData`, the Shift+Enter chord, and the macOS Backspace
+ * workaround so the session/sub-session branching and error logging live in exactly one place.
+ */
+function sendPtyInput(id: string, ioKind: IoKind, data: string): void {
+  const inputPromise = ioKind === 'session' ? sessionInput({ sessionId: id, data }) : subSessionInput({ id, data });
+  inputPromise.catch((err: unknown) => {
+    const message = formatError(err);
+    console.warn(`[use-terminal] ${ioKind} input(${id}) failed: ${message}`);
+  });
+}
+
+/**
  * CLI interpret a bare `\r` as "submit"; the de-facto convention (matching what `claude /terminal-setup` configures in iTerm2) is ESC-prefixed CR
  * for "newline without submit". Dispatches through the same kind-aware switch the `term.onData` handler uses so it works for both parent sessions
  * and terminal sub-sessions. Returns `true` when the chord was consumed so the caller stops processing the event.
@@ -526,31 +517,52 @@ function handleShiftEnterKey(event: KeyboardEvent, id: string, entry: RegistryEn
   if (!(event.key === 'Enter' && event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey)) return false;
   event.preventDefault();
   event.stopPropagation();
-  const inputPromise =
-    entry.ioKind === 'session'
-      ? sessionInput({ sessionId: id as SessionId, data: '\x1b\r' })
-      : subSessionInput({ id: id as SubSessionId, data: '\x1b\r' });
-  inputPromise.catch((err: unknown) => {
-    const message = formatError(err);
-    console.warn(`[use-terminal] ${entry.ioKind} input(${id}) failed: ${message}`);
-  });
+  sendPtyInput(id, entry.ioKind, '\x1b\r');
   return true;
 }
 
 /**
- * Handle paste chords (Ctrl+V, Ctrl+Shift+V, Cmd+V) by reading the clipboard and writing through `term.paste()`. We intercept here because xterm's
- * own keydown handler would otherwise eat the keypress (sending the literal `\x16` SYN byte) and the browser would never fire a `paste` event.
- * Cmd+Shift+V (macOS "paste and match style") and any Alt-modified chord are deliberately not accepted and pass through. We match on the physical
- * `event.code === 'KeyV'` rather than `event.key`, so the shortcut is layout-independent (on a Russian layout the V position prints `м`). Returns
- * `true` only when we actually consumed the event — when no clipboard read API is available we leave the event alone (swallowing it would turn
- * Ctrl+V into a silent no-op) so xterm can fall back to its own handling.
+ * Whether we're running on macOS. Used to scope the Backspace workaround ([`handleBackspaceKey`]) to the only platform that needs it. WKWebView
+ * routes editing keystrokes — including Delete/Backspace (`deleteBackward:`) — through the native Edit-menu responder chain; with no Delete item in
+ * the menu the keystroke is swallowed before it reaches xterm's textarea, so backspace silently does nothing inside the terminal. Windows/Linux don't
+ * gate editing on a menu, so we leave xterm's own handling untouched there. Matches the `navigator.userAgent` style used elsewhere (see
+ * `plugins/custom-process/explorer`); falls back to `navigator.platform` (`"MacIntel"` in WebKit, even on Apple Silicon) which, though deprecated in
+ * the spec, is still populated in every WebView we target. Evaluated once per attach (platform can't change at runtime) — see [`attachToHost`].
+ */
+function isMacPlatform(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return /Mac/i.test(navigator.platform || '') || /Mac OS X/i.test(navigator.userAgent || '');
+}
+
+/**
+ * Handle the Backspace key on macOS by sending the erase byte straight to the PTY, bypassing WKWebView's native editing responder chain (which drops
+ * `deleteBackward:` when the Edit menu has no Delete item — see [`isMacPlatform`]). We send `\x7f` (DEL / `^?`), matching the byte xterm itself emits
+ * for Backspace on every other platform, so zsh/bash line editing behaves identically; Option(Alt)+Backspace sends `\x1b\x7f` (ESC + DEL) for
+ * "delete word", the de-facto macOS terminal convention. Ctrl/Cmd-modified chords are left to fall through unchanged. `isMac` is captured at attach
+ * time so off macOS xterm's own backspace handling is preserved untouched. Like the sibling handlers we capture on the host and `stopPropagation()`
+ * so xterm's textarea listener never double-processes the key. Returns `true` when the key was consumed.
+ */
+function handleBackspaceKey(event: KeyboardEvent, id: string, entry: RegistryEntry, isMac: boolean): boolean {
+  if (!isMac || event.key !== 'Backspace' || event.ctrlKey || event.metaKey) return false;
+  event.preventDefault();
+  event.stopPropagation();
+  sendPtyInput(id, entry.ioKind, event.altKey ? '\x1b\x7f' : '\x7f');
+  return true;
+}
+
+/**
+ * Handle paste chords (Ctrl+V, Ctrl+Shift+V, Cmd+V) by reading the clipboard (via the Tauri plugin) and writing through `term.paste()`. We intercept
+ * here because xterm's own keydown handler would otherwise eat the keypress (sending the literal `\x16` SYN byte) and the browser would never fire a
+ * `paste` event. Cmd+Shift+V (macOS "paste and match style") and any Alt-modified chord are deliberately not accepted and pass through. We match on
+ * the physical `event.code === 'KeyV'` rather than `event.key`, so the shortcut is layout-independent (on a Russian layout the V position prints `м`).
+ * Returns `true` when the chord was consumed. The plugin clipboard is always available in the Tauri runtime, so we always consume the event rather
+ * than feature-detecting up front the way the old `navigator.clipboard` path had to.
  */
 function handlePasteShortcut(event: KeyboardEvent, id: string, entry: RegistryEntry): boolean {
   const v = event.code === 'KeyV';
   const isCtrlPaste = v && event.ctrlKey && !event.metaKey && !event.altKey;
   const isMetaPaste = v && event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
   if (!isCtrlPaste && !isMetaPaste) return false;
-  if (!canReadClipboard()) return false;
   event.preventDefault();
   event.stopPropagation();
   pasteFromClipboard(id, entry);
@@ -703,19 +715,22 @@ function attachToHost(id: string, entry: RegistryEntry, host: HTMLDivElement): v
   // it fires too early).
   refitEntry(id, entry);
 
-  // Capture-phase keydown listener on the host with three responsibilities, each delegated to a helper that returns whether it consumed the event:
-  // (1) Shift+Enter → ESC + CR for "newline without submit" ([`handleShiftEnterKey`]); (2) Ctrl/Cmd+V paste ([`handlePasteShortcut`]); and
-  // (3) Ctrl/Ctrl+Shift/Cmd+C copy-on-selection-else-SIGINT ([`handleCopyShortcut`]).
+  // Capture-phase keydown listener on the host with four responsibilities, each delegated to a helper that returns whether it consumed the event:
+  // (1) Shift+Enter → ESC + CR for "newline without submit" ([`handleShiftEnterKey`]); (2) Backspace → DEL straight to the PTY on macOS, where
+  // WKWebView otherwise swallows it ([`handleBackspaceKey`]); (3) Ctrl/Cmd+V paste ([`handlePasteShortcut`]); and (4) Ctrl/Ctrl+Shift/Cmd+C
+  // copy-on-selection-else-SIGINT ([`handleCopyShortcut`]).
   //
   // We listen at the **host** in the **capture** phase so we run before xterm's own keydown listener (registered on its hidden textarea, also
   // capture-phase). xterm's `attachCustomKeyEventHandler` is unreliable here because by the time it runs the textarea may already have committed
   // default behaviour, and we cannot from inside it `preventDefault()` the textarea's own newline insertion. Capturing on the host fully owns the
   // event before any descendant listener.
+  const isMac = isMacPlatform();
   const keydownListener = (event: KeyboardEvent): void => {
-    // Skip IME composition: Enter/Shift+Enter during candidate selection belongs to the IME, not the terminal. `keyCode === 229` is the legacy
-    // Chromium/WebView "still composing" signal.
+    // Skip IME composition: keystrokes during candidate selection (Enter/Shift+Enter, Backspace, etc.) belong to the IME, not the terminal.
+    // `keyCode === 229` is the legacy Chromium/WebView "still composing" signal.
     if (event.isComposing || event.keyCode === 229) return;
     if (handleShiftEnterKey(event, id, entry)) return;
+    if (handleBackspaceKey(event, id, entry, isMac)) return;
     if (handlePasteShortcut(event, id, entry)) return;
     handleCopyShortcut(event, entry);
   };
@@ -726,22 +741,17 @@ function attachToHost(id: string, entry: RegistryEntry, host: HTMLDivElement): v
   // calls `event.stopPropagation()` — so a bubble-phase listener at the host **never fires**. Worse, in the Tauri/WebView2 environment the
   // `clipboardData` xterm receives via that path is sometimes empty (Ctrl+V / right-click → Paste / X11 middle-click all silently no-op). We capture
   // at the host, which runs before any descendant listener; we own the event end-to-end. If `clipboardData` is populated we use it directly (works
-  // without permission, since the user gesture supplies the data). Otherwise we fall back to the async `navigator.clipboard.readText()` — slower, may
-  // prompt in some environments, but recovers when the WebView won't fill clipboardData.
-  //
-  // Cancellation policy: only call `preventDefault`/`stopPropagation` when we have something to paste (inline payload) or a viable async fallback. If
-  // both are unavailable we let the event continue so xterm or any other listener still has a shot at handling it.
+  // without permission, since the user gesture supplies the data). Otherwise we fall back to the Tauri clipboard plugin via `pasteFromClipboard`,
+  // which reads the native pasteboard regardless of WebView clipboard sandboxing (notably macOS WKWebView, where `navigator.clipboard.readText`
+  // rejects). Either way we own the paste, so we always `preventDefault`/`stopPropagation` here.
   const pasteListener = (event: ClipboardEvent): void => {
+    event.preventDefault();
+    event.stopPropagation();
     const inline = event.clipboardData?.getData('text/plain') ?? '';
     if (inline) {
-      event.preventDefault();
-      event.stopPropagation();
       entry.term.paste(inline);
       return;
     }
-    if (!canReadClipboard()) return;
-    event.preventDefault();
-    event.stopPropagation();
     pasteFromClipboard(id, entry);
   };
   host.addEventListener('paste', pasteListener as EventListener, true);

--- a/src/lib/tauri-bridge.mock.ts
+++ b/src/lib/tauri-bridge.mock.ts
@@ -126,6 +126,10 @@ export const workspaceSwitch: Mock<typeof realBridge.workspaceSwitch> = vi.fn(re
 
 export const pickDirectory: Mock<typeof realBridge.pickDirectory> = vi.fn(() => Promise.resolve(null));
 
+export const clipboardReadText: Mock<typeof realBridge.clipboardReadText> = vi.fn(() => Promise.resolve(''));
+
+export const clipboardWriteText: Mock<typeof realBridge.clipboardWriteText> = vi.fn(() => Promise.resolve());
+
 export const onSessionOutput: Mock<typeof realBridge.onSessionOutput> = vi.fn(() => Promise.resolve(noopUnlisten));
 
 export const onSessionStatus: Mock<typeof realBridge.onSessionStatus> = vi.fn(() => Promise.resolve(noopUnlisten));
@@ -205,6 +209,8 @@ export function resetBridgeMocks(): void {
   worktreeCreateFromBranch.mockReset().mockImplementation(rejectNotImplemented);
   workspaceSwitch.mockReset().mockImplementation(rejectNotImplemented);
   pickDirectory.mockReset().mockImplementation(() => Promise.resolve(null));
+  clipboardReadText.mockReset().mockImplementation(() => Promise.resolve(''));
+  clipboardWriteText.mockReset().mockImplementation(() => Promise.resolve());
   onSessionOutput.mockReset().mockImplementation(() => Promise.resolve(noopUnlisten));
   onSessionStatus.mockReset().mockImplementation(() => Promise.resolve(noopUnlisten));
   onSessionActivity.mockReset().mockImplementation(() => Promise.resolve(noopUnlisten));
@@ -260,6 +266,8 @@ export function resetBridgeMocks(): void {
   worktreeCreateFromBranch,
   workspaceSwitch,
   pickDirectory,
+  clipboardReadText,
+  clipboardWriteText,
   onSessionOutput,
   onSessionStatus,
   onSessionActivity,

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -15,6 +15,7 @@
 
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { readText as pluginReadText, writeText as pluginWriteText } from '@tauri-apps/plugin-clipboard-manager';
 
 export { formatError, isAppErrorLike } from '@/lib/tauri-error';
 export type { AppErrorLike } from '@/lib/tauri-error';
@@ -407,6 +408,30 @@ export function workspaceSwitch(path: string): Promise<WorkspaceSwitchResult> {
  */
 export function pickDirectory(): Promise<string | null> {
   return invoke<string | null>('dialog_pick_directory');
+}
+
+// ---------------------------------------------------------------------------
+// System clipboard
+//
+// Routed through `tauri-plugin-clipboard-manager` (native NSPasteboard /
+// Win32 / X11-Wayland) rather than the browser `navigator.clipboard` API.
+// On macOS WKWebView, `navigator.clipboard.readText()` is sandboxed and
+// rejects with `NotAllowedError`, so terminal paste silently failed; the
+// plugin path is reliable on every platform. Components MUST go through
+// these wrappers so the bridge mock can stub them in tests.
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the system clipboard as plain text. Typically resolves to `''` for an empty/non-text clipboard, though the plugin may surface other falsy
+ * values, so callers must treat any falsy result as "nothing to paste" rather than relying on an exact empty string.
+ */
+export function clipboardReadText(): Promise<string> {
+  return pluginReadText();
+}
+
+/** Write plain text to the system clipboard. */
+export function clipboardWriteText(text: string): Promise<void> {
+  return pluginWriteText(text);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -421,10 +421,7 @@ export function pickDirectory(): Promise<string | null> {
 // these wrappers so the bridge mock can stub them in tests.
 // ---------------------------------------------------------------------------
 
-/**
- * Read the system clipboard as plain text. Typically resolves to `''` for an empty/non-text clipboard, though the plugin may surface other falsy
- * values, so callers must treat any falsy result as "nothing to paste" rather than relying on an exact empty string.
- */
+/** Read the system clipboard as plain text. Resolves to `''` when the clipboard holds no text, which callers treat as "nothing to paste". */
 export function clipboardReadText(): Promise<string> {
   return pluginReadText();
 }


### PR DESCRIPTION
## Summary

Fixes two macOS-specific terminal bugs, both rooted in WKWebView sandboxing.

### Backspace in zsh did nothing
WKWebView routes editing keys (`deleteBackward:`) through the native Edit-menu responder chain. Tauri's `Menu::default` Edit submenu has no Delete item, so Backspace was swallowed before xterm ever saw it. Now intercepted in the existing capture-phase keydown listener (scoped to macOS via `isMacPlatform()`) and sent straight to the PTY as `\x7f` (`\x1b\x7f` for Alt/word-delete). Ctrl/Cmd-modified chords still fall through.

### Paste was broken
`navigator.clipboard.readText()` is sandboxed in macOS WKWebView and rejects with `NotAllowedError`. All clipboard I/O — Ctrl/Cmd+V paste, Ctrl/Cmd+C copy-on-selection, and OSC 52 CLI copy — now routes through `tauri-plugin-clipboard-manager` (native pasteboard via Rust IPC) through the `tauri-bridge` wrappers `clipboardReadText`/`clipboardWriteText`. Because the plugin is always available in Tauri, the old `navigator.clipboard` feature-detection and graceful-fallthrough were removed; paste/copy now always intercept.

## Changes
- `src/hooks/use-terminal.ts` — macOS Backspace handler; clipboard migration; shared `sendPtyInput` helper; `isMac` captured once per attach.
- `src/lib/tauri-bridge.ts` / `tauri-bridge.mock.ts` — `clipboardReadText`/`clipboardWriteText` wrappers + mocks.
- `src-tauri/` — register `tauri-plugin-clipboard-manager`; add `clipboard-manager:allow-read-text`/`allow-write-text` capabilities.
- `src/hooks/use-terminal.test.tsx` — backspace + clipboard tests rewritten to the plugin/always-intercept semantics.

## Testing
- `pnpm run lint` ✅  `pnpm test --run` ✅ (736 passed)  `tsc --noEmit` ✅
- `cargo fmt --check` ✅  `cargo clippy --all-targets --features test-helpers -D warnings` ✅  `cargo test` ✅
- macOS runtime verification of backspace + paste is still recommended (the bugs are WKWebView-only and can't be reproduced in jsdom/CI).