### PR TITLE
[ai-dashboard-clarity] Fix misleading AI usage widget empty-state copy

### DIFF
--- a/src/plugins/dashboard-widget/ai-usage/widget.tsx
+++ b/src/plugins/dashboard-widget/ai-usage/widget.tsx
@@ -45,7 +45,7 @@ export function AiUsageWidget({ tabPath }: DashboardWidgetProps): JSX.Element {
     >
       <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">AI Usage</h2>
       {childCount === 0 ? (
-        <p className="text-xs text-slate-500 dark:text-slate-400">No agents yet — launch one below or right-click this tab.</p>
+        <p className="text-xs text-slate-500 dark:text-slate-400">No agents yet — use the Launch buttons above to start one.</p>
       ) : (
         <>
           <p className="text-xs text-slate-500 dark:text-slate-400">


### PR DESCRIPTION
## Problem

The AI Usage dashboard widget's empty state read:

> No agents yet — launch one below or right-click this tab.

Three inaccuracies:
1. **"below"** — the launch buttons render *above* the widget grid, not below.
2. **"this tab"** — the dashboard has no tabs; the phrase confusingly pointed at the sidebar worktree tab from within the dashboard.
3. **"right-click"** — right-click on worktree tabs was removed in issue #49 (moved to a button), so the gesture no longer exists.

## Change

New copy points users at the on-dashboard launch buttons:

> No agents yet — use the Launch buttons above to start one.

## Verification

- \pnpm test --run\ on the widget suite (3 tests) passes.
- \pnpm run lint\ clean.