### PR TITLE
[about-version] Show release version on the About tab

### DIFF
--- a/scripts/read-app-version.ts
+++ b/scripts/read-app-version.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, URL } from 'node:url';
+
+// Single source of truth for the app version exposed to the frontend as `__APP_VERSION__`.
+// Both vite.config.ts and vitest.config.ts inject this so the build and test bundles agree.
+export function readAppVersion(): string {
+  const pkg = JSON.parse(readFileSync(fileURLToPath(new URL('../package.json', import.meta.url)), 'utf-8')) as { version?: unknown };
+  if (typeof pkg.version !== 'string' || pkg.version.length === 0) {
+    throw new Error('package.json is missing a "version" field; cannot inject __APP_VERSION__');
+  }
+  return pkg.version;
+}

--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('@/lib/tauri-bridge', async () => await import('@/lib/tauri-bridge.mock'));
 
 import { SettingsDialog } from './SettingsDialog';
+import { formatAppVersion } from '@/lib/format-app-version';
 import * as bridgeMock from '@/lib/tauri-bridge.mock';
 import { PluginRegistryProvider } from '@/plugins';
 import { useConfigStore } from '@/store/config-store';
@@ -280,6 +281,10 @@ describe('SettingsDialog', () => {
     renderWithPlugins(<SettingsDialog onClose={() => {}} />);
     fireEvent.click(screen.getByTestId('settings-tab-about'));
     expect(screen.getByTestId('settings-about-attribution')).toHaveTextContent('mcaden');
+    // Mirror the component's dev/prod logic so the assertion holds under both vitest (DEV=true)
+    // and any future production-mode test run, rather than hardcoding the `-dev` suffix.
+    const expectedVersion = formatAppVersion(__APP_VERSION__, import.meta.env.DEV);
+    expect(screen.getByTestId('settings-about-version')).toHaveTextContent(`Version ${expectedVersion}`);
     expect(screen.getByText(/cross-platform desktop app/i)).toBeInTheDocument();
     expect(screen.getByText(/terminal persistent in the background/i)).toBeInTheDocument();
   });

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -24,10 +24,13 @@ import { CustomProcessesTab } from './CustomProcessesTab';
 import { PluginsTab } from './PluginsTab';
 import { WorkspacePicker } from './WorkspacePicker';
 import { formatError } from '@/lib/tauri-bridge';
+import { formatAppVersion } from '@/lib/format-app-version';
 import { changeWorkspace } from '@/lib/workspace-switch';
 import { selectTheme, selectWorkspaceRoot, selectWorktreePrepCommands, useConfigStore } from '@/store/config-store';
 
 export type SettingsTab = 'general' | 'plugins' | 'customProcesses' | 'about';
+
+const appVersion = formatAppVersion(__APP_VERSION__, import.meta.env.DEV);
 
 export interface SettingsDialogProps {
   onClose: () => void;
@@ -425,6 +428,9 @@ export function SettingsDialog({ onClose, initialTab = 'general' }: SettingsDial
               <section className="space-y-3 text-xs leading-5 text-slate-600 dark:text-slate-300">
                 <p data-testid="settings-about-attribution">
                   Arborist is created by <strong>mcaden</strong>.
+                </p>
+                <p data-testid="settings-about-version">
+                  Version <strong>{appVersion}</strong>
                 </p>
                 <p>
                   Arborist is a cross-platform desktop app for managing multiple Claude CLI / GitHub Copilot CLI sessions, each bound to a Git

--- a/src/lib/format-app-version.test.ts
+++ b/src/lib/format-app-version.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatAppVersion } from './format-app-version';
+
+describe('formatAppVersion', () => {
+  it('suffixes dev builds with -dev', () => {
+    expect(formatAppVersion('1.2.3', true)).toBe('1.2.3-dev');
+  });
+
+  it('leaves production builds bare', () => {
+    expect(formatAppVersion('1.2.3', false)).toBe('1.2.3');
+  });
+});

--- a/src/lib/format-app-version.ts
+++ b/src/lib/format-app-version.ts
@@ -1,0 +1,5 @@
+// Format the release version for display. Dev builds get a `-dev` suffix so it's
+// obvious when a running instance came from `pnpm dev` rather than a release bundle.
+export function formatAppVersion(version: string, isDev: boolean): string {
+  return isDev ? `${version}-dev` : version;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+// Injected at build/test time via Vite's `define` (see vite.config.ts and vitest.config.ts),
+// sourced from package.json's `version` field by scripts/read-app-version.ts.
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { fileURLToPath, URL } from 'node:url';
 import { relative, isAbsolute } from 'node:path';
+import { readAppVersion } from './scripts/read-app-version';
+
+// Version shown on the About tab. Injected as `__APP_VERSION__` via `define` below.
+const appVersion = readAppVersion();
 
 // Default dev port. The actual per-worktree port is supplied by
 // `scripts/tauri-dev.mjs` via vite's `--port=<n>` CLI flag (see Vite's
@@ -29,6 +33,9 @@ function ignoreNestedWorktrees(file: string): boolean {
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig, configDefaults } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
+import { readAppVersion } from './scripts/read-app-version';
+
+const appVersion = readAppVersion();
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary

The settings dialog **About** tab now displays the app release version. Production builds show the bare version (e.g. `0.1.15`); dev builds get a `-dev` suffix (e.g. `0.1.15-dev`) so it's obvious when a running instance came from `pnpm dev` rather than a release bundle.

## How it works

- `scripts/read-app-version.ts` reads `version` from `package.json` once at build/test time (throws if missing/empty) — single source of truth.
- `vite.config.ts` and `vitest.config.ts` inject it as the `__APP_VERSION__` global via Vite `define` (declared in `src/vite-env.d.ts`).
- `src/lib/format-app-version.ts` is a pure `formatAppVersion(version, isDev)` helper; `SettingsDialog` renders `formatAppVersion(__APP_VERSION__, import.meta.env.DEV)`.

## Tests

- `src/lib/format-app-version.test.ts` covers both branches (dev suffix + bare prod).
- `SettingsDialog.test.tsx` asserts the rendered version line.

Acceptance gate green locally: `pnpm run lint`, `pnpm test --run`, `pnpm run build`.