### PR TITLE
[ado-pull-request] Route PR-info CLI launch through resolved LaunchMethod

### DIFF
--- a/src-tauri/src/cmd_resolver.rs
+++ b/src-tauri/src/cmd_resolver.rs
@@ -71,6 +71,9 @@ pub fn parse_program(command: &str) -> Option<String> {
 /// 2. If it contains a path separator, resolve it relative to `cwd`.
 /// 3. Otherwise look it up in `PATH` (Windows: also tries each `PATHEXT`
 ///    suffix).
+///
+/// This returns the real on-disk path (what the icon extractor needs). Callers that intend to *spawn* the program should prefer
+/// [`resolve_launchable`], which also reports how the OS must be asked to launch it.
 #[must_use]
 pub fn resolve_executable(program: &str, cwd: &Path) -> Option<PathBuf> {
     let p = Path::new(program);
@@ -84,20 +87,76 @@ pub fn resolve_executable(program: &str, cwd: &Path) -> Option<PathBuf> {
     search_path(program)
 }
 
-fn existing_with_pathext(path: &Path) -> Option<PathBuf> {
-    if path.is_file() {
-        return Some(path.to_path_buf());
+/// How a resolved program must be handed to the OS to spawn it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LaunchMethod {
+    /// Spawn the resolved path directly via `CreateProcess` / `execvp`.
+    Direct,
+    /// Spawn through `cmd.exe /c <path>` (Windows only). Required for anything the Windows loader can't execute directly — script wrappers
+    /// (`.cmd` / `.bat`) and extensionless shims (the Azure CLI's bare `az`) — which otherwise fail with "is not a valid Win32 application"
+    /// (os error 193).
+    ViaCmdShell,
+}
+
+/// A resolved program together with the [`LaunchMethod`] required to spawn it. Returned by [`resolve_launchable`] so the launch decision is made
+/// once, at resolution time, rather than re-derived from the path extension at each spawn site.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedCommand {
+    pub path: PathBuf,
+    pub launch: LaunchMethod,
+}
+
+/// Resolve `program` (see [`resolve_executable`]) and classify how it must be spawned. This is the entry point for callers that intend to *run* the
+/// resolved program; the icon extractor, which only needs the on-disk path, uses [`resolve_executable`] directly.
+#[must_use]
+pub fn resolve_launchable(program: &str, cwd: &Path) -> Option<ResolvedCommand> {
+    let path = resolve_executable(program, cwd)?;
+    let launch = launch_method_for(&path);
+    Some(ResolvedCommand { path, launch })
+}
+
+/// Decide how `path` must be spawned. On Windows, only native PE images (`.exe` / `.com`) go straight to `CreateProcess`; everything else
+/// (script wrappers, extensionless shims) routes through `cmd.exe /c`. On other platforms every resolved path is launched directly.
+fn launch_method_for(path: &Path) -> LaunchMethod {
+    if cfg!(target_os = "windows") && !is_windows_native_executable(path) {
+        LaunchMethod::ViaCmdShell
+    } else {
+        LaunchMethod::Direct
     }
+}
+
+fn existing_with_pathext(path: &Path) -> Option<PathBuf> {
     if cfg!(target_os = "windows") {
-        // Re-try with each PATHEXT suffix only if the path has no extension — `code` → `code.cmd`/`code.exe`, but `Code.exe` → `Code.exe.cmd` would
-        // be nonsense.
+        // On Windows, an extensionless file can't be launched via `CreateProcess` — e.g. the Azure CLI ships a bare `az` bash shim next to the
+        // runnable `az.cmd`. Prefer a PATHEXT-suffixed sibling (`az` → `az.cmd`/`az.exe`) so we hand the OS something it can actually execute, and
+        // only fall back to the literal extensionless file when no executable sibling exists. A path that already has an extension is used as-is
+        // (`Code.exe` → `Code.exe.cmd` would be nonsense).
         if path.extension().is_none() {
-            for ext in pathext_entries() {
-                let with_ext: PathBuf = format!("{}{}", path.display(), ext).into();
-                if with_ext.is_file() {
-                    return Some(with_ext);
-                }
+            if let Some(found) = pathext_sibling(path, &pathext_entries()) {
+                return Some(found);
             }
+        }
+        if path.is_file() {
+            return Some(path.to_path_buf());
+        }
+        return None;
+    }
+    if path.is_file() {
+        Some(path.to_path_buf())
+    } else {
+        None
+    }
+}
+
+/// Return the first PATHEXT-suffixed sibling of `path` that exists on disk (`az` → `az.cmd`). Caller is responsible for the bare-file fallback;
+/// this only reports an executable sibling, and assumes `path` is extensionless — suffixing an already-extensioned path (`Code.exe` →
+/// `Code.exe.cmd`) is nonsense. `exts` is passed in so a multi-directory sweep can parse `PATHEXT` once instead of per directory.
+fn pathext_sibling(path: &Path, exts: &[String]) -> Option<PathBuf> {
+    debug_assert!(path.extension().is_none(), "pathext_sibling expects an extensionless path");
+    for ext in exts {
+        let with_ext: PathBuf = format!("{}{}", path.display(), ext).into();
+        if with_ext.is_file() {
+            return Some(with_ext);
         }
     }
     None
@@ -105,9 +164,34 @@ fn existing_with_pathext(path: &Path) -> Option<PathBuf> {
 
 fn search_path(program: &str) -> Option<PathBuf> {
     let path_var = std::env::var_os("PATH")?;
-    for dir in std::env::split_paths(&path_var) {
-        let candidate = dir.join(program);
-        if let Some(found) = existing_with_pathext(&candidate) {
+    let dirs: Vec<PathBuf> = std::env::split_paths(&path_var).collect();
+    search_path_in(program, &dirs)
+}
+
+fn search_path_in(program: &str, dirs: &[PathBuf]) -> Option<PathBuf> {
+    // On Windows a bare extensionless program (`az`) can match both a runnable PATHEXT sibling (`az.cmd`) and a non-executable bash shim (`az`) that
+    // CreateProcess rejects with os error 193. The two can live in different PATH directories, so we sweep ALL directories for an executable sibling
+    // first and only fall back to a literal extensionless file if none is found — otherwise PATH ordering alone could decide whether we return
+    // something launchable. This deliberately differs from strict `cmd.exe` resolution (dir-major, then the bare name before PATHEXT within each
+    // dir): a bare extensionless file isn't launchable via CreateProcess anyway, so matching cmd's order here would just reproduce the os-error-193 bug.
+    if cfg!(target_os = "windows") && Path::new(program).extension().is_none() {
+        let exts = pathext_entries();
+        for dir in dirs {
+            if let Some(found) = pathext_sibling(&dir.join(program), &exts) {
+                return Some(found);
+            }
+        }
+        for dir in dirs {
+            let candidate = dir.join(program);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+        return None;
+    }
+
+    for dir in dirs {
+        if let Some(found) = existing_with_pathext(&dir.join(program)) {
             return Some(found);
         }
     }
@@ -129,6 +213,17 @@ pub fn is_script_wrapper(path: &Path) -> bool {
         return false;
     };
     matches!(ext.to_ascii_lowercase().as_str(), "cmd" | "bat" | "ps1" | "sh")
+}
+
+/// True only for paths the Windows loader can hand straight to `CreateProcess` — native PE images (`.exe` / `.com`). Anything else (script wrappers
+/// like `.cmd` / `.bat`, or an extensionless shim such as the Azure CLI's bare `az`) must be launched through `cmd.exe /c`, otherwise the launch
+/// fails with "is not a valid Win32 application" (os error 193). This is broader than [`is_script_wrapper`], which keys off a known-shim extension
+/// and so would let an extensionless shim through. Drives [`launch_method_for`].
+fn is_windows_native_executable(path: &Path) -> bool {
+    match path.extension().and_then(|s| s.to_str()) {
+        Some(ext) => matches!(ext.to_ascii_lowercase().as_str(), "exe" | "com"),
+        None => false,
+    }
 }
 
 /// If `path` is a script wrapper, peek inside (read the first ~8KB) and look for an executable reference. Returns the first one that resolves to an
@@ -486,6 +581,98 @@ mod tests {
         let exe = tmp.path().join("foo.exe");
         std::fs::write(&exe, b"binary").unwrap();
         assert_eq!(resolve_executable(exe.to_str().unwrap(), tmp.path()), Some(exe));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn resolve_executable_prefers_pathext_over_bare_shim() {
+        // Mirrors the Azure CLI layout: a bare `az` bash shim sits next to the runnable `az.cmd`. On Windows the extensionless shim can't be
+        // launched via CreateProcess, so resolution must hand back `az.cmd`, not `az`.
+        let tmp = tempfile::tempdir().unwrap();
+        let bare = tmp.path().join("az");
+        std::fs::write(&bare, b"#!/bin/bash\n").unwrap();
+        let cmd = tmp.path().join("az.cmd");
+        std::fs::write(&cmd, b"@echo off\n").unwrap();
+        let resolved = resolve_executable(bare.to_str().unwrap(), tmp.path()).expect("should resolve to the .cmd sibling");
+        assert!(resolved.is_file(), "resolved path must exist on disk");
+        assert_eq!(
+            resolved.to_string_lossy().to_ascii_lowercase(),
+            cmd.to_string_lossy().to_ascii_lowercase()
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn resolve_executable_falls_back_to_bare_file_without_pathext_sibling() {
+        // When no PATHEXT sibling exists, the literal extensionless file must still resolve — this is the fallback branch that keeps tools shipping
+        // only a bare launcher working (and is the branch most at risk of a future regression).
+        let tmp = tempfile::tempdir().unwrap();
+        let bare = tmp.path().join("solo");
+        std::fs::write(&bare, b"binary").unwrap();
+        assert_eq!(resolve_executable(bare.to_str().unwrap(), tmp.path()), Some(bare));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn search_path_in_prefers_executable_sibling_across_directories() {
+        // The bare `az` shim and the runnable `az.cmd` can live in different PATH directories. Even when the shim's directory comes first, the
+        // cross-directory sweep must return the `.cmd` so we never hand CreateProcess an unlaunchable file.
+        let tmp = tempfile::tempdir().unwrap();
+        let shim_dir = tmp.path().join("shim");
+        let cmd_dir = tmp.path().join("cmd");
+        std::fs::create_dir(&shim_dir).unwrap();
+        std::fs::create_dir(&cmd_dir).unwrap();
+        std::fs::write(shim_dir.join("az"), b"#!/bin/bash\n").unwrap();
+        let cmd = cmd_dir.join("az.cmd");
+        std::fs::write(&cmd, b"@echo off\n").unwrap();
+
+        let resolved = search_path_in("az", &[shim_dir, cmd_dir]).expect("should resolve across directories");
+        assert_eq!(
+            resolved.to_string_lossy().to_ascii_lowercase(),
+            cmd.to_string_lossy().to_ascii_lowercase()
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn search_path_in_falls_back_to_bare_shim_when_no_sibling_anywhere() {
+        // With no `.cmd`/`.exe` sibling in any directory, the bare extensionless file is the only option and must still resolve.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("bin");
+        std::fs::create_dir(&dir).unwrap();
+        let bare = dir.join("az");
+        std::fs::write(&bare, b"#!/bin/bash\n").unwrap();
+        assert_eq!(search_path_in("az", &[dir]), Some(bare));
+    }
+
+    #[test]
+    fn is_windows_native_executable_only_matches_pe_images() {
+        assert!(is_windows_native_executable(Path::new("foo.exe")));
+        assert!(is_windows_native_executable(Path::new("FOO.EXE")));
+        assert!(is_windows_native_executable(Path::new("foo.com")));
+        // Script wrappers and extensionless shims are NOT directly launchable and must route through cmd.exe.
+        assert!(!is_windows_native_executable(Path::new("az.cmd")));
+        assert!(!is_windows_native_executable(Path::new("foo.bat")));
+        assert!(!is_windows_native_executable(Path::new("foo.ps1")));
+        assert!(!is_windows_native_executable(Path::new("az")));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn launch_method_classifies_native_vs_shell() {
+        assert_eq!(launch_method_for(Path::new(r"C:\tools\gh.exe")), LaunchMethod::Direct);
+        assert_eq!(launch_method_for(Path::new(r"C:\tools\foo.com")), LaunchMethod::Direct);
+        // Script wrappers and extensionless shims need the cmd.exe shell.
+        assert_eq!(launch_method_for(Path::new(r"C:\tools\az.cmd")), LaunchMethod::ViaCmdShell);
+        assert_eq!(launch_method_for(Path::new(r"C:\tools\az")), LaunchMethod::ViaCmdShell);
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn launch_method_is_always_direct_off_windows() {
+        // No `cmd.exe` indirection outside Windows — every resolved path is launched directly regardless of extension.
+        assert_eq!(launch_method_for(Path::new("/usr/bin/gh")), LaunchMethod::Direct);
+        assert_eq!(launch_method_for(Path::new("/usr/bin/az")), LaunchMethod::Direct);
     }
 
     #[test]

--- a/src-tauri/src/plugins/dashboard_widget/git_status/pr_info.rs
+++ b/src-tauri/src/plugins/dashboard_widget/git_status/pr_info.rs
@@ -16,7 +16,9 @@ use std::process::Command;
 
 use serde_json::Value;
 
-use crate::cmd_resolver::resolve_executable;
+#[cfg(windows)]
+use crate::cmd_resolver::LaunchMethod;
+use crate::cmd_resolver::{resolve_executable, resolve_launchable, ResolvedCommand};
 use crate::git_remote::parse_remote_url;
 use crate::types::{GitProvider, PrChecksStatus, PrState, PullRequestInfo, WorktreePrInfo};
 
@@ -80,8 +82,8 @@ impl PrInfoRunner for RealPrInfoRunner {
     }
 
     fn run(&self, program: &str, args: &[&str], worktree: &Path) -> Result<CliOutput, String> {
-        let exe = resolve_executable(program, worktree).ok_or_else(|| format!("{program} not found on PATH"))?;
-        let mut command = build_cli_command(&exe, args);
+        let resolved = resolve_launchable(program, worktree).ok_or_else(|| format!("{program} not found on PATH"))?;
+        let mut command = build_cli_command(&resolved, args);
         command.current_dir(worktree);
         let output = command.output().map_err(|e| format!("failed to run {program}: {e}"))?;
         Ok(CliOutput {
@@ -92,29 +94,32 @@ impl PrInfoRunner for RealPrInfoRunner {
     }
 }
 
-/// Build a [`Command`] for a resolved CLI path. Windows script wrappers (`.cmd` / `.bat`, e.g. the Azure CLI's `az.cmd`) cannot be executed
-/// directly via `CreateProcess`, so they are invoked through `cmd.exe /c`. The console window is suppressed to match [`crate::git::git_command`].
-fn build_cli_command(exe: &Path, args: &[&str]) -> Command {
+/// Build a [`Command`] for a [`ResolvedCommand`], honouring its [`LaunchMethod`]: directly-launchable native executables are spawned as-is, while
+/// script wrappers and extensionless shims (`LaunchMethod::ViaCmdShell`) go through `cmd.exe /c` — launching such a file directly fails with os
+/// error 193. The console window is suppressed to match [`crate::git::git_command`].
+fn build_cli_command(resolved: &ResolvedCommand, args: &[&str]) -> Command {
     #[cfg(windows)]
     let command = {
         const CREATE_NO_WINDOW: u32 = 0x0800_0000;
         use std::os::windows::process::CommandExt as _;
-        let is_script = crate::cmd_resolver::is_script_wrapper(exe);
-        let mut command = if is_script {
-            let mut c = Command::new("cmd.exe");
-            c.arg("/c").arg(exe).args(args);
-            c
-        } else {
-            let mut c = Command::new(exe);
-            c.args(args);
-            c
+        let mut command = match resolved.launch {
+            LaunchMethod::Direct => {
+                let mut c = Command::new(&resolved.path);
+                c.args(args);
+                c
+            }
+            LaunchMethod::ViaCmdShell => {
+                let mut c = Command::new("cmd.exe");
+                c.arg("/c").arg(&resolved.path).args(args);
+                c
+            }
         };
         command.creation_flags(CREATE_NO_WINDOW);
         command
     };
     #[cfg(not(windows))]
     let command = {
-        let mut c = Command::new(exe);
+        let mut c = Command::new(&resolved.path);
         c.args(args);
         c
     };
@@ -711,5 +716,30 @@ mod tests {
     fn gh_checks_empty_is_none() {
         assert_eq!(gh_checks(Some(&serde_json::json!([]))), PrChecksStatus::None);
         assert_eq!(gh_checks(None), PrChecksStatus::None);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn build_cli_command_honours_launch_method() {
+        use std::ffi::OsStr;
+
+        // A directly-launchable executable is spawned as-is.
+        let native = ResolvedCommand {
+            path: std::path::PathBuf::from(r"C:\tools\gh.exe"),
+            launch: LaunchMethod::Direct,
+        };
+        let cmd = build_cli_command(&native, &["pr", "view"]);
+        assert_eq!(cmd.get_program(), OsStr::new(r"C:\tools\gh.exe"));
+
+        // `ViaCmdShell` routes through `cmd.exe /c <path>` — launching a `.cmd`/extensionless shim directly fails with os error 193.
+        let shim = ResolvedCommand {
+            path: std::path::PathBuf::from(r"C:\Program Files\Azure\az.cmd"),
+            launch: LaunchMethod::ViaCmdShell,
+        };
+        let routed = build_cli_command(&shim, &["repos", "pr", "list"]);
+        assert_eq!(routed.get_program(), OsStr::new("cmd.exe"));
+        let args: Vec<&OsStr> = routed.get_args().collect();
+        assert_eq!(args.first().copied(), Some(OsStr::new("/c")));
+        assert_eq!(args.get(1).copied(), Some(OsStr::new(r"C:\Program Files\Azure\az.cmd")));
     }
 }

--- a/src-tauri/src/plugins/dashboard_widget/git_status/pr_info.rs
+++ b/src-tauri/src/plugins/dashboard_widget/git_status/pr_info.rs
@@ -94,9 +94,9 @@ impl PrInfoRunner for RealPrInfoRunner {
     }
 }
 
-/// Build a [`Command`] for a [`ResolvedCommand`], honouring its [`LaunchMethod`]: directly-launchable native executables are spawned as-is, while
-/// script wrappers and extensionless shims (`LaunchMethod::ViaCmdShell`) go through `cmd.exe /c` — launching such a file directly fails with os
-/// error 193. The console window is suppressed to match [`crate::git::git_command`].
+/// Build a [`Command`] for a [`ResolvedCommand`], honouring its [`crate::cmd_resolver::LaunchMethod`]: directly-launchable native executables are
+/// spawned as-is, while script wrappers and extensionless shims (`LaunchMethod::ViaCmdShell`) go through `cmd.exe /c` — launching such a file
+/// directly fails with os error 193. The console window is suppressed to match [`crate::git::git_command`].
 fn build_cli_command(resolved: &ResolvedCommand, args: &[&str]) -> Command {
     #[cfg(windows)]
     let command = {


### PR DESCRIPTION
## Summary

Refactors how the Git Status dashboard widget launches PR-info CLIs (`gh` / `glab` / `az`). Each CLI is now resolved to a `ResolvedCommand` that carries a `LaunchMethod`, so the launch decision is made once at resolution time instead of re-deriving it at spawn.

- On **Windows**, script wrappers (`.cmd` / `.bat`, e.g. the Azure CLI's `az.cmd`) and extensionless shims resolve to `LaunchMethod::ViaCmdShell` and are invoked through `cmd.exe /c` — launching such a file directly fails with os error 193. Native executables resolve to `LaunchMethod::Direct` and are spawned as-is. A PATHEXT sibling is preferred over a bare shim so PATH ordering doesn't decide launchability.
- On **macOS/Linux**, the CLI is spawned directly (`execvp`) as before.

## Tests

- New `build_cli_command_honours_launch_method` (Windows) covering both the `Direct` and `ViaCmdShell` arms.
- New `resolve_launchable` tests in `cmd_resolver.rs` for the PATHEXT-sibling-before-bare-shim and launch-method paths.

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets --features test-helpers -- -D warnings` ✅
- `cargo test --workspace --features test-helpers` ✅